### PR TITLE
fix: core off by default, getMany() batch-read bug, Node 24 compat

### DIFF
--- a/packages/activeledger/src/default.config.json
+++ b/packages/activeledger/src/default.config.json
@@ -23,7 +23,7 @@
     "reached": 60
   },
   "autostart": {
-    "core": true,
+    "core": false,
     "restore": true
   },
   "hybrid": [],

--- a/packages/crypto/src/crypto/keypair.ts
+++ b/packages/crypto/src/crypto/keypair.ts
@@ -473,7 +473,7 @@ export class KeyPair {
       case "rsa":
         sign = crypto.createSign("RSA-SHA256");
         sign.update(data);
-        return new Buffer(
+        return Buffer.from(
           sign.sign(this.handler.prv.pkcs8pem, "hex"),
           "hex"
         ).toString(encoding);
@@ -483,7 +483,7 @@ export class KeyPair {
         try {
           sign = crypto.createSign("sha256");
           sign.update(data);
-          return new Buffer(
+          return Buffer.from(
             sign.sign(this.handler.prv.pkcs8pem, "hex"),
             "hex"
           ).toString(encoding);

--- a/packages/storage/src/drivers/leveldb.ts
+++ b/packages/storage/src/drivers/leveldb.ts
@@ -29,7 +29,17 @@ export class LevelDBDriver implements IStorageDriver {
 
   public async getMany(keys: string[]): Promise<Buffer[]> {
     const vals = await this.db.getMany(keys);
-    return vals.map((v: any) => Buffer.isBuffer(v) ? v : Buffer.from(v));
+    // classic-level resolves undefined per-key for anything missing from
+    // the batch (matching get()'s single-key behaviour) rather than
+    // throwing - callers (permissionsChecker's stream lookups in
+    // particular) request keys that legitimately don't always exist
+    // (e.g. an optional ":stream" companion document) and rely on
+    // getMany() simply omitting those, not on positional correspondence
+    // to the input keys, so filter rather than converting undefined and
+    // crashing the whole batch.
+    return vals
+      .filter((v: any) => v !== undefined)
+      .map((v: any) => Buffer.isBuffer(v) ? v : Buffer.from(v));
   }
 
   public async put(key: string, value: any): Promise<void> {

--- a/packages/storage/src/drivers/rocksdb.ts
+++ b/packages/storage/src/drivers/rocksdb.ts
@@ -28,7 +28,13 @@ export class RocksDBDriver implements IStorageDriver {
 
   public async getMany(keys: string[]): Promise<Buffer[]> {
     const vals = await this.db.getMany(keys);
-    return vals.map((v: any) => Buffer.isBuffer(v) ? v : Buffer.from(v));
+    // See leveldb.ts's getMany() - same fix, same reasoning: abstract-level
+    // -based drivers resolve undefined per-key for a missing entry rather
+    // than throwing, and callers rely on getMany() omitting those, not on
+    // positional correspondence to the input keys.
+    return vals
+      .filter((v: any) => v !== undefined)
+      .map((v: any) => Buffer.isBuffer(v) ? v : Buffer.from(v));
   }
 
   public async put(key: string, value: any): Promise<void> {


### PR DESCRIPTION
## Summary
Three independent code fixes pulled out of the `hpe-13` documentation branch - no doc changes included here, those stay on `hpe-13`.

- **`autostart.core` now defaults to `false`** (`packages/activeledger/src/default.config.json`). `core` is being considered increasingly redundant next to the storage engine's own direct HTTP API; it no longer launches automatically. `restore` is unaffected. `core` remains fully installable/usable if explicitly re-enabled.
- **Fixed `getMany()` crashing an entire batch read over a single missing key** (`packages/storage/src/drivers/leveldb.ts`, `rocksdb.ts`). `classic-level` resolves `undefined` for a missing key in a batch rather than throwing; the driver did `Buffer.from(v)` unconditionally, which threw on `undefined` and rejected the whole batch. In practice, any transaction referencing a stream without an optional `:stream` companion document failed 100% of the time with a generic "Stream(s) not found." Fixed to filter out missing entries instead of converting them.
- **Node 24 LTS compatibility**: replaced deprecated `new Buffer(x, "hex")` with `Buffer.from()` in `KeyPair.sign()` (`packages/crypto/src/crypto/keypair.ts`) - this was on the hot path for every transaction signature and emitted a `DEP0005` warning under Node 24.

## Test plan
- [x] `getMany()` fix verified live: onboard → non-selfsign follow-up transaction (signed by the newly onboarded identity) → deliberately bad signature, all behave correctly where the follow-up previously failed 100% of the time.
- [x] `autostart.core: false` verified: source compiles, config template copies to `lib/` correctly.
- [x] Node 24 fix verified live under `24.19.0`: full monorepo build clean, a node booted (main host + self-hosted storage + `core` + `restore`) and stayed stable, a real signed onboarding transaction round-tripped successfully, no more `DEP0005` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)