### PR TITLE
perf: hpe-14 - fresh performance audit + two severe LevelMe write-path bugs

### DIFF
--- a/packages/activeledger/src/contracts/default/contract.ts
+++ b/packages/activeledger/src/contracts/default/contract.ts
@@ -26,6 +26,173 @@ import * as ts from "typescript";
 import { Standard, Activity } from "@activeledger/activecontracts";
 import { ActiveOptions } from "@activeledger/activeoptions";
 
+// Read-only security denylists used by securityScan() below. Unlike
+// allowedModules/policy (which get extended per-call from namespace
+// config), these three are never mutated - only ever looked up via
+// indexOf() - so they're safe to build once at module load instead of
+// on every single contract deploy/update.
+
+// Definitive denylist for identifiers (Globals and sensitive objects)
+const BANNED_IDENTIFIERS = [
+  "process",
+  "global",
+  "globalThis",
+  "eval",
+  "Function",
+  "AsyncFunction",
+  "GeneratorFunction",
+  "AsyncGeneratorFunction",
+  "module",
+  "exports",
+  "__dirname",
+  "__filename",
+  "setTimeout",
+  "setInterval",
+  "setImmediate",
+  "atob",
+  "btoa",
+  "Reflect",
+  "Proxy",
+  "WebAssembly",
+  "Symbol",
+  "arguments",
+  "caller",
+  "callee",
+  "console",
+  "debugger",
+  "fetch",
+  "SharedArrayBuffer",
+  "Atomics",
+  "performance",
+  "Performance",
+  "Intl",
+  "FinalizationRegistry",
+  "WeakRef",
+  "gc",
+  "v8",
+  "vm",
+  "worker_threads",
+  "cluster",
+  "child_process",
+  "os",
+  "path",
+  "fs",
+  "http",
+  "https",
+  "net",
+  "tls",
+  "crypto",
+  "root",
+  "window",
+  "top",
+  "stop",
+  "close",
+  "InternalError",
+];
+
+// Identifiers that can be used but not reassigned or shadowed
+const PROTECTED_IDENTIFIERS = [
+  "ActiveLogger",
+  "ActiveRequest",
+  "ActiveCrypto",
+  "ActiveOptions",
+  "ActiveDefinitions",
+  "ActiveGZip",
+  "Standard",
+  "Activity",
+  "ActivityStream",
+  "EventEngine",
+  "PostProcessQueryEvent",
+  "Math",
+  "Date",
+  "JSON",
+  "Array",
+  "Object",
+  "String",
+  "Number",
+  "Boolean",
+  "Error",
+  "Promise",
+  "Buffer",
+  "Map",
+  "Set",
+  "Uint8Array",
+  "BigInt",
+  "URL",
+  "URLSearchParams",
+  "TextEncoder",
+  "TextDecoder",
+  "self",
+];
+
+// Definitive denylist for property access (Reflection and System methods)
+const BANNED_PROPERTIES = [
+  "exit",
+  "kill",
+  "spawn",
+  "fork",
+  "exec",
+  "readFile",
+  "writeFile",
+  "unlink",
+  "rmdir",
+  "mkdir",
+  "appendFile",
+  "readdir",
+  "stat",
+  "lstat",
+  "constructor",
+  "__proto__",
+  "prototype",
+  "defineProperty",
+  "defineProperties",
+  "setPrototypeOf",
+  "getPrototypeOf",
+  "assign",
+  "__defineGetter__",
+  "__defineSetter__",
+  "__lookupGetter__",
+  "__lookupSetter__",
+  "binding",
+  "internalBinding",
+  "allocUnsafe",
+  "bind",
+  "call",
+  "apply",
+  "getOwnPropertyDescriptor",
+  "getOwnPropertyDescriptors",
+  "getOwnPropertyNames",
+  "getOwnPropertySymbols",
+  "preventExtensions",
+  "isExtensible",
+  "seal",
+  "isSealed",
+  "freeze",
+  "isFrozen",
+  "toSource",
+  "valueOf",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toLocaleString",
+  "captureStackTrace",
+  "stackTraceLimit",
+  "stack",
+  "fileName",
+  "lineNumber",
+  "columnNumber",
+  "__count__",
+  "__noSuchMethod__",
+  "__parent__",
+  "eval",
+  "Function",
+  "global",
+  "globalThis",
+  "process",
+  "module",
+  "require",
+];
+
 /**
  * Default Onboarding (New Account) contract
  *
@@ -215,167 +382,6 @@ export default class Contract extends Standard {
    * @param {string} namespace
    */
   private securityScan(sourceCode: string, namespace: string): void {
-    // Definitive denylist for identifiers (Globals and sensitive objects)
-    const bannedIdentifiers = [
-      "process",
-      "global",
-      "globalThis",
-      "eval",
-      "Function",
-      "AsyncFunction",
-      "GeneratorFunction",
-      "AsyncGeneratorFunction",
-      "module",
-      "exports",
-      "__dirname",
-      "__filename",
-      "setTimeout",
-      "setInterval",
-      "setImmediate",
-      "atob",
-      "btoa",
-      "Reflect",
-      "Proxy",
-      "WebAssembly",
-      "Symbol",
-      "arguments",
-      "caller",
-      "callee",
-      "console",
-      "debugger",
-      "fetch",
-      "SharedArrayBuffer",
-      "Atomics",
-      "performance",
-      "Performance",
-      "Intl",
-      "FinalizationRegistry",
-      "WeakRef",
-      "gc",
-      "v8",
-      "vm",
-      "worker_threads",
-      "cluster",
-      "child_process",
-      "os",
-      "path",
-      "fs",
-      "http",
-      "https",
-      "net",
-      "tls",
-      "crypto",
-      "root",
-      "window",
-      "top",
-      "stop",
-      "close",
-      "InternalError",
-    ];
-
-    // Identifiers that can be used but not reassigned or shadowed
-    const protectedIdentifiers = [
-      "ActiveLogger",
-      "ActiveRequest",
-      "ActiveCrypto",
-      "ActiveOptions",
-      "ActiveDefinitions",
-      "ActiveGZip",
-      "Standard",
-      "Activity",
-      "ActivityStream",
-      "EventEngine",
-      "PostProcessQueryEvent",
-      "Math",
-      "Date",
-      "JSON",
-      "Array",
-      "Object",
-      "String",
-      "Number",
-      "Boolean",
-      "Error",
-      "Promise",
-      "Buffer",
-      "Map",
-      "Set",
-      "Uint8Array",
-      "BigInt",
-      "URL",
-      "URLSearchParams",
-      "TextEncoder",
-      "TextDecoder",
-      "self",
-    ];
-
-    // Definitive denylist for property access (Reflection and System methods)
-    const bannedProperties = [
-      "exit",
-      "kill",
-      "spawn",
-      "fork",
-      "exec",
-      "readFile",
-      "writeFile",
-      "unlink",
-      "rmdir",
-      "mkdir",
-      "appendFile",
-      "readdir",
-      "stat",
-      "lstat",
-      "constructor",
-      "__proto__",
-      "prototype",
-      "defineProperty",
-      "defineProperties",
-      "setPrototypeOf",
-      "getPrototypeOf",
-      "assign",
-      "__defineGetter__",
-      "__defineSetter__",
-      "__lookupGetter__",
-      "__lookupSetter__",
-      "binding",
-      "internalBinding",
-      "allocUnsafe",
-      "bind",
-      "call",
-      "apply",
-      "getOwnPropertyDescriptor",
-      "getOwnPropertyDescriptors",
-      "getOwnPropertyNames",
-      "getOwnPropertySymbols",
-      "preventExtensions",
-      "isExtensible",
-      "seal",
-      "isSealed",
-      "freeze",
-      "isFrozen",
-      "toSource",
-      "valueOf",
-      "hasOwnProperty",
-      "isPrototypeOf",
-      "propertyIsEnumerable",
-      "toLocaleString",
-      "captureStackTrace",
-      "stackTraceLimit",
-      "stack",
-      "fileName",
-      "lineNumber",
-      "columnNumber",
-      "__count__",
-      "__noSuchMethod__",
-      "__parent__",
-      "eval",
-      "Function",
-      "global",
-      "globalThis",
-      "process",
-      "module",
-      "require",
-    ];
-
     // Allowed modules for require/import
     const allowedModules: string[] = ["@activeledger/activetoolkits", "@activeledger/activecontracts"];
     const policy = {
@@ -500,14 +506,14 @@ export default class Contract extends Standard {
              // Skip further checks for process
              return;
         }
-        if (bannedIdentifiers.indexOf(node.text) !== -1) {
+        if (BANNED_IDENTIFIERS.indexOf(node.text) !== -1) {
             // Allow if part of a property access (e.g. this.setTimeout)
             if (!(ts.isPropertyAccessExpression(node.parent) && node.parent.name === node)) {
                 report(node, `Unauthorized identifier '${node.text}'`);
             }
         }
         if (
-          protectedIdentifiers.indexOf(node.text) !== -1 &&
+          PROTECTED_IDENTIFIERS.indexOf(node.text) !== -1 &&
           isWriteAccess(node)
         ) {
           report(
@@ -521,7 +527,7 @@ export default class Contract extends Standard {
       if (ts.isPropertyAccessExpression(node)) {
         if (
           ts.isIdentifier(node.name) &&
-          bannedProperties.indexOf(node.name.text) !== -1
+          BANNED_PROPERTIES.indexOf(node.name.text) !== -1
         ) {
           // Allow access if it is on 'this'
           if (node.expression.kind === ts.SyntaxKind.ThisKeyword) {
@@ -534,7 +540,7 @@ export default class Contract extends Standard {
 
         if (
           ts.isIdentifier(unwrappedExpr) &&
-          protectedIdentifiers.indexOf(unwrappedExpr.text) !== -1 &&
+          PROTECTED_IDENTIFIERS.indexOf(unwrappedExpr.text) !== -1 &&
           isWriteAccess(node)
         ) {
           report(
@@ -577,7 +583,7 @@ export default class Contract extends Standard {
                 // Block all other dynamic accesses unless they are demonstrably safe
                 if (dynamicAccess) {
                     // If the key is known and banned, block it
-                    if (key && bannedProperties.indexOf(key) !== -1) {
+                    if (key && BANNED_PROPERTIES.indexOf(key) !== -1) {
                         report(node.argumentExpression, `Unauthorized element access '${key}'`);
                     } else if (!key) {
                         // If the key is entirely dynamic, block it for non-this
@@ -589,7 +595,7 @@ export default class Contract extends Standard {
 
         if (
           ts.isIdentifier(unwrappedExpr) &&
-          protectedIdentifiers.indexOf(unwrappedExpr.text) !== -1 &&
+          PROTECTED_IDENTIFIERS.indexOf(unwrappedExpr.text) !== -1 &&
           isWriteAccess(node)
         ) {
           report(
@@ -602,7 +608,7 @@ export default class Contract extends Standard {
       // 4. Block Banned Properties in Destructuring (const { exit } = obj)
       if (ts.isBindingElement(node) && ts.isIdentifier(node.name)) {
         const propertyName = node.propertyName ? (ts.isIdentifier(node.propertyName) ? node.propertyName.text : "") : node.name.text;
-        if (propertyName && bannedProperties.indexOf(propertyName) !== -1) {
+        if (propertyName && BANNED_PROPERTIES.indexOf(propertyName) !== -1) {
           report(node, `Unauthorized destructuring of property '${propertyName}'`);
         }
       }
@@ -651,7 +657,7 @@ export default class Contract extends Standard {
         report(node, `debugger statements are forbidden`);
       }
       if (ts.isDeleteExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
-        if (bannedProperties.indexOf(node.expression.name.text) !== -1) {
+        if (BANNED_PROPERTIES.indexOf(node.expression.name.text) !== -1) {
            report(node.expression.name, `Unauthorized deletion of property '${node.expression.name.text}'`);
         }
       }

--- a/packages/core/src/heartbeat.ts
+++ b/packages/core/src/heartbeat.ts
@@ -42,11 +42,7 @@ export class HeartBeat {
         // Empty bytes can cause issues to some client
         //response.write("\0");
         // better to use a "comment"
-        if (!response.write(":\n\n")) {
-        } else {
-          // force flush
-          process.nextTick(() => {});
-        }
+        response.write(":\n\n");
       }
       // Increase timeout with TCP keepalive enabled.
       // Some connections still may timeout after long periods of inactivity

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,7 +58,7 @@ if (ActiveOptions.get("db", false)) {
   // Extend Config
   ActiveOptions.extendConfig();
   // Create Light Server
-  let http = new ActiveHttpd(true);
+  let http = new ActiveHttpd();
 
   // Welcome
   http.use("/", "GET", welcome);

--- a/packages/httpd/src/httpd.ts
+++ b/packages/httpd/src/httpd.ts
@@ -171,7 +171,10 @@ export class ActiveHttpd {
       };
 
       const method = req.getMethod().toUpperCase();
-      const query = Object.fromEntries(new URLSearchParams(req.getQuery()).entries());
+      const rawQuery = req.getQuery();
+      const query = rawQuery
+        ? Object.fromEntries(new URLSearchParams(rawQuery).entries())
+        : {};
       const url2 = req.getUrl();
       const path = url2.split("?")[0];
 

--- a/packages/httpd/src/httpd.ts
+++ b/packages/httpd/src/httpd.ts
@@ -104,10 +104,10 @@ export class ActiveHttpd {
   private compiled: any = {};
 
   /**
-   * Creates an instance of ActiveHttpd.
-   * @param {boolean} [enableCORS=false]
+   * Creates an instance of ActiveHttpd. CORS is always allowed - see
+   * writeResponse() - there is no per-instance opt-out.
    */
-  constructor(private enableCORS: boolean = false) { }
+  constructor() { }
 
   /**
    * Define Route
@@ -328,13 +328,6 @@ export class ActiveHttpd {
     );
     if (handler) {
       try {
-        // Default Allow CORS
-        // if (this.enableCORS && req.headers["origin"]) {
-        //   res.setHeader(
-        //     "Access-Control-Allow-Origin",
-        //     req.headers["origin"] as string
-        //   );
-        // }
         // Run the call handler
         const data = await handler(incoming, req, res);
         // If the headers have been sent handler took control

--- a/packages/hybrid/src/server.ts
+++ b/packages/hybrid/src/server.ts
@@ -97,7 +97,7 @@ export class HybridNode {
     this.dbEventConnection.info();
 
     // Create Server
-    this.httpServer = new ActiveHttpd(true);
+    this.httpServer = new ActiveHttpd();
 
     // Listen for root requests
     this.httpServer.use(

--- a/packages/network/src/network/host.ts
+++ b/packages/network/src/network/host.ts
@@ -1456,8 +1456,12 @@ export class Host extends Home {
         reason: "Failed to rebroadcast while in memory",
       };
 
-      // Return
-      this.dbErrorConnection.post(doc);
+      // Fire and forget, but post() can now reject on a real write failure
+      // (see levelme.ts) - this call site has nothing awaiting it, so an
+      // unhandled rejection would otherwise result.
+      this.dbErrorConnection.post(doc).catch((error) => {
+        ActiveLogger.error(error, "Failed to write rebroadcast-failure error document");
+      });
     }
   }
 

--- a/packages/network/src/network/host.ts
+++ b/packages/network/src/network/host.ts
@@ -1680,9 +1680,16 @@ export class Host extends Home {
   public release(umid: string) {
     if (this.processPending[umid]) {
       const entry = this.processPending[umid].entry;
-      // Ask for releases
+      // Ask for releases - hold() already computed and cached this on the
+      // entry, no need to redo the $i/$o walk here (recomputing ignored the
+      // $selfsign/dedupe logic hold() applies too, which is harmless for
+      // release - Locker.release() is idempotent per key - but still wasted
+      // work on every single transaction completion).
       Locker.release(
-        [...this.labelOrKey(entry.$tx.$i), ...this.labelOrKey(entry.$tx.$o)],
+        entry.$$labelOrKey || [
+          ...this.labelOrKey(entry.$tx.$i),
+          ...this.labelOrKey(entry.$tx.$o),
+        ],
         entry.$umid
       );
 

--- a/packages/network/src/network/host.ts
+++ b/packages/network/src/network/host.ts
@@ -61,6 +61,29 @@ const KILL_PROC_SHUTDOWN = 2.5 * 1000;
 const MAX_RETRIES = 35; // Bubbling up error (may need different counters)
 
 /**
+ * Reads the first `n` bytes across the front of a chunk array without
+ * concatenating everything buffered so far - almost always just chunks[0]
+ * if it's already big enough, only falling back to a (small) concat of the
+ * leading chunks that actually make up those n bytes.
+ *
+ * @param {Buffer[]} chunks
+ * @param {number} n
+ * @returns {Buffer}
+ */
+function peekBytes(chunks: Buffer[], n: number): Buffer {
+  if (chunks.length > 0 && chunks[0].length >= n) {
+    return chunks[0];
+  }
+  let total = 0;
+  let end = 0;
+  while (end < chunks.length && total < n) {
+    total += chunks[end].length;
+    end++;
+  }
+  return Buffer.concat(chunks.slice(0, end));
+}
+
+/**
  * Process object used to manage an individual transaction
  *
  * @interface process
@@ -426,11 +449,20 @@ export class Host extends Home {
 
           // Frame: [SenderRef (40)][Length (4)][Payload]
           while (bufferLength >= 44) {
-            const fullBuffer = Buffer.concat(chunks);
-            const senderRef = fullBuffer.slice(0, 40).toString().trim();
-            const length = fullBuffer.readUInt32BE(40);
+            // Peek just the 44-byte header without concatenating the whole
+            // buffered backlog - almost always already in chunks[0] alone.
+            // A multi-chunk message (e.g. a large contract deploy) used to
+            // pay a full Buffer.concat() of everything received so far on
+            // every single TCP segment while still waiting for the rest of
+            // the frame to arrive - O(n^2) for an n-segment message.
+            const header = peekBytes(chunks, 44);
+            const length = header.readUInt32BE(40);
 
             if (bufferLength >= 44 + length) {
+              // Frame complete - now it's safe/necessary to do the one
+              // full concat needed to slice out the item.
+              const fullBuffer = Buffer.concat(chunks);
+              const senderRef = fullBuffer.slice(0, 40).toString().trim();
               const item = fullBuffer.slice(44, 44 + length);
 
               // Clean up consumed data

--- a/packages/protocol/src/protocol/shared.ts
+++ b/packages/protocol/src/protocol/shared.ts
@@ -23,7 +23,11 @@
 
 import { IVirtualMachine } from "./interfaces/vm.interface";
 import { ActiveDefinitions } from "@activeledger/activedefinitions";
-import { ActiveDSConnect } from "@activeledger/activeoptions";
+import {
+  ActiveDSConnect,
+  ActiveCache,
+  ActiveCacheManager,
+} from "@activeledger/activeoptions";
 import { ActiveCrypto } from "@activeledger/activecrypto";
 import { ActiveLogger } from "@activeledger/activelogger";
 import { Process } from "./process";
@@ -67,6 +71,24 @@ export class Shared {
     reason: "",
     priority: 0,
   };
+
+  /**
+   * Cross-transaction cache of parsed KeyPair instances used for signature
+   * verification, keyed by the raw key material itself (type + public key)
+   * - never by streamId/identity, since one identity stream can hold
+   * multiple distinct authority keys. Reusing the same KeyPair instance
+   * across calls is what lets its own internal parsed-KeyObject cache
+   * (see crypto/keypair.ts) actually engage - signatureCheck() used to
+   * construct a fresh KeyPair on every single call, so that cache never
+   * had a chance to be hit. Same TTL/sliding-extend tuning as LevelMe's
+   * document cache (30s base, extended 30s per hit) - same idea: a key
+   * that's actively signing stays warm indefinitely, a quiet one ages out
+   * rather than growing this cache unbounded over a node's lifetime.
+   *
+   * @private
+   */
+  private readonly verifyKeyCache: ActiveCache<ActiveCrypto.KeyPair> =
+    ActiveCacheManager.fetch<ActiveCrypto.KeyPair>("verifyKeys", 30000);
 
   constructor(
     private _storeSingleError: boolean,
@@ -345,8 +367,15 @@ export class Shared {
     type: string = "rsa"
   ): boolean {
     try {
-      // Get Key Object
-      let key: ActiveCrypto.KeyPair = new ActiveCrypto.KeyPair(type, publicKey);
+      // Reuse a cached KeyPair for this exact key material if we've seen
+      // it recently, instead of constructing (and re-parsing) a fresh one
+      // on every single signature check.
+      const cacheKey = `${type}\0${publicKey}`;
+      let key = this.verifyKeyCache.get(cacheKey, 30000);
+      if (!key) {
+        key = new ActiveCrypto.KeyPair(type, publicKey);
+        this.verifyKeyCache.set(cacheKey, key);
+      }
 
       // Return Valid or not
       return key.verify(this.entry.$tx, signature);

--- a/packages/protocol/src/protocol/vm.ts
+++ b/packages/protocol/src/protocol/vm.ts
@@ -215,6 +215,13 @@ export class VirtualMachine
       exported.push(contractData as unknown as ActiveDefinitions.LedgerStream);
     }
 
+    // If we are performing a staged rollout, hide the new auditing features
+    // until the 'build' flag is configured to 40000 or higher. This allows
+    // legacy nodes to process transactions without data schema conflicts.
+    // Invariant across every stream in this call, so read it once rather
+    // than on every updatedMeta stream in the loop below.
+    const build = ActiveOptions.get<number>("build", 0);
+
     // Loop each stream and find the marked ones
     while (i--) {
       if (activities[streams[i]].updated) {
@@ -223,15 +230,11 @@ export class VirtualMachine
           //@ts-ignore
           state: activities[streams[i]].state
         }
-        
+
         if (activities[streams[i]].updatedMeta) {
           //@ts-ignore
           stream.meta = activities[streams[i]].meta;
 
-          // If we are performing a staged rollout, hide the new auditing features
-          // until the 'build' flag is configured to 40000 or higher. This allows
-          // legacy nodes to process transactions without data schema conflicts.
-          const build = ActiveOptions.get<number>("build", 0);
           if (build < 40000) {
             if (stream.meta) {
               if (stream.meta.removedAuthorities) {

--- a/packages/storage/src/levelme.ts
+++ b/packages/storage/src/levelme.ts
@@ -551,11 +551,29 @@ export class LevelMe {
         // the stale entry so the next non-raw get() recomputes it.
         this.cache.delete(writer.changes.id);
       }
-      this.changeEmitter.emit("change", writer.changes);
     } catch (e) {
-      // May contain multiple documents, Easier & safer to clear the cache
+      // Real write failure - every caller up the stack (streamUpdater.ts,
+      // shared.ts's storeError(), selfhost.ts's own POST handler) already
+      // has a try/catch written expecting post() to reject on failure; it
+      // was just unreachable dead code because this used to always resolve
+      // { ok: true } regardless. May contain multiple documents, Easier &
+      // safer to clear the cache.
       this.cache.clear();
+      throw e;
     }
+
+    // Emit outside the try/catch, same reasoning as bulkDocs() - a
+    // listener's own bug should never be able to masquerade as this write
+    // having failed. EventEmitter doesn't isolate a listener's own thrown
+    // exception by default though, so this is its own try/catch too -
+    // otherwise a listener throwing would propagate straight out and
+    // reject this call, the same class of bug being fixed here.
+    try {
+      this.changeEmitter.emit("change", writer.changes);
+    } catch (listenerError) {
+      ActiveLogger.error(listenerError, "change listener threw");
+    }
+
     return {
       ok: true,
       id: doc._id,
@@ -683,8 +701,19 @@ export class LevelMe {
     // succeeded, which streamUpdater.ts's commit path took as a genuine
     // disk failure (error 1510) on every transaction, for as long as any
     // /events client stayed connected.
+    //
+    // EventEmitter doesn't isolate a listener's own exception by default -
+    // a synchronous throw inside emit() propagates straight out to us, so
+    // being outside the write's try/catch above isn't enough on its own to
+    // fully protect the return value. Each emit is individually try/caught
+    // here too, so one listener throwing can't stop the rest from being
+    // notified, and can never turn into bulkDocs() itself rejecting.
     for (let i = changes.length; i--;) {
-      this.changeEmitter.emit("change", changes[i]);
+      try {
+        this.changeEmitter.emit("change", changes[i]);
+      } catch (listenerError) {
+        ActiveLogger.error(listenerError, "change listener threw");
+      }
     }
     return true;
   }

--- a/packages/storage/src/levelme.ts
+++ b/packages/storage/src/levelme.ts
@@ -454,8 +454,16 @@ export class LevelMe {
         if (!this.cache.has(keys[i])) {
           tmpKeys.push(LevelMe.DOC_PREFIX + keys[i]);
         } else {
-          //cached.push({ doc: this.cache.get(keys[i], 30000) });
-          cached.push({ ...this.cache.get(keys[i], 30000) });
+          // No copy here, same as the cache-miss branch below (cached.push(data)
+          // shares the object with cache.set() unconditionally) - this was an
+          // inconsistent, incomplete defensive copy: a stream that's already
+          // warm skipped mutation exposure, one that wasn't didn't. Contract
+          // code itself never touches either one directly regardless -
+          // Activity.getState() (contracts/stream.ts) always deep-clones
+          // before handing state to a contract - so this copy wasn't
+          // load-bearing for correctness, just an extra allocation on every
+          // cache hit.
+          cached.push(this.cache.get(keys[i], 30000));
         }
       }
 

--- a/packages/storage/src/levelme.ts
+++ b/packages/storage/src/levelme.ts
@@ -664,10 +664,27 @@ export class LevelMe {
           this.cache.delete(changes[i].id);
         }
       }
-      // Emit Changed Docs
-      this.changeEmitter.emit("change", changes);
     } catch (e) {
       return false;
+    }
+
+    // Emit Changed Docs - one event per document, matching post()'s shape
+    // (a flat object, not an array), so a "change" listener never has to
+    // handle two different shapes depending on which write path triggered
+    // it. This used to emit a single event carrying the whole array, which
+    // crashed any listener written for post()'s single-object shape -
+    // selfhost.ts's /events SSE handler is exactly one such listener
+    // (change.id.startsWith(...) threw on an array, since arrays don't
+    // have an .id). Emitting outside the try/catch above (rather than
+    // inside it, as before) means a listener's own bug can no longer be
+    // misattributed as this write having failed - that's what let a
+    // thrown listener exception get silently caught here and turn into
+    // bulkDocs() returning false even though batch.write() had already
+    // succeeded, which streamUpdater.ts's commit path took as a genuine
+    // disk failure (error 1510) on every transaction, for as long as any
+    // /events client stayed connected.
+    for (let i = changes.length; i--;) {
+      this.changeEmitter.emit("change", changes[i]);
     }
     return true;
   }

--- a/packages/storage/src/selfhost.ts
+++ b/packages/storage/src/selfhost.ts
@@ -677,8 +677,11 @@ import { IActiveHttpResponse } from "@activeledger/httpd/lib/httpd";
         changes.off("change", listener);
       };
 
-      // Run on close connection
-      //res.on("close", cancelChanges);
+      // Run on disconnect immediately, rather than only being discovered
+      // reactively the next time a change event fires and listener() sees
+      // sse.write() return false - on a quiet database that could be a long
+      // time (or never) after the client actually disconnects.
+      sse.onDisconnect(cancelChanges);
 
       // Listening for changes
       let changes = db.changes().on("change", listener);

--- a/packages/storage/src/sse.ts
+++ b/packages/storage/src/sse.ts
@@ -31,6 +31,20 @@ import { HeartBeat } from "./heartbeat";
  */
 export class SSE {
   private heartBeat: NodeJS.Timeout;
+
+  /**
+   * Extra caller-supplied cleanup to run on disconnect, in addition to this
+   * class's own (writable=false, stop heartbeat). uWS's res.onAborted()
+   * replaces any previously registered callback rather than stacking them -
+   * this exists so a caller (e.g. selfhost.ts's /events handler, to
+   * deregister its own db.changes() listener) doesn't have to call
+   * res.onAborted() a second time and silently clobber this class's own
+   * handler.
+   *
+   * @private
+   */
+  private disconnectCallback?: () => void;
+
   constructor(private res: IActiveHttpResponse) {
     // Make sure we have an array
     //res.statusCode = 200;
@@ -77,7 +91,23 @@ export class SSE {
     res.onAborted(() => {
       res.writable = false;
       HeartBeat.Stop(this.heartBeat);
+      if (this.disconnectCallback) {
+        this.disconnectCallback();
+      }
     });
+  }
+
+  /**
+   * Register extra cleanup to run immediately on disconnect (in the same
+   * onAborted callback this class already owns), instead of only being
+   * discovered reactively the next time write() is called and notices
+   * res.writable is false. On a quiet stream that could otherwise be a long
+   * time - or never - after the client actually disconnects.
+   *
+   * @param {() => void} callback
+   */
+  public onDisconnect(callback: () => void): void {
+    this.disconnectCallback = callback;
   }
 
   /**

--- a/packages/utilities/src/clone.ts
+++ b/packages/utilities/src/clone.ts
@@ -78,13 +78,30 @@ export class ActiveClone {
     options: SerializationOptions = DEFAULT_SERIALIZATION_OPTIONS
   ): Promise<Buffer> {
     const binary = packr.pack(obj);
-    
+
     if (options.enableCompression && binary.length > COMPRESSION_THRESHOLD) {
       const compressed = await ActiveGZip.gzip(binary);
-      return Buffer.concat([Buffer.from([SerializationType.Gzip]), compressed]);
+      return this.prefixFlag(SerializationType.Gzip, compressed);
     }
-    
-    return Buffer.concat([Buffer.from([SerializationType.Uncompressed]), binary]);
+
+    return this.prefixFlag(SerializationType.Uncompressed, binary);
+  }
+
+  /**
+   * Prepend a one-byte flag to a buffer without the extra throwaway
+   * allocation Buffer.from([flag]) + Buffer.concat costs on every write.
+   *
+   * @private
+   * @static
+   * @param {SerializationType} flag
+   * @param {Buffer} data
+   * @returns {Buffer}
+   */
+  private static prefixFlag(flag: SerializationType, data: Buffer): Buffer {
+    const result = Buffer.allocUnsafe(data.length + 1);
+    result[0] = flag;
+    data.copy(result, 1);
+    return result;
   }
 
   /**

--- a/packages/utilities/src/frame.ts
+++ b/packages/utilities/src/frame.ts
@@ -29,6 +29,31 @@
  */
 export class ActiveFrame {
   /**
+   * Reads the first `n` bytes across the front of the chunk array without
+   * concatenating everything buffered so far - almost always just
+   * chunks[0] if it's already big enough, only falling back to a (small)
+   * concat of the leading chunks that actually make up those n bytes.
+   *
+   * @private
+   * @static
+   * @param {Buffer[]} chunks
+   * @param {number} n
+   * @returns {Buffer}
+   */
+  private static peek(chunks: Buffer[], n: number): Buffer {
+    if (chunks.length > 0 && chunks[0].length >= n) {
+      return chunks[0];
+    }
+    let total = 0;
+    let end = 0;
+    while (end < chunks.length && total < n) {
+      total += chunks[end].length;
+      end++;
+    }
+    return Buffer.concat(chunks.slice(0, end));
+  }
+
+  /**
    * Reads a frame from the chunk array
    *
    * @static
@@ -39,18 +64,24 @@ export class ActiveFrame {
   public static read(chunks: Buffer[], bufferLength: number): { item: Buffer; remaining: Buffer; consumed: number } | null {
     if (bufferLength < 4) return null;
 
-    const fullBuffer = Buffer.concat(chunks);
-    const length = fullBuffer.readUInt32BE(0);
+    const length = this.peek(chunks, 4).readUInt32BE(0);
 
-    if (bufferLength >= 4 + length) {
-      const item = fullBuffer.slice(4, 4 + length);
-      const remaining = fullBuffer.slice(4 + length);
-      return {
-        item,
-        remaining,
-        consumed: 4 + length,
-      };
+    if (bufferLength < 4 + length) {
+      // Frame not fully buffered yet - avoid paying for a full concat of
+      // everything received so far just to find that out. Previously this
+      // ran on every single incoming chunk of a multi-chunk message
+      // (O(n^2) for an n-chunk message); now only the completed-frame case
+      // below does the one full concat that's actually needed.
+      return null;
     }
-    return null;
+
+    const fullBuffer = Buffer.concat(chunks);
+    const item = fullBuffer.slice(4, 4 + length);
+    const remaining = fullBuffer.slice(4 + length);
+    return {
+      item,
+      remaining,
+      consumed: 4 + length,
+    };
   }
 }


### PR DESCRIPTION
## Summary
Follow-up performance audit on top of `v4.1.1`, plus two severe correctness bugs found and fixed along the way. Tested independently: 120/120 transactions clean across a 4-node network with SSE connections held open throughout (see Test plan).

### Tier 1 - mechanical perf fixes, no behaviour change
- `host.release()` reuses `hold()`'s cached `$$labelOrKey` instead of recomputing on every transaction completion.
- `ActiveClone.serialize()` avoids an extra `Buffer` allocation on every document write.
- `httpd.ts` skips `URLSearchParams` parsing on requests with no query string.
- Removed a leftover empty `process.nextTick()` on `core`'s SSE heartbeat (missed in `hpe-12`).
- Hoisted an invariant config read out of a per-stream loop in `vm.ts`.
- Fixed O(n²) buffer reassembly on the P2P receive path (currently dead code, fixed proactively).
- Hoisted `contract.ts`'s read-only security denylists to module scope.

### Real fixes
- **Made the `hpe-12` verify-key cache actually reachable** - `Shared.signatureCheck()` constructed a fresh `KeyPair` per call, so the cache never engaged. Added a cross-transaction cache keyed by the raw key material (never by streamId/identity - one identity stream can hold multiple distinct authority keys).
- **Dropped an inconsistent defensive copy in `LevelMe.getMany()`'s cache-hit path**, matching the cache-miss path's existing (already-relied-upon) reference-sharing behaviour.
- **Cleaned up `/events` SSE listeners immediately on disconnect** instead of only reactively on the next unrelated change event.
- **`bulkDocs()` spuriously failed every transaction while any `/events` client was connected** - the most severe finding. It emitted its `"change"` event with an array; `/events`'s listener assumed a flat object, threw, and that throw got caught by `bulkDocs()`'s own write-failure `try/catch`, misreporting a successful write as a disk failure (error 1510). Fixed the emit shape and moved emit handling outside the write's own error-signalling path.
- **`LevelMe.post()` always reported `{ok:true}`, even on a genuine write failure** - every caller up the stack was already written expecting it to throw; that error handling was dead code until now.
- **Removed `ActiveHttpd`'s dead `enableCORS` flag** and formalized CORS-always-on as the deliberate behaviour (explicit product decision - CORS was already unconditional in practice).

Full details and verification notes are in each commit message.

## Test plan
- [x] Every fix build-verified individually and as a full monorepo build.
- [x] Each fix verified live against a real running node (or standalone against real `LevelMe`/`KeyPair`/`SSE` instances where a full node wasn't necessary).
- [x] The `bulkDocs()` bug was reproduced first (confirmed it actually failed pre-fix) before the fix was considered verified.
- [x] Independently tested by another session across a real 4-node network: 15 rounds x 4 nodes x 2 transaction types (direct-onboard + cross-node namespace-claim) = 120 transactions, every node used as origin repeatedly - 120/120 passed, no consensus failures, SSE connections held open to all 4 nodes' event feeds throughout the entire run (directly exercises the `bulkDocs()`/1510 fix under real multi-node load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)