### PR TITLE
Fix consensus early-vote bug + non-breaking perf improvements

### DIFF
--- a/packages/core/src/controllers/general.ts
+++ b/packages/core/src/controllers/general.ts
@@ -54,13 +54,22 @@ export function options(
 }
 
 /**
+ * Cached OpenAPI File contents (Swagger) - the file is static at runtime,
+ * so read it once instead of on every request.
+ */
+let openApiCache: Buffer | undefined;
+
+/**
  * Return OpenAPI File (Swagger)
  *
  * @export
  * @returns {Buffer}
  */
 export function openApi(): Buffer {
-  return readFileSync(__dirname + "/../openapi.json");
+  if (!openApiCache) {
+    openApiCache = readFileSync(__dirname + "/../openapi.json");
+  }
+  return openApiCache;
 }
 
 /**

--- a/packages/core/src/controllers/sse.ts
+++ b/packages/core/src/controllers/sse.ts
@@ -81,16 +81,10 @@ export class SSE {
     // Connection still open?
     if (this.res.writable) {
       // Write new event
-      if (
-        !this.res.write(
-          `id:${sequence}\nevent: message\ndata:${JSON.stringify(prepare)}\n\n`
-        )
-      ) {
-        return true;
-      } else {
-        process.nextTick(() => {});
-        return true;
-      }
+      this.res.write(
+        `id:${sequence}\nevent: message\ndata:${JSON.stringify(prepare)}\n\n`
+      );
+      return true;
     } else {
       // End Server Side
       this.res.end();

--- a/packages/crypto/src/crypto/keypair.ts
+++ b/packages/crypto/src/crypto/keypair.ts
@@ -78,6 +78,14 @@ export class KeyPair {
   private readonly webpackBypassCheck = "generateKeyPairSync";
 
   /**
+   * Cached parsed public KeyObject for verify(), keyed by the pem it was
+   * parsed from. Avoids re-parsing the same PEM/DER on every verify call.
+   *
+   * @private
+   */
+  private cachedVerifyKey?: { pem: string; key: crypto.KeyObject };
+
+  /**
    * Creates an instance of KeyPair.
    * @param {*} [type="rsa"]
    * @param {*} [pem]
@@ -497,6 +505,20 @@ export class KeyPair {
   }
 
   /**
+   * Returns a parsed public KeyObject for verify(), reusing the cached
+   * one when the underlying pem hasn't changed.
+   *
+   * @private
+   */
+  private getVerifyKeyObject(): crypto.KeyObject {
+    const pem = this.handler.pub.pkcs8pem;
+    if (!this.cachedVerifyKey || this.cachedVerifyKey.pem !== pem) {
+      this.cachedVerifyKey = { pem, key: crypto.createPublicKey(pem) };
+    }
+    return this.cachedVerifyKey.key;
+  }
+
+  /**
    * Verify
    *
    * @param {*} data
@@ -524,24 +546,22 @@ export class KeyPair {
       // Data Object to string
       data = this.getString(data);
 
+      // Parsing the PEM/DER into a KeyObject is the expensive part of
+      // verify() - cache it since the public key is immutable per instance.
+      const pubKey = this.getVerifyKeyObject();
+
       switch (this.type) {
         case "rsa":
           verify = crypto.createVerify("RSA-SHA256");
           verify.update(data);
-          return verify.verify(
-            this.handler.pub.pkcs8pem,
-            Buffer.from(signature, encoding)
-          );
+          return verify.verify(pubKey, Buffer.from(signature, encoding));
         case "bitcoin":
         case "ethereum":
         case "secp256k1":
           try {
             verify = crypto.createVerify("sha256");
             verify.update(data);
-            return verify.verify(
-              this.handler.pub.pkcs8pem,
-              Buffer.from(signature, encoding)
-            );
+            return verify.verify(pubKey, Buffer.from(signature, encoding));
           } catch {
             if (this.enableCompatMode()) {
               return this.verify(data, signature);

--- a/packages/httpd/src/httpd.ts
+++ b/packages/httpd/src/httpd.ts
@@ -447,23 +447,17 @@ export class ActiveHttpd {
 
   private readBuffer(res: HttpResponse): Promise<Buffer> {
     return new Promise((resolve, reject) => {
-      let buffer: Buffer;
+      const chunks: Buffer[] = [];
 
       /* Register data cb */
       res.onData((ab, isLast) => {
-        let chunk = Buffer.from(ab);
+        // Immediately copy the ArrayBuffer into a Buffer, every return of onData neuters the ArrayBuffer
+        chunks.push(Buffer.from(ab.slice(0)));
+
         if (isLast) {
-          if (buffer) {
-            return resolve(Buffer.concat([buffer, chunk]));
-          } else {
-            return resolve(chunk);
-          }
-        } else {
-          if (buffer) {
-            buffer = Buffer.concat([buffer, chunk]);
-          } else {
-            buffer = Buffer.concat([chunk]);
-          }
+          return resolve(
+            chunks.length === 1 ? chunks[0] : Buffer.concat(chunks)
+          );
         }
       });
     });

--- a/packages/network/src/network/host.ts
+++ b/packages/network/src/network/host.ts
@@ -763,7 +763,7 @@ export class Host extends Home {
 
   private readBuffer(res: HttpResponse): Promise<Buffer> {
     return new Promise((resolve, reject) => {
-      let buffer: Buffer = Buffer.alloc(0);
+      const chunks: Buffer[] = [];
 
       res.onData((ab, isLast) => {
         if (res.aborted) {
@@ -773,9 +773,8 @@ export class Host extends Home {
 
         if (ab.byteLength > 0) {
           // I found some non-last onData with 0 byte length
-          //const copy = copyArrayBuffer(ab); // Immediately copy the ArrayBuffer into a Buffer, every return of onData neuters the ArrayBuffer
-          //totalSize += copy.byteLength;
-          buffer = Buffer.concat([buffer, Buffer.from(ab)]);
+          // Immediately copy the ArrayBuffer into a Buffer, every return of onData neuters the ArrayBuffer
+          chunks.push(Buffer.from(ab.slice(0)));
         }
 
         if (isLast) {
@@ -783,7 +782,13 @@ export class Host extends Home {
           // Convert the buffer to a string and parse it as JSON
           // this will fail if the buffer doesn't contain a valid JSON (e.g. length = 0)
           //const resolveValue = JSON.parse(buffer.toString());
-          resolve(buffer);
+          resolve(
+            chunks.length === 0
+              ? Buffer.alloc(0)
+              : chunks.length === 1
+              ? chunks[0]
+              : Buffer.concat(chunks)
+          );
         }
       });
     });

--- a/packages/network/src/network/host.ts
+++ b/packages/network/src/network/host.ts
@@ -1236,11 +1236,14 @@ export class Host extends Home {
       // unresolved early placeholder must never be sent as if it were a
       // real vote, regardless of why broadcast() was called (early flag
       // here only affects $$noreply, not whether our own data is ready).
-      const data = !this.processPending[umid].entry.$nodes[this.reference].early
+      // Note: when early=true the outer if above allows entry even when
+      // $nodes[this.reference] doesn't exist yet (see the commented-out
+      // check above), so this must not assume it's set.
+      const selfEntry = this.processPending[umid].entry.$nodes[this.reference];
+      const data = selfEntry && !selfEntry.early
         ? Object.assign(this.processPending[umid].entry, {
             $nodes: {
-              [this.reference]:
-                this.processPending[umid].entry.$nodes[this.reference],
+              [this.reference]: selfEntry,
             },
           })
         : Object.assign(this.processPending[umid].entry, {

--- a/packages/network/src/network/host.ts
+++ b/packages/network/src/network/host.ts
@@ -1623,7 +1623,7 @@ export class Host extends Home {
       this.processingBLQ = true;
 
       // Checked idententies. This means there is no "chance" we select the next one by bad timing
-      const checked: string[] = [];
+      const checked: Set<string> = new Set();
 
       // TODO Convert to method
       if (this.busyLocksQueue.internal.length) {
@@ -1632,10 +1632,10 @@ export class Host extends Home {
           const labelOrKey = this.busyLocksQueue.internal[i].entry.$$labelOrKey;
           // // Skip if we have already tried
           if (labelOrKey?.length) {
-            if (checked.some((io) => labelOrKey.includes(io))) {
+            if (labelOrKey.some((io) => checked.has(io))) {
               continue;
             }
-            checked.push(...labelOrKey);
+            labelOrKey.forEach((io) => checked.add(io));
           }
 
           if (

--- a/packages/network/src/network/host.ts
+++ b/packages/network/src/network/host.ts
@@ -1232,8 +1232,11 @@ export class Host extends Home {
       // TODO detect leader!
       //this.processPending[umid].entry.$nodes
 
-      // We only want to send our value
-      const data = (!early || !this.processPending[umid].entry.$nodes[this.reference].early)
+      // We only want to send our value, and only once it's resolved - an
+      // unresolved early placeholder must never be sent as if it were a
+      // real vote, regardless of why broadcast() was called (early flag
+      // here only affects $$noreply, not whether our own data is ready).
+      const data = !this.processPending[umid].entry.$nodes[this.reference].early
         ? Object.assign(this.processPending[umid].entry, {
             $nodes: {
               [this.reference]:

--- a/packages/protocol/src/protocol/process.ts
+++ b/packages/protocol/src/protocol/process.ts
@@ -1073,6 +1073,12 @@ export class Process extends EventEmitter {
     // Set voting completed state
     this.voting = false;
 
+    // Voting has concluded (with a real vote or a real error) - this
+    // node's response is no longer a placeholder, so network/host.ts's
+    // broadcast() is now safe to send it. nodeResponse aliases
+    // entry.$nodes[reference], so this also updates the entry directly.
+    delete this.nodeResponse.early;
+
     if (!this.entry) {
       // Unhandled contract error issues
       ActiveLogger.debug(`postVote entry is missing?`);

--- a/packages/protocol/src/protocol/shared.ts
+++ b/packages/protocol/src/protocol/shared.ts
@@ -310,13 +310,20 @@ export class Shared {
     if (!this._storeSingleError && this.entry) {
       // Take a copy of entry, To manipulate the $nodes incomms
       // Reason for copy is this node maybe the one that errors and the incomms maybe useful elsewhere
-      const tmpEntry = JSON.parse(
-        JSON.stringify(this.entry)
-      ) as ActiveDefinitions.LedgerEntry;
-      const nodeErrors = Object.keys(tmpEntry.$nodes);
+      // Only $nodes (and each node record within it) needs to be its own
+      // copy, everything else can be shared with the original entry.
+      const nodeErrors = Object.keys(this.entry.$nodes);
+      const clonedNodes: ActiveDefinitions.INodes = {};
       for (let i = nodeErrors.length; i--; ) {
-        tmpEntry.$nodes[nodeErrors[i]].incomms = null;
+        clonedNodes[nodeErrors[i]] = {
+          ...this.entry.$nodes[nodeErrors[i]],
+          incomms: null,
+        };
       }
+      const tmpEntry: ActiveDefinitions.LedgerEntry = {
+        ...this.entry,
+        $nodes: clonedNodes,
+      };
       // Build document for database
       const doc = {
         _id: `${this.entry.$umid}:${Date.now()}`,

--- a/packages/storage/src/levelme.ts
+++ b/packages/storage/src/levelme.ts
@@ -1048,6 +1048,10 @@ export class LevelMe {
 
       if (ENABLE_CACHE) {
         this.cache.set(cacheKey, doc);
+        // The resolved (non-raw) shape is now stale - drop it so the next
+        // non-raw get() recomputes it from the fresh raw doc instead of
+        // returning what was there before this write.
+        this.cache.delete(doc._id);
       }
     }
 

--- a/packages/storage/src/levelme.ts
+++ b/packages/storage/src/levelme.ts
@@ -586,17 +586,20 @@ export class LevelMe {
    */
   public async get(key: string, raw = false) {
     if (ENABLE_CACHE) {
-      if (!this.cache.has(key)) {
+      // raw and non-raw reads store different shapes for the same id, so
+      // they need distinct cache keys or one mode poisons the other.
+      const cacheKey = raw ? `raw:${key}` : key;
+      if (!this.cache.has(cacheKey)) {
         await this.open();
         // Allow errors to bubble up?
         let doc = JSON.parse(await this.levelUp.get(LevelMe.DOC_PREFIX + key));
         if (raw) {
-          this.cache.set(key, doc);
+          this.cache.set(cacheKey, doc);
         } else {
-          this.cache.set(key, await this.seqDocFromRoot(doc));
+          this.cache.set(cacheKey, await this.seqDocFromRoot(doc));
         }
       }
-      return this.cache.get(key, 30000);
+      return this.cache.get(cacheKey, 30000);
     } else {
       await this.open();
       // Allow errors to bubble up?
@@ -745,8 +748,14 @@ export class LevelMe {
     // _local_doc_count need to reduce count
     batch.del(LevelMe.DOC_PREFIX + key);
 
-    if (ENABLE_CACHE && this.cache.has(key)) {
-      this.cache.delete(key);
+    if (ENABLE_CACHE) {
+      if (this.cache.has(key)) {
+        this.cache.delete(key);
+      }
+      const rawKey = `raw:${key}`;
+      if (this.cache.has(rawKey)) {
+        this.cache.delete(rawKey);
+      }
     }
 
     await batch.write();
@@ -899,6 +908,16 @@ export class LevelMe {
     } catch (e) {
       // Unwinde the counter increases, Incorrect count should be ok as long as it overeads
       //this.docCount = this.docCount - docs.length;
+
+      // prepareForWrite() optimistically populated the cache for every doc
+      // in this batch before the write was confirmed - since it failed,
+      // those entries were never actually persisted, so drop them.
+      if (ENABLE_CACHE) {
+        for (let i = docs.length; i--; ) {
+          this.cache.delete(docs[i]._id);
+          this.cache.delete(`raw:${docs[i]._id}`);
+        }
+      }
       return false;
     }
     return true;
@@ -950,10 +969,15 @@ export class LevelMe {
     // Flag for doc counter
     let newDoc = false;
 
+    // Raw root doc shares its cache key with get(key, true) - see below
+    const cacheKey = `raw:${doc._id}`;
+
     // Does Document eixst?
     try {
-      currentDocRoot = JSON.parse(
-        await this.levelUp.get(LevelMe.DOC_PREFIX + doc._id)
+      currentDocRoot = (
+        ENABLE_CACHE && this.cache.has(cacheKey)
+          ? this.cache.get(cacheKey, 30000)
+          : JSON.parse(await this.levelUp.get(LevelMe.DOC_PREFIX + doc._id))
       ) as schema;
       // We need to pull out the right revision
       const currentRev =
@@ -1023,7 +1047,7 @@ export class LevelMe {
       chain.put(LevelMe.DOC_PREFIX + doc._id, JSON.stringify(doc));
 
       if (ENABLE_CACHE) {
-        this.cache.set(doc._id, doc);
+        this.cache.set(cacheKey, doc);
       }
     }
 

--- a/packages/utilities/src/request.ts
+++ b/packages/utilities/src/request.ts
@@ -37,6 +37,9 @@ interface IHTTPResponse {
   data: unknown;
 }
 
+// Below this many bytes, gzip's CPU cost outweighs the bandwidth it saves.
+const GZIP_MIN_BYTES = 1024;
+
 setGlobalDispatcher(
   new Agent({
     connect: {
@@ -102,13 +105,13 @@ export class ActiveRequest {
         (options.headers as any)["content-type"] = "application/json";
       }
 
-      // Compressable?
-      if (enableGZip) {
+      // Compressable? Below GZIP_MIN_BYTES the compression CPU cost outweighs
+      // the bandwidth saved, so skip it - the receiver already falls back to
+      // treating the body as plain JSON whenever content-encoding isn't "gzip".
+      if (enableGZip && data.length >= GZIP_MIN_BYTES) {
         // Compress
         data = await ActiveGZip.gzip(data);
         (options.headers as any)["content-encoding"] = "gzip";
-        // options.headers.push("Content-Encoding: gzip")
-        // options.headers.push("Content-Encoding-2: gzip")
       }
 
       // Additional Post headers

--- a/packages/utilities/src/request.ts
+++ b/packages/utilities/src/request.ts
@@ -42,6 +42,11 @@ setGlobalDispatcher(
     connect: {
       rejectUnauthorized: false,
     },
+    // Nodes repeatedly talk to the same small, fixed set of neighbours.
+    // undici's 4s default tears the socket down between consensus rounds
+    // more often than needed, forcing a fresh TCP+TLS handshake. 30s keeps
+    // connections warm across typical gaps without holding them open forever.
+    keepAliveTimeout: 30_000,
   })
 );
 


### PR DESCRIPTION
## Summary

**Consensus fix (the headline item):** fixes intermittent `Failed Network Voting Round - No More Voters` failures on non-leader-originated transactions in a live multi-node network. Root cause was a node's own tentative vote placeholder (`$nodes[self]`, `early: true`) being broadcast as if it were a resolved vote, plus that placeholder's `early` flag never being cleared once the vote actually resolved (aliasing bug in `protocol/process.ts`). Three commits, each fixing one layer of the same underlying issue as it was traced live:

- `78de5a0` — don't broadcast unresolved early-vote placeholders as real votes
- `243b1d6` — null guard on `$nodes[self]` in `broadcast()` (regression from the above)
- `eb9cb53` — clear the stale `early` flag once a vote actually resolves

**Verification:** live 4-node Docker network, 64/64 transactions passed (8 rounds × 4 nodes) across both original repro cases (direct-onboard and cross-node namespace-claim), zero failures with every node acting as origin. Confirmed the tested image was built from the exact `eb9cb53` commit tip (matched Dockerfile pin against `git ls-remote`), not a stale layer.

**Non-breaking perf improvements (10 commits):** each is independently revertable, verified individually (build + targeted runtime tests where applicable — see commit messages). No API or protocol changes; P2P/raw-socket layer untouched (out of scope, semi-disabled).

## Test plan
- [x] Live 4-node Docker network: 64/64 transactions across both consensus repro cases
- [x] Per-commit build + targeted runtime verification (buffer growth, KeyPair cache, LevelMe cache keys, undici keep-alive, gzip threshold — see individual commit messages)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)