### PR TITLE
hpe-16: umid event replay, hardened test suite, --stop fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 
 <img src="docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
-Activeledger is a powerful distributed ledger technology. Consider it as a single ledger updated simultaneously in multiple locations. As the data is written to a ledger, it is approved and confirmed by all other locations.
+Activeledger is a distributed ledger technology. A network of permissioned nodes gossips transactions to each other, votes on them, and commits the ones that reach consensus — each node reaching its own conclusion by watching the same traffic, rather than waiting on a single leader. Application logic lives in smart contracts (TypeScript, sandboxed), and consensus is tracked per-stream rather than globally, so unrelated transactions can be voted on and committed concurrently.
+
+## Requirements
+
+**Node.js 24.x** (the current LTS line) is the recommended and actively-tested version. The native HTTP/consensus transport ([uWebSockets.js](https://github.com/uNetworking/uWebSockets.js)) ships prebuilt bindings for a specific set of Node majors at any given time — 22.x also works today, but if you hit an error like `This version of uWS.js (...) supports only Node.js versions ...` on a Node version you'd expect to work, check that `node_modules/uWebSockets.js` itself is up to date (`npm i` again) before assuming the version genuinely isn't supported.
 
 ## Installation
 
@@ -20,10 +24,10 @@ Please see our documentation for detailed instructions. We currently have 2 lang
 
 ## Quickstart Guide
 
-Use NPM to install the 3 main applications for running activeledger.
+Use NPM to install Activeledger. `@activeledger/activerestore` is recommended alongside it (heals a node that falls behind or comes up empty); `@activeledger/activecore`'s REST API is optional and off by default (`autostart.core: false`) — install it too only if you specifically want it, see the documentation above.
 
 ```bash
-npm i -g @activeledger/activeledger @activeledger/activerestore @activeledger/activecore
+npm i -g @activeledger/activeledger @activeledger/activerestore
 ```
 
 ##### Creating a local Activeledger testnet
@@ -62,7 +66,7 @@ Then set `NODE_AUTH_TOKEN` to a GitHub personal access token with `read:packages
 
 ```bash
 export NODE_AUTH_TOKEN=<your github token>
-npm i -g @activeledger/activeledger @activeledger/activerestore @activeledger/activecore
+npm i -g @activeledger/activeledger @activeledger/activerestore
 ```
 
 For a Docker build, pass the token in as a build secret (e.g. `--secret id=npmrc,src=.npmrc` with a `RUN --mount=type=secret,id=npmrc,target=/root/.npmrc npm i -g ...` step) rather than baking it into an image layer.
@@ -95,8 +99,23 @@ npm install --global lerna
 
 ```bash
 npm i
-npm run setup
+npm run build
 ```
+
+`npm run setup` is also available for a full clean rebuild (`lerna clean` + bootstrap + build) if your `node_modules` are in a bad state — slower, and rarely needed for everyday work.
+
+## Testing
+
+Two separate test suites, deliberately decoupled so the fast one stays fast:
+
+```bash
+npm test              # fast unit tests (tests/*.ts, Mocha) - in-process, no real nodes
+npm run test:network  # live 4-node network integration test - boots real nodes on the local machine
+```
+
+`npm test` runs in well under a second and is safe to run constantly during development.
+
+`npm run test:network` (`tests/network/`) boots a real 4-node bare-host network, runs 100+ real transactions spread across every node as origin, deploys custom contracts and verifies `returnToRemote()`, verifies live event delivery over SSE, and verifies the network's Stream-Position-Incorrect self-healing by directly desyncing one node's local copy of a stream and confirming a transaction still succeeds whether that node is the transaction's origin or not. It prints live progress and a pass/fail summary, and takes well under a minute. Deliberately bare-host rather than Docker, so it doesn't add any requirements beyond what building the repo already needs.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "link:core": "cd ./packages/restore/ && npm link",
     "link:restore": "cd ./packages/core/ && npm link",
     "link:hybrid": "cd ./packages/hybrid/ && npm link",
-    "test": "mocha -r ts-node/register/transpile-only tests/**/*.ts -- --no-warnings"
+    "test": "mocha -r ts-node/register/transpile-only tests/*.ts -- --no-warnings",
+    "test:network": "ts-node --transpile-only tests/network/run.ts"
   },
   "devDependencies": {
     "@types/chai": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "link:core": "cd ./packages/restore/ && npm link",
     "link:restore": "cd ./packages/core/ && npm link",
     "link:hybrid": "cd ./packages/hybrid/ && npm link",
-    "test": "mocha -r ts-node/register/transpile-only tests/**/*.ts -- --no-warnings"
+    "test": "mocha -r ts-node/register/transpile-only tests/**/*.ts --exit -- --no-warnings"
   },
   "devDependencies": {
     "@types/chai": "4.3.1",

--- a/packages/activeledger/src/index.ts
+++ b/packages/activeledger/src/index.ts
@@ -59,7 +59,16 @@ if (ActiveOptions.get<boolean>("testnet", false)) {
   // Merge Configs (Helps Build local net)
   CLIHandler.merge();
 } else if (ActiveOptions.get<boolean>("stop", false)) {
-  CLIHandler.stop();
+  // The unconditional SIGTERM listener below holds the event loop open
+  // (a registered process signal handler is a real libuv handle), so
+  // this must exit explicitly once done - same reason backup/restore do.
+  CLIHandler.stop()
+    .then(() => {
+      process.exit();
+    })
+    .catch(() => {
+      process.exit();
+    });
 } else if (ActiveOptions.get<boolean>("restart", false)) {
   if (ActiveOptions.get<boolean>("auto", false)) {
     CLIHandler.restart(true);

--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -545,7 +545,6 @@ export class Endpoints {
                       // I imagine its because commit is called early now so less filter chance
                       //output.$responses = [responses[0]];
                       output.$responses = responses;
-                      // TODO fix (it wasn't broken just happened to be an array returned)
                     }
 
                     // Append Debug View
@@ -612,7 +611,14 @@ export class Endpoints {
                     ActiveLogger.error(error, "Sent 500 Response (1000)");
                     return reject({
                       statusCode: 500,
-                      content: error, // TODO this isn't passing correctly onto Failed to send back
+                      // A raw Error instance JSON.stringifies to "{}" (message/stack
+                      // aren't own enumerable properties), so the client would get an
+                      // empty body on genuine exceptions even though it's logged fine
+                      // above - normalise it to a plain object first.
+                      content:
+                        error instanceof Error
+                          ? { error: error.message }
+                          : error,
                     });
                   }
                 });
@@ -882,7 +888,9 @@ export class Endpoints {
                   ];
 
                   if (streams.length) {
-                    // TODO - Improve, bnreak isn't breaking? same umid multiple times
+                    // The dedup attempt below (rewrote/break) was disabled in favour
+                    // of the plain unconditional push further down - the "break isn't
+                    // breaking" bug only applied to that disabled approach.
                     //const rewrote: any = {};
                     // const rewrote = CacheManager.fetch("rewrote", 10000);
 

--- a/packages/network/src/network/host.ts
+++ b/packages/network/src/network/host.ts
@@ -285,8 +285,10 @@ export class Host extends Home {
           if (
             !this.processPending[entry.$umid]?.finished &&
             this.processPending[entry.$umid]?.pid &&
-            // If a lead/er we don't need to let sub processor know
-            // TODO sometimes this.reference is nullin $nodes related to the #
+            // If a lead/er we don't need to let sub processor know. This node's
+            // own key may not exist in $nodes yet (we haven't voted/committed
+            // in this entry), which optional-chains to undefined here and
+            // correctly falls through to "let the sub processor know".
             !this.processPending[entry.$umid]?.entry?.$nodes?.[this.reference]
               ?.leader
           ) {
@@ -1163,7 +1165,6 @@ export class Host extends Home {
           // If we want to send AFTER this node has completed uncomment
           // If Hybrid enabled, Send transaction on
           if (this.hybridHosts.length) {
-            // TODO : TypeError: Cannot read property '$streams' of undefined
             this.processHybridNodes(pending.entry, m.data.entry?.$streams);
           }
           break;

--- a/packages/protocol/src/protocol/interfaces/vm.interface.ts
+++ b/packages/protocol/src/protocol/interfaces/vm.interface.ts
@@ -109,6 +109,8 @@ export interface IVirtualMachine {
 
   getThrowsFromVM(umid: string): string[];
 
+  getEvents(umid: string): any[];
+
   destroy(umid: string): void;
 
   getInputs(umid: string): ActiveDefinitions.LedgerStream[];

--- a/packages/protocol/src/protocol/permissionsChecker.ts
+++ b/packages/protocol/src/protocol/permissionsChecker.ts
@@ -251,9 +251,19 @@ export class PermissionsChecker {
       }
     } catch (error) {
       ActiveLogger.error(error, "Error fetching streams for permissions check - " + this.entry.$umid);
-      // Add Info
-      error.code = 950;
-      error.reason = "Stream(s) not found";
+      // Preserve a deliberately-thrown, specific error (1700/1710 from the
+      // lock checks above, or this function's own 950 "not found") -
+      // only default to the generic "Stream(s) not found" for a genuinely
+      // unexpected failure (e.g. the allDocs() call itself throwing) that
+      // doesn't already carry a real error code. Previously this
+      // overwrote unconditionally, so a contractlock/namespaceLock
+      // rejection always surfaced to the client as a misleading 950
+      // "Stream(s) not found" instead of the documented 1700/1710 -
+      // found while adding network-test coverage for locked streams.
+      if (!error.code) {
+        error.code = 950;
+        error.reason = "Stream(s) not found";
+      }
       // Rethrow
       throw error;
     }

--- a/packages/protocol/src/protocol/streamUpdater.ts
+++ b/packages/protocol/src/protocol/streamUpdater.ts
@@ -196,11 +196,18 @@ export class StreamUpdater {
     // Now we need to append transaction to the inputs of the transaction
     //if (this.inputs && this.inputs.length) this.handleInputs();
 
-    // Create umid document containing the transaction details
+    // Create umid document containing the transaction details. Includes
+    // every event this transaction's contract raised (sibling to umid/
+    // streams, not nested inside compactTxEntry() - matches the shape
+    // Endpoints.umid() serves back as-is via db.get(umid + ":umid"), which
+    // is what restore/interagent.ts's insertUmid() and quick-restore.ts
+    // read to replay them on a node that's restoring this transaction
+    // having missed it the first time).
     this.docs.push({
       _id: this.entry.$umid + ":umid",
       umid: this.compactTxEntry(),
       streams: this.refStreams,
+      events: this.virtualMachine.getEvents(this.entry.$umid),
     });
 
     this.detectCollisions();
@@ -210,7 +217,8 @@ export class StreamUpdater {
    * Creates a smaller trasnaction entry for ledger walking. This will also
    * keep the value deterministic (not including nodes)
    *
-   * TODO Add Events (So we can replay them on insertion)
+   * (Events are attached as a sibling field in processStreams()'s
+   * docs.push(), not here - see getEvents() above.)
    *
    * @private
    * @returns

--- a/packages/protocol/src/protocol/vm.ts
+++ b/packages/protocol/src/protocol/vm.ts
@@ -350,6 +350,17 @@ export class VirtualMachine
   }
 
   /**
+   * Every event this transaction's contract raised, in emission order -
+   * for streamUpdater.ts to attach to the transaction's umid document so
+   * a node restoring this transaction later can replay them.
+   *
+   * @returns {any[]}
+   */
+  public getEvents(umid: string): any[] {
+    return this.events[umid] ? this.events[umid].getEvents() : [];
+  }
+
+  /**
    * Get current working inputs of the contract (External to VM)
    *
    * @returns {ActiveDefinitions.LedgerStream[]}

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -44,6 +44,18 @@ export class EventEngine {
   private counter = 0;
 
   /**
+   * Every event raised during this transaction, in emission order. Read by
+   * streamUpdater.ts (via VirtualMachine.getEvents()) to attach to the
+   * transaction's umid document, so a node that later needs to restore
+   * this transaction (having missed it the first time - see
+   * restore/interagent.ts's insertUmid() and quick-restore.ts) can replay
+   * them into its own events database instead of silently losing them.
+   *
+   * @private
+   */
+  private emitted: any[] = [];
+
+  /**
    * Creates an instance of EventEngine.
    * @param {ActiveDefinitions.IActiveDSConnect} db
    * @param {string} contract
@@ -59,7 +71,7 @@ export class EventEngine {
    * @returns {Promise<any>}
    */
   public emit(name: string, data: any): void {
-    // Event object to store 
+    // Event object to store
     let event: any = {
       _id: `event:${Date.now()}-${++this.counter},${this.umid}`,
       name: name,
@@ -68,12 +80,23 @@ export class EventEngine {
       contract: this.contract,
     };
 
+    this.emitted.push(event);
+
     // TODO: Instruct to write to the database instead of just doing it?
     // ie vote gets sent on commit, commit gets sent when confirmed etc.
     this.db
       .post(event)
       .then(() => {})
       .catch(() => {});
+  }
+
+  /**
+   * Every event raised so far in this transaction, in emission order.
+   *
+   * @returns {any[]}
+   */
+  public getEvents(): any[] {
+    return this.emitted;
   }
 
   /**

--- a/packages/restore/src/modules/helper/helper.ts
+++ b/packages/restore/src/modules/helper/helper.ts
@@ -67,4 +67,40 @@ export class Helper {
   ) =>
     (votes / Helper.getNeighbourCount(dontIncludeSelf)) * 100 >=
     Provider.consensusReachedAmount;
+
+  /**
+   * Replays every event a restored transaction's contract raised, into
+   * this node's own events database - shared by both restore paths
+   * (interagent.ts's per-error insertUmid(), and quick-restore.ts's bulk
+   * catch-up), since a node restoring a umid it never ran itself would
+   * otherwise never see events its own commit() never actually executed.
+   *
+   * Reuses each event's original _id (embeds the umid + a per-transaction
+   * counter, see EventEngine.emit()) rather than minting a new one - the
+   * write is then naturally idempotent if this ever runs twice for the
+   * same umid, and any subscriber tracking Last-Event-ID sees the same
+   * event identity a node that ran the transaction itself would have
+   * produced.
+   *
+   * @static
+   * @param {*} umidDoc
+   * @returns {Promise<void>}
+   */
+  public static async replayEvents(umidDoc: any): Promise<void> {
+    const events = umidDoc?.events;
+    if (!Array.isArray(events) || !events.length) {
+      return;
+    }
+
+    for (let i = events.length; i--;) {
+      try {
+        await Provider.eventDatabase.post(events[i]);
+      } catch (error) {
+        ActiveLogger.error(
+          error,
+          `Failed to replay event ${events[i]?._id} for restored UMID ${umidDoc?.umid?.$umid || umidDoc?._id}`
+        );
+      }
+    }
+  }
 }

--- a/packages/restore/src/modules/interagent/interagent.ts
+++ b/packages/restore/src/modules/interagent/interagent.ts
@@ -22,6 +22,7 @@
  */
 
 import { Provider } from "../provider/provider";
+import { Helper } from "../helper/helper";
 import {
   IChangeDocument,
   IResponse,
@@ -267,6 +268,13 @@ export class Interagent {
             _id,
           }),
             ActiveLogger.info(`UMID Added ${_id}`);
+
+          // This node never ran this transaction's own commit() itself
+          // (that's why it needed restoring), so its own events database
+          // would otherwise never see whatever this transaction's
+          // contract raised - replay them now they're here.
+          await Helper.replayEvents(umidDoc);
+
           resolve();
         } catch (error) {
           ActiveLogger.info(

--- a/packages/restore/src/modules/quick-restore/quick-restore.ts
+++ b/packages/restore/src/modules/quick-restore/quick-restore.ts
@@ -151,6 +151,17 @@ export class QuickRestore {
         await Provider.database.bulkDocs(networkData.documents, {
           new_edits: false
         });
+
+        // Every :umid document just restored belongs to a transaction this
+        // node never ran itself (that's the whole point of a bulk
+        // catch-up), so replay whatever events it raised - same reasoning
+        // as interagent.ts's per-error insertUmid().
+        for (let i = networkData.documents.length; i--;) {
+          const doc = networkData.documents[i] as IBaseData;
+          if (doc._id && doc._id.indexOf(":umid") !== -1) {
+            await Helper.replayEvents(doc);
+          }
+        }
       } catch (error) {
         ActiveLogger.error(
           "Error occurred in processNetworkData: Uploading documents to database"

--- a/tests/contract-security-scan.test.ts
+++ b/tests/contract-security-scan.test.ts
@@ -1,0 +1,60 @@
+import Contract from "../packages/activeledger/src/contracts/default/contract";
+import { expect } from "chai";
+import "mocha";
+
+// Regression coverage for the hpe-14 perf fix (aa365df) that hoisted
+// securityScan()'s ~80-entry read-only denylists to module scope instead
+// of rebuilding them on every call. Calling securityScan() directly on the
+// prototype with a bare `{}` as `this` (matching how this was verified
+// live during hpe-14 - the method doesn't touch any instance state, only
+// its own arguments and the module-level denylists) sidesteps needing a
+// full Contract/VM instantiation.
+
+function scan(source: string, namespace = "somenamespace"): string | null {
+  try {
+    Contract.prototype.securityScan.call({}, source, namespace);
+    return null;
+  } catch (e: any) {
+    return e.message;
+  }
+}
+
+describe("Contract.securityScan() - hpe-14 regression (aa365df)", () => {
+  it("allows a clean contract with no violations", () => {
+    expect(scan("export default class Foo { vote() { return 1; } }")).to.be.null;
+  });
+
+  it("blocks a banned global identifier (process)", () => {
+    const result = scan("export default class Foo { vote() { return process.env; } }");
+    expect(result).to.not.be.null;
+    expect(result).to.include("process");
+  });
+
+  it("blocks a require() of a module not on the allow-list", () => {
+    const result = scan('const x = require("fs");');
+    expect(result).to.not.be.null;
+    expect(result).to.include("fs");
+  });
+
+  it("blocks a banned property access (constructor)", () => {
+    const result = scan("export default class Foo { vote() { return ({}).constructor; } }");
+    expect(result).to.not.be.null;
+    expect(result).to.include("constructor");
+  });
+
+  it("blocks a banned property access (exit)", () => {
+    const result = scan("export default class Foo { vote() { return process.exit; } }");
+    expect(result).to.not.be.null;
+  });
+
+  it("still allows a protected identifier to be used (just not reassigned/shadowed)", () => {
+    expect(scan("export default class Foo { vote() { return new Date(); } }")).to.be.null;
+  });
+
+  it("skips the scan entirely for the privileged 'default' namespace", () => {
+    // Would otherwise be blocked - proves the privileged-namespace early
+    // return still runs before the (now module-scope) denylists are ever
+    // consulted.
+    expect(scan("process.exit();", "default")).to.be.null;
+  });
+});

--- a/tests/httpd.test.ts
+++ b/tests/httpd.test.ts
@@ -1,0 +1,59 @@
+import { ActiveHttpd } from "../packages/httpd/src/httpd";
+import { expect } from "chai";
+import "mocha";
+import * as http from "http";
+
+// Regression coverage for the hpe-14 perf fix (3620b36) that skips
+// URLSearchParams parsing on requests with no query string (every internal
+// consensus POST, none of which ever carry one) - and, incidentally, for
+// ActiveHttpd's now-unconditional CORS headers (825db4e, the dead
+// enableCORS flag removal).
+describe("ActiveHttpd - hpe-14 regressions", () => {
+  const PORT = 5701;
+  let httpd: ActiveHttpd;
+
+  before((done) => {
+    httpd = new ActiveHttpd();
+    httpd.use("/test", "GET", async (incoming: any) => {
+      // The handler's return value is passed straight through as the
+      // response body (writeResponse() JSON.stringifies a plain object
+      // itself) - not a {statusCode, content} envelope.
+      return { query: incoming.query };
+    });
+    httpd.listen(PORT);
+    // listen() itself doesn't return a promise - give the underlying
+    // uWS server a moment to actually bind before the first request.
+    setTimeout(done, 200);
+  });
+
+  after(() => {
+    httpd.shutdown();
+  });
+
+  function get(path: string): Promise<{ statusCode: number; headers: http.IncomingHttpHeaders; body: string }> {
+    return new Promise((resolve, reject) => {
+      http.get({ hostname: "127.0.0.1", port: PORT, path }, (res) => {
+        let body = "";
+        res.on("data", (c) => (body += c));
+        res.on("end", () => resolve({ statusCode: res.statusCode || 0, headers: res.headers, body }));
+      }).on("error", reject);
+    });
+  }
+
+  it("returns an empty query object for a request with no query string (3620b36)", async () => {
+    const res = await get("/test");
+    expect(JSON.parse(res.body)).to.deep.equal({ query: {} });
+  });
+
+  it("still correctly parses a real query string", async () => {
+    const res = await get("/test?foo=bar&baz=qux");
+    expect(JSON.parse(res.body)).to.deep.equal({ query: { foo: "bar", baz: "qux" } });
+  });
+
+  it("still writes CORS headers unconditionally with no constructor argument (825db4e)", async () => {
+    const res = await get("/test");
+    expect(res.headers["access-control-allow-origin"]).to.equal("*");
+    expect(res.headers["access-control-allow-methods"]).to.equal("GET, POST");
+    expect(res.headers["access-control-allow-headers"]).to.equal("*");
+  });
+});

--- a/tests/network/actions.ts
+++ b/tests/network/actions.ts
@@ -1,0 +1,106 @@
+/**
+ * Domain-level actions built on top of http.ts's plain submit() - onboarding,
+ * namespace registration, and contract deploy/run. Shapes verified live,
+ * real transactions, repeatedly throughout the hpe-13/hpe-14 sessions (see
+ * docs-v4/transactions.md and docs-v4/contracts.md on the hpe-13 branch).
+ */
+
+import * as fs from "fs";
+import { ActiveCrypto } from "../../packages/crypto/src";
+import { submit } from "./http";
+
+export interface Identity {
+  streamId: string;
+  keyPair: ActiveCrypto.KeyPair;
+}
+
+export async function onboard(baseUrl: string): Promise<Identity> {
+  const keyPair = new ActiveCrypto.KeyPair("rsa");
+  const keys = keyPair.generate();
+  const txBody = {
+    $namespace: "default",
+    $contract: "onboard",
+    $i: { identity: { type: "rsa", publicKey: keys.pub.pkcs8pem } },
+    $o: {},
+  };
+  const tx = {
+    $tx: txBody,
+    $selfsign: true,
+    $sigs: { identity: keyPair.sign(txBody) },
+  };
+  const result = await submit(baseUrl, tx);
+  if (!result.$streams?.new?.[0]?.id) {
+    throw new Error(`Onboard failed: ${JSON.stringify(result)}`);
+  }
+  return { streamId: result.$streams.new[0].id, keyPair };
+}
+
+export async function registerNamespace(
+  baseUrl: string,
+  identity: Identity,
+  namespace: string
+): Promise<any> {
+  const txBody = {
+    $namespace: "default",
+    $contract: "namespace",
+    $i: { [identity.streamId]: { namespace } },
+  };
+  const tx = {
+    $tx: txBody,
+    $sigs: { [identity.streamId]: identity.keyPair.sign(txBody) },
+  };
+  return submit(baseUrl, tx);
+}
+
+export async function deployContract(
+  baseUrl: string,
+  identity: Identity,
+  namespace: string,
+  contractName: string,
+  sourcePath: string
+): Promise<string> {
+  const contractSrc = fs.readFileSync(sourcePath, "utf8");
+  const txBody = {
+    $namespace: "default",
+    $contract: "contract",
+    $i: {
+      [identity.streamId]: {
+        version: "0.0.1",
+        namespace,
+        name: contractName,
+        contract: Buffer.from(contractSrc).toString("base64"),
+      },
+    },
+  };
+  const tx = {
+    $tx: txBody,
+    $sigs: { [identity.streamId]: identity.keyPair.sign(txBody) },
+  };
+  const result = await submit(baseUrl, tx);
+  const contractStreamId = result.$streams?.new?.[0]?.id;
+  if (!contractStreamId) {
+    throw new Error(`Contract deploy failed: ${JSON.stringify(result)}`);
+  }
+  return contractStreamId;
+}
+
+/** Runs a deployed contract, writing to (and reading permission from) the caller's own identity stream. */
+export async function runContract(
+  baseUrl: string,
+  identity: Identity,
+  namespace: string,
+  contractStreamId: string,
+  outputPayload: Record<string, unknown>
+): Promise<any> {
+  const txBody = {
+    $namespace: namespace,
+    $contract: contractStreamId,
+    $i: { [identity.streamId]: {} },
+    $o: { [identity.streamId]: outputPayload },
+  };
+  const tx = {
+    $tx: txBody,
+    $sigs: { [identity.streamId]: identity.keyPair.sign(txBody) },
+  };
+  return submit(baseUrl, tx);
+}

--- a/tests/network/contracts/emitter-contract.ts
+++ b/tests/network/contracts/emitter-contract.ts
@@ -1,0 +1,60 @@
+import { Event, Activity } from "@activeledger/activecontracts";
+
+/**
+ * Writes a message onto an existing output stream's state and emits a
+ * named event carrying the same correlation id, so the test runner can
+ * verify events actually arrive over SSE on a real, live 4-node network -
+ * not just read from source.
+ */
+export default class Emitter extends Event {
+  private oActivity: Activity;
+  private message: string;
+  private correlationId: string;
+
+  public verify(selfsigned: boolean): Promise<boolean> {
+    return new Promise<boolean>((resolve, reject) => {
+      if (selfsigned) {
+        reject("No self sign");
+      } else {
+        resolve(true);
+      }
+    });
+  }
+
+  public vote(): Promise<boolean> {
+    return new Promise<boolean>((resolve, reject) => {
+      const oStreams = Object.keys(this.transactions.$o);
+      if (!oStreams.length) {
+        reject("Need an output stream");
+        return;
+      }
+      this.oActivity = this.getActivityStreams(oStreams[0]);
+      this.message = this.transactions.$o[oStreams[0]].message as string;
+      this.correlationId = this.transactions.$o[oStreams[0]].correlationId as string;
+      if (!this.message || !this.correlationId) {
+        reject("Need a message and correlationId");
+        return;
+      }
+      resolve(true);
+    });
+  }
+
+  public commit(): Promise<any> {
+    return new Promise<any>((resolve) => {
+      // See returner-contract.ts - deliberately no wall-clock timestamp
+      // written into state, since commit() runs independently per node and
+      // that would produce a different resulting revision hash on each
+      // one.
+      const state = this.oActivity.getState();
+      state.message = this.message;
+      this.oActivity.setState(state);
+
+      this.event.emit("network-test", {
+        correlationId: this.correlationId,
+        message: this.message,
+      });
+
+      resolve(true);
+    });
+  }
+}

--- a/tests/network/contracts/returner-contract.ts
+++ b/tests/network/contracts/returner-contract.ts
@@ -1,0 +1,59 @@
+import { Standard, Activity } from "@activeledger/activecontracts";
+
+/**
+ * Writes a message onto an existing output stream's state, and hands the
+ * same message back to the caller via returnToRemote() so the test runner
+ * can verify $responses actually carries commit()-returned data end to end
+ * on a real, live 4-node network - not just read from source.
+ */
+export default class Returner extends Standard {
+  private oActivity: Activity;
+  private message: string;
+
+  public verify(selfsigned: boolean): Promise<boolean> {
+    return new Promise<boolean>((resolve, reject) => {
+      if (selfsigned) {
+        reject("No self sign");
+      } else {
+        resolve(true);
+      }
+    });
+  }
+
+  public vote(): Promise<boolean> {
+    return new Promise<boolean>((resolve, reject) => {
+      const oStreams = Object.keys(this.transactions.$o);
+      if (!oStreams.length) {
+        reject("Need an output stream");
+        return;
+      }
+      this.oActivity = this.getActivityStreams(oStreams[0]);
+      this.message = this.transactions.$o[oStreams[0]].message as string;
+      if (!this.message) {
+        reject("Need a message");
+        return;
+      }
+      resolve(true);
+    });
+  }
+
+  public commit(): Promise<any> {
+    return new Promise<any>((resolve) => {
+      // Deliberately no wall-clock timestamp written into state here -
+      // commit() runs independently on every node (see architecture.md),
+      // so anything non-deterministic like new Date() written into
+      // persisted state produces a genuinely different resulting revision
+      // hash per node. Invisible on a single run, but running this
+      // contract twice against the same stream (as the SPI tests in
+      // tests/network/run.ts do) surfaces it immediately as multi-way
+      // "Input Stream Position Incorrect" disagreement on the second run -
+      // found and root-caused while building that test.
+      const state = this.oActivity.getState();
+      state.message = this.message;
+      this.oActivity.setState(state);
+
+      this.returnToRemote({ via: "returner-contract", echoedMessage: this.message });
+      resolve(true);
+    });
+  }
+}

--- a/tests/network/harness.ts
+++ b/tests/network/harness.ts
@@ -1,0 +1,365 @@
+/**
+ * Bare-host multi-node network harness for the live integration test
+ * (tests/network/run.ts). Boots N real activeledger node processes on the
+ * local machine, following the manual procedure documented in cli.md
+ * (--setup-only per instance, --merge to stitch neighbourhoods together,
+ * then start each node for real) - reused throughout hpe-13/hpe-14's own
+ * live testing, now made reusable and reliable instead of one-off shell
+ * commands.
+ *
+ * Deliberately bare-host, not Docker - no additional requirements for a
+ * developer running this beyond what's already needed to build the repo.
+ */
+
+import { ChildProcess, spawn } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as http from "http";
+
+const LEDGER_ENTRY = path.resolve(
+  __dirname,
+  "../../packages/activeledger/lib/index.js"
+);
+
+export interface NetworkNode {
+  index: number;
+  port: number;
+  storagePort: number;
+  dataDir: string;
+  baseUrl: string;
+  storageUrl: string;
+  child: ChildProcess;
+  logPath: string;
+}
+
+export interface NetworkHarnessOptions {
+  nodeCount?: number;
+  basePort?: number;
+  portSpacing?: number;
+  readyTimeoutMs?: number;
+}
+
+const DEFAULTS: Required<NetworkHarnessOptions> = {
+  nodeCount: 4,
+  // Not the literal default (5260) - see cli.md's --port gotcha, a
+  // non-default port keeps every instance's autostart behaviour identical
+  // and avoids colliding with anything a developer might already have
+  // running locally.
+  basePort: 5510,
+  portSpacing: 10,
+  readyTimeoutMs: 20000,
+};
+
+function runOnce(args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [LEDGER_ENTRY, ...args], {
+      cwd,
+      stdio: "ignore",
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${args.join(" ")} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+/**
+ * `activeledger --stop` does its actual job (killing the tracked
+ * activeledger/activestorage/activecore/activerestore PIDs) but then never
+ * calls process.exit() itself, unlike --backup/--restore - confirmed as a
+ * real, standalone bug (reproduced directly outside this harness, not an
+ * artifact of how this harness spawns it). Don't wait for its own exit;
+ * give it a short window to do its work, then kill it regardless.
+ */
+function runStop(cwd: string): Promise<void> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [LEDGER_ENTRY, "--stop"], {
+      cwd,
+      stdio: "ignore",
+    });
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // already gone
+      }
+      resolve();
+    }, 3000);
+    child.on("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    child.on("error", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+function httpGetJson(url: string, timeoutMs = 2000): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, { timeout: timeoutMs }, (res) => {
+      let body = "";
+      res.on("data", (c) => (body += c));
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(body));
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+    req.on("timeout", () => req.destroy(new Error("timeout")));
+    req.on("error", reject);
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    // Signal 0 doesn't actually send anything - just checks the pid exists
+    // and is signalable by this user.
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Recursively collects every descendant PID of `rootPid` via /proc (Linux
+ * only, matches this environment). Needed because a node forks a whole
+ * worker pool (network/process.js, one per CPU core plus a standby - see
+ * network-internals.md) that survives a direct kill of just the main
+ * process: Node doesn't kill children automatically on a parent's exit,
+ * and these workers aren't tracked in the .PID file the way
+ * activestorage/activecore/activerestore are - confirmed directly (ps aux
+ * still showed a full set of network/process.js instances after --stop
+ * completed and the main process had already exited). This is the same
+ * gap documented in cli.md's --stop section; harmless for a human running
+ * --stop once, but a test harness that boots and tears down repeatedly
+ * needs to actually not leak these.
+ */
+function collectDescendantPids(rootPid: number): number[] {
+  const descendants: number[] = [];
+  const stack = [rootPid];
+  while (stack.length > 0) {
+    const pid = stack.pop()!;
+    try {
+      const childrenPath = `/proc/${pid}/task/${pid}/children`;
+      const raw = fs.readFileSync(childrenPath, "utf8").trim();
+      if (!raw) continue;
+      const children = raw.split(/\s+/).map(Number).filter((n) => !isNaN(n));
+      for (const child of children) {
+        descendants.push(child);
+        stack.push(child);
+      }
+    } catch {
+      // /proc not available, or the process already exited - nothing more
+      // to find down this branch.
+    }
+  }
+  return descendants;
+}
+
+export class NetworkHarness {
+  public nodes: NetworkNode[] = [];
+  private opts: Required<NetworkHarnessOptions>;
+  private rootDir: string;
+
+  constructor(options: NetworkHarnessOptions = {}) {
+    this.opts = { ...DEFAULTS, ...options };
+    this.rootDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "activeledger-network-test-")
+    );
+  }
+
+  /**
+   * Runs --setup-only for every instance, merges their neighbourhoods
+   * together, then starts every node for real and waits until each
+   * reports status:4 (a settled view of its ring neighbours).
+   */
+  public async start(): Promise<NetworkNode[]> {
+    const { nodeCount, basePort, portSpacing } = this.opts;
+
+    const dataDirs: string[] = [];
+    for (let i = 0; i < nodeCount; i++) {
+      const dataDir = path.join(this.rootDir, `instance-${i}`);
+      fs.mkdirSync(dataDir, { recursive: true });
+      dataDirs.push(dataDir);
+    }
+
+    // --setup-only for every instance in parallel - each just writes its
+    // own config.json/.identity, no network involved yet.
+    await Promise.all(
+      dataDirs.map((dataDir, i) =>
+        runOnce(
+          ["--setup-only", "--port", String(basePort + i * portSpacing), "--data-dir", ".ds"],
+          dataDir
+        )
+      )
+    );
+
+    // Stitch every instance's neighbourhood together into one list, written
+    // back into every config.json.
+    await runOnce(
+      dataDirs.flatMap((dataDir) => ["--merge", path.join(dataDir, "config.json")]),
+      this.rootDir
+    );
+
+    // Start every node for real.
+    this.nodes = dataDirs.map((dataDir, i) => {
+      const port = basePort + i * portSpacing;
+      const logPath = path.join(dataDir, "node.log");
+      const logFd = fs.openSync(logPath, "a");
+      const child = spawn(process.execPath, [LEDGER_ENTRY, "--port", String(port)], {
+        cwd: dataDir,
+        stdio: ["ignore", logFd, logFd],
+      });
+      return {
+        index: i,
+        port,
+        storagePort: port - 1,
+        dataDir,
+        baseUrl: `http://127.0.0.1:${port}`,
+        storageUrl: `http://127.0.0.1:${port - 1}`,
+        child,
+        logPath,
+      };
+    });
+
+    await this.waitUntilReady();
+    return this.nodes;
+  }
+
+  private async waitUntilReady(): Promise<void> {
+    const deadline = Date.now() + this.opts.readyTimeoutMs;
+    const pending = new Set(this.nodes.map((n) => n.index));
+
+    while (pending.size > 0) {
+      if (Date.now() > deadline) {
+        throw new Error(
+          `Timed out waiting for nodes to become ready: ${[...pending].join(", ")}`
+        );
+      }
+      for (const node of this.nodes) {
+        if (!pending.has(node.index)) continue;
+        if (node.child.exitCode !== null) {
+          throw new Error(
+            `Node ${node.index} exited early (code ${node.child.exitCode}) - see ${node.logPath}`
+          );
+        }
+        try {
+          const status = await httpGetJson(`${node.baseUrl}/a/status`);
+          if (status.status === 4) {
+            pending.delete(node.index);
+          }
+        } catch {
+          // Not up yet, try again next tick
+        }
+      }
+      if (pending.size > 0) {
+        await sleep(300);
+      }
+    }
+  }
+
+  /**
+   * Stop every node via `activeledger --stop`, not a raw SIGTERM to the
+   * child handle - a node forks a separate storage subprocess
+   * (selfhost.js) that survives a direct kill of just the main process
+   * (its own SIGTERM handler is a bare process.exit(), which doesn't cascade
+   * to children Node didn't fork itself - see cli.md's --stop gotcha).
+   * `--stop` reads each instance's own .PID file (main process +
+   * activestorage, written directly by datastore.ts's storePid() - plus
+   * activecore/activerestore if running) and kills all of them. Also not a
+   * pattern-matched pkill, which repeatedly proved unreliable during
+   * hpe-13/hpe-14's manual testing (command lines don't include any
+   * distinguishing scratch-dir name, so loose patterns miss processes or
+   * catch unrelated ones).
+   */
+  public async stop(): Promise<void> {
+    // Capture the worker pool's PIDs before touching anything - once the
+    // main process exits, its /proc entry (and the parent/child
+    // relationship recorded there) disappears, so this only works if done
+    // first.
+    const workerPids = this.nodes.flatMap((node) =>
+      node.child.pid ? collectDescendantPids(node.child.pid) : []
+    );
+
+    await Promise.all(
+      this.nodes.map(async (node) => {
+        if (node.child.exitCode === null && !node.child.killed) {
+          await runStop(node.dataDir);
+        }
+
+        await new Promise<void>((resolve) => {
+          if (node.child.exitCode !== null || node.child.killed) {
+            resolve();
+            return;
+          }
+          const timer = setTimeout(() => {
+            // --stop didn't take within a reasonable window - force it.
+            try {
+              node.child.kill("SIGKILL");
+            } catch {
+              // already gone
+            }
+          }, 5000);
+          node.child.once("exit", () => {
+            clearTimeout(timer);
+            resolve();
+          });
+        });
+      })
+    );
+
+    // The storage subprocess doesn't share a parent/child relationship
+    // with anything we hold a handle to, so double check nothing with this
+    // run's exact data directory is still alive and clean it up directly
+    // if --stop somehow missed it.
+    for (const node of this.nodes) {
+      try {
+        const pidPath = path.join(node.dataDir, ".PID");
+        const pidData = JSON.parse(fs.readFileSync(pidPath, "utf8"));
+        for (const key of ["activeledger", "activestorage", "activecore", "activerestore"]) {
+          const pid = pidData[key];
+          if (pid && pid !== 0 && isProcessAlive(pid)) {
+            try {
+              process.kill(pid, "SIGKILL");
+            } catch {
+              // already gone
+            }
+          }
+        }
+      } catch {
+        // No .PID file, or already cleaned up - nothing to do.
+      }
+    }
+
+    // Finally, the worker pool captured above - these are never tracked
+    // anywhere on disk, so this PID list captured before teardown started
+    // is the only record of them.
+    for (const pid of workerPids) {
+      if (isProcessAlive(pid)) {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          // already gone
+        }
+      }
+    }
+  }
+
+  public cleanup(): void {
+    fs.rmSync(this.rootDir, { recursive: true, force: true });
+  }
+}

--- a/tests/network/http.ts
+++ b/tests/network/http.ts
@@ -1,0 +1,80 @@
+/**
+ * Small HTTP helpers for the live network test - plain transaction
+ * submission against a node's root, and direct reads/writes against a
+ * node's own storage engine (used by the SPI test to desync one node's
+ * local copy of a stream without going through consensus at all).
+ */
+
+import * as http from "http";
+import { URL } from "url";
+
+export function requestJson(
+  url: string,
+  method: string,
+  body?: unknown,
+  timeoutMs = 20000
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url);
+    const data = body !== undefined ? Buffer.from(JSON.stringify(body)) : undefined;
+    const req = http.request(
+      {
+        hostname: target.hostname,
+        port: target.port,
+        path: target.pathname + target.search,
+        method,
+        timeout: timeoutMs,
+        headers: data
+          ? { "Content-Type": "application/json", "Content-Length": data.length }
+          : undefined,
+      },
+      (res) => {
+        let responseBody = "";
+        res.on("data", (chunk) => (responseBody += chunk));
+        res.on("end", () => {
+          try {
+            const parsed = responseBody ? JSON.parse(responseBody) : {};
+            resolve(parsed);
+          } catch (e) {
+            reject(new Error(`Non-JSON response from ${url}: ${responseBody.slice(0, 200)}`));
+          }
+        });
+      }
+    );
+    req.on("timeout", () => req.destroy(new Error(`Request timed out after ${timeoutMs}ms: ${method} ${url}`)));
+    req.on("error", reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+/** Submits a transaction to a node's root endpoint. */
+export function submit(baseUrl: string, tx: unknown): Promise<any> {
+  return requestJson(baseUrl + "/", "POST", tx);
+}
+
+/** Reads a document directly from a node's own storage engine. */
+export function storageGet(
+  storageUrl: string,
+  streamId: string,
+  database = "activeledger"
+): Promise<any> {
+  return requestJson(`${storageUrl}/${database}/${encodeURIComponent(streamId)}`, "GET");
+}
+
+/**
+ * Writes a document directly to a node's own storage engine, bypassing
+ * consensus/gossip entirely - LevelMe.post()/put() recompute a fresh
+ * revision from whatever's currently stored regardless of the _rev in the
+ * body (new_edits defaults to true), so this is enough to desync a single
+ * node's local copy of a stream from the rest of the network for the SPI
+ * test.
+ */
+export function storagePut(
+  storageUrl: string,
+  streamId: string,
+  doc: unknown,
+  database = "activeledger"
+): Promise<any> {
+  return requestJson(`${storageUrl}/${database}/${encodeURIComponent(streamId)}`, "PUT", doc);
+}

--- a/tests/network/report.ts
+++ b/tests/network/report.ts
@@ -1,0 +1,115 @@
+/**
+ * Live CLI progress + a final summary report for the network integration
+ * test. Plain ANSI escapes, no new dependency - matches how ActiveLogger
+ * already colours its own console output.
+ */
+
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const CYAN = "\x1b[36m";
+const DIM = "\x1b[2m";
+
+interface CategoryStats {
+  category: string;
+  passed: number;
+  failed: number;
+  durationsMs: number[];
+}
+
+export class Report {
+  private categories = new Map<string, CategoryStats>();
+  private startedAt = Date.now();
+  private isTty = process.stdout.isTTY === true;
+
+  public phase(name: string): void {
+    console.log(`\n${BOLD}${CYAN}== ${name} ==${RESET}`);
+  }
+
+  public info(message: string): void {
+    console.log(`  ${DIM}${message}${RESET}`);
+  }
+
+  public ok(message: string): void {
+    console.log(`  ${GREEN}✔${RESET} ${message}`);
+  }
+
+  public fail(message: string): void {
+    console.log(`  ${RED}✖${RESET} ${message}`);
+  }
+
+  public warn(message: string): void {
+    console.log(`  ${YELLOW}!${RESET} ${message}`);
+  }
+
+  /** Live, overwriting progress line - falls back to periodic plain lines when not a TTY (e.g. piped/CI output). */
+  public progress(current: number, total: number, label: string): void {
+    const line = `  [${current}/${total}] ${label}`;
+    if (this.isTty) {
+      process.stdout.write(`\r\x1b[K${line}`);
+    } else if (current === total || current % 10 === 0) {
+      console.log(line);
+    }
+  }
+
+  public endProgress(): void {
+    if (this.isTty) process.stdout.write("\n");
+  }
+
+  public record(category: string, passed: boolean, durationMs: number): void {
+    let stats = this.categories.get(category);
+    if (!stats) {
+      stats = { category, passed: 0, failed: 0, durationsMs: [] };
+      this.categories.set(category, stats);
+    }
+    if (passed) stats.passed++;
+    else stats.failed++;
+    stats.durationsMs.push(durationMs);
+  }
+
+  public summary(): boolean {
+    const totalWallMs = Date.now() - this.startedAt;
+    console.log(`\n${BOLD}${CYAN}== Summary ==${RESET}`);
+
+    let allPassed = true;
+    const rows: string[][] = [
+      ["Category", "Passed", "Failed", "Avg ms", "Max ms"],
+    ];
+    // Array.from(), not for...of, over the Map's iterator - this project's
+    // root tsconfig has no explicit `target` (defaults low) combined with
+    // `lib: ["es2018"]` and no downlevelIteration, under which a for...of
+    // loop over a true iterable like Map.values() silently iterates zero
+    // times instead of erroring - a real, confirmed pitfall (reproduced
+    // directly), not a hypothetical.
+    for (const stats of Array.from(this.categories.values())) {
+      const total = stats.passed + stats.failed;
+      const avg = Math.round(stats.durationsMs.reduce((a, b) => a + b, 0) / total);
+      const max = Math.max(...stats.durationsMs);
+      if (stats.failed > 0) allPassed = false;
+      rows.push([
+        stats.category,
+        String(stats.passed),
+        String(stats.failed),
+        String(avg),
+        String(max),
+      ]);
+    }
+
+    const widths = rows[0].map((_, col) => Math.max(...rows.map((row) => row[col].length)));
+    for (let i = 0; i < rows.length; i++) {
+      const line = rows[i].map((cell, col) => cell.padEnd(widths[col])).join("  ");
+      const color = i === 0 ? BOLD : rows[i][2] !== "0" ? RED : GREEN;
+      console.log(`  ${color}${line}${RESET}`);
+    }
+
+    console.log(`\n  Total wall time: ${(totalWallMs / 1000).toFixed(1)}s`);
+    console.log(
+      allPassed
+        ? `\n${BOLD}${GREEN}ALL CHECKS PASSED${RESET}\n`
+        : `\n${BOLD}${RED}SOME CHECKS FAILED${RESET}\n`
+    );
+    return allPassed;
+  }
+}

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -188,6 +188,8 @@ async function main(): Promise<boolean> {
       report.fail(`Event only observed on ${seenOn.size}/${nodes.length} nodes: [${[...seenOn].join(", ")}]`);
     }
 
+    await runNegativeTests(report, nodes, returnerId);
+
     await runSpiTests(report, nodes, identity, NAMESPACE, returnerId);
 
     return report.summary();
@@ -196,6 +198,74 @@ async function main(): Promise<boolean> {
     await harness.stop();
     harness.cleanup();
     report.ok("Stopped and cleaned up");
+  }
+}
+
+/**
+ * Negative-path coverage: a transaction that's genuinely supposed to be
+ * rejected. Everything else in this suite asserts success - these assert
+ * the opposite, and check the actual error surfaced, not just that
+ * something failed.
+ */
+async function runNegativeTests(report: Report, nodes: NetworkNode[], returnerId: string): Promise<void> {
+  report.phase("Negative path: deliberately bad signature");
+  {
+    const badIdentity = await onboard(nodes[0].baseUrl);
+    const namespace = "negtest-badsig";
+    await registerNamespace(nodes[0].baseUrl, badIdentity, namespace);
+    const txBody = {
+      $namespace: "default",
+      $contract: "namespace",
+      $i: { [badIdentity.streamId]: { namespace: namespace + "-again" } },
+    };
+    const badTx = { $tx: txBody, $sigs: { [badIdentity.streamId]: "not-a-real-signature" } };
+    const { result, ms } = await timed(() => submit(nodes[0].baseUrl, badTx));
+    const rejected = result.$summary?.commit === 0 && (result.$summary?.errors || []).some((e: string) => e.includes("Signature Incorrect"));
+    report.record("negative-bad-signature", rejected, ms);
+    rejected
+      ? report.ok(`Bad signature correctly rejected (${ms}ms)`)
+      : report.fail(`Expected a rejected "Signature Incorrect" result, got: ${JSON.stringify(result.$summary)}`);
+  }
+
+  report.phase("Negative path: locked contract stream");
+  {
+    // Own fresh identity/namespace, same reasoning as every other phase in
+    // this suite - avoids any cross-phase stream contention.
+    const lockIdentity = await onboard(nodes[1].baseUrl);
+    const namespace = "negtest-lock";
+    await registerNamespace(nodes[1].baseUrl, lockIdentity, namespace);
+    // One normal run first, to establish the stream's :stream meta
+    // document - it doesn't exist yet straight after onboarding.
+    await runContract(nodes[1].baseUrl, lockIdentity, namespace, returnerId, { message: "establish" });
+
+    const meta = await storageGet(nodes[1].storageUrl, `${lockIdentity.streamId}:stream`);
+    await storagePut(nodes[1].storageUrl, `${lockIdentity.streamId}:stream`, {
+      ...meta,
+      // A lock naming some other contract - not returnerId - so any
+      // transaction naming returnerId should be rejected.
+      contractlock: ["some-other-contract-id-not-returner"],
+    });
+
+    const { result, ms } = await timed(() =>
+      runContract(nodes[1].baseUrl, lockIdentity, namespace, returnerId, { message: "should-be-blocked" })
+    );
+    const rejected = result.$summary?.commit === 0 && (result.$summary?.errors || []).length > 0;
+    report.record("negative-locked-contract", rejected, ms);
+    if (rejected) {
+      // Real, confirmed bug found while writing this test (not the test's
+      // own fault): permissionsChecker.ts's buildPromises() throws
+      // { code: 1700, reason: "Stream contract locked" } for exactly this
+      // case, but the surrounding try/catch unconditionally overwrites
+      // error.code/error.reason to 950 "Stream(s) not found" before
+      // rethrowing - so the specific, documented 1700 never actually
+      // reaches a client, regardless of what tripped the lock check. This
+      // asserts the transaction is rejected at all (the actual guarantee
+      // that currently holds), not that it's rejected with 1700 (which it
+      // never is, even though the lock genuinely works).
+      report.ok(`Locked contract correctly rejected (as 950 "Stream(s) not found", not the documented 1700 - see comment) (${ms}ms)`);
+    } else {
+      report.fail(`Expected a rejected result, got: ${JSON.stringify(result.$summary)}`);
+    }
   }
 }
 

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -1,0 +1,290 @@
+/**
+ * Live 4-node network integration test. Boots a real bare-host network,
+ * runs 100+ real transactions spread across all nodes as origin, verifies
+ * SSE event delivery, verifies returnToRemote(), and verifies SPI recovery
+ * both when the desynced node is the transaction's origin and when it
+ * isn't. Not a Mocha suite - a standalone script with live progress and a
+ * final summary, run via `npm run test:network`.
+ */
+
+import * as path from "path";
+import { NetworkHarness, NetworkNode } from "./harness";
+import { submit, storageGet, storagePut } from "./http";
+import { SSEClient } from "./sse";
+import { Report } from "./report";
+import {
+  Identity,
+  onboard,
+  registerNamespace,
+  deployContract,
+  runContract,
+} from "./actions";
+import { ActiveCrypto } from "../../packages/crypto/src";
+
+const TRANSACTION_COUNT = 120;
+const CONCURRENCY = 8;
+const NAMESPACE = "networktest";
+
+async function pool<T>(items: T[], concurrency: number, worker: (item: T, index: number) => Promise<void>): Promise<void> {
+  let cursor = 0;
+  async function runNext(): Promise<void> {
+    while (cursor < items.length) {
+      const index = cursor++;
+      await worker(items[index], index);
+    }
+  }
+  await Promise.all(Array.from({ length: concurrency }, runNext));
+}
+
+async function timed<T>(fn: () => Promise<T>): Promise<{ result: T; ms: number }> {
+  const start = Date.now();
+  const result = await fn();
+  return { result, ms: Date.now() - start };
+}
+
+async function main(): Promise<boolean> {
+  const report = new Report();
+  const harness = new NetworkHarness({ nodeCount: 4 });
+
+  report.phase("Booting 4-node network");
+  const nodes = await harness.start();
+  report.ok(`${nodes.length} nodes ready: ${nodes.map((n) => n.port).join(", ")}`);
+
+  try {
+    report.phase("Onboarding an identity and registering a namespace");
+    const identity = await onboard(nodes[0].baseUrl);
+    report.ok(`Onboarded ${identity.streamId}`);
+    const nsResult = await registerNamespace(nodes[0].baseUrl, identity, NAMESPACE);
+    if (nsResult.$summary?.errors) {
+      throw new Error(`Namespace registration failed: ${JSON.stringify(nsResult)}`);
+    }
+    report.ok(`Namespace "${NAMESPACE}" registered`);
+
+    report.phase("Deploying custom contracts");
+    const returnerId = await deployContract(
+      nodes[0].baseUrl,
+      identity,
+      NAMESPACE,
+      "returner",
+      path.join(__dirname, "contracts/returner-contract.ts")
+    );
+    report.ok(`returner-contract deployed: ${returnerId}`);
+    const emitterId = await deployContract(
+      nodes[0].baseUrl,
+      identity,
+      NAMESPACE,
+      "emitter",
+      path.join(__dirname, "contracts/emitter-contract.ts")
+    );
+    report.ok(`emitter-contract deployed: ${emitterId}`);
+
+    report.phase(`Running ${TRANSACTION_COUNT} transactions across all ${nodes.length} nodes`);
+    let completed = 0;
+    const indices = Array.from({ length: TRANSACTION_COUNT }, (_, i) => i);
+    await pool(indices, CONCURRENCY, async (i) => {
+      const node = nodes[i % nodes.length];
+      // Every 5th iteration onboards its own fresh, throwaway identity and
+      // immediately runs the returner contract against it (exercises
+      // custom-contract execution as part of the load); the rest are
+      // fresh, real self-signed onboarding transactions - the same
+      // "direct-onboard" repro case used throughout hpe-12/hpe-13/hpe-14's
+      // own live testing. Deliberately never touches the shared `identity`
+      // concurrently here - hammering one stream with many in-flight
+      // transactions at once is a real, separate SPI "hot stream" scenario
+      // (see spi.md), not representative load, and belongs in the
+      // dedicated SPI phase below where it's controlled and expected.
+      const isContractRun = i % 5 === 0;
+      const { result, ms } = await timed(async () => {
+        const kp = new ActiveCrypto.KeyPair("rsa");
+        const keys = kp.generate();
+        const txBody = {
+          $namespace: "default",
+          $contract: "onboard",
+          $i: { identity: { type: "rsa", publicKey: keys.pub.pkcs8pem } },
+          $o: {},
+        };
+        const onboardResult = await submit(node.baseUrl, {
+          $tx: txBody,
+          $selfsign: true,
+          $sigs: { identity: kp.sign(txBody) },
+        });
+        if (!isContractRun) return onboardResult;
+
+        const freshStreamId = onboardResult.$streams?.new?.[0]?.id;
+        if (!freshStreamId) return onboardResult; // onboarding itself failed - report that as the result
+        return runContract(node.baseUrl, { streamId: freshStreamId, keyPair: kp }, NAMESPACE, returnerId, {
+          message: `load-${i}`,
+        });
+      });
+
+      const passed = !result.$summary?.errors && result.$summary?.commit >= 1;
+      report.record(isContractRun ? "contract-run" : "onboard", passed, ms);
+      completed++;
+      report.progress(completed, TRANSACTION_COUNT, `node ${node.index} (:${node.port})`);
+    });
+    report.endProgress();
+
+    report.phase("Verifying returnToRemote()");
+    // Own fresh identity, not the shared one - reusing the same stream
+    // back-to-back from a different origin node than the previous phase
+    // used is exactly the "hot stream" SPI-churn scenario the load phase
+    // already learned to avoid; each independent verification gets its own
+    // clean stream so it isn't racing convergence from an unrelated check.
+    const returnerCheckIdentity = await onboard(nodes[1].baseUrl);
+    const expectedMessage = `returnToRemote-check-${Date.now()}`;
+    const { result: returnerResult, ms: returnerMs } = await timed(() =>
+      runContract(nodes[1].baseUrl, returnerCheckIdentity, NAMESPACE, returnerId, {
+        message: expectedMessage,
+      })
+    );
+    const echoed = returnerResult.$responses?.[0]?.echoedMessage;
+    const returnerOk = echoed === expectedMessage;
+    report.record("returnToRemote", returnerOk, returnerMs);
+    if (returnerOk) {
+      report.ok(`$responses carried back the expected message via node ${nodes[1].port}`);
+    } else {
+      report.fail(`Expected "${expectedMessage}", got ${JSON.stringify(returnerResult.$responses)}`);
+    }
+
+    report.phase("Verifying SSE event delivery across all nodes");
+    // Own fresh identity too, same reasoning as the returnToRemote check
+    // above.
+    const sseCheckIdentity = await onboard(nodes[2].baseUrl);
+    const correlationId = `sse-check-${Date.now()}`;
+    const seenOn = new Set<number>();
+    const clients = nodes.map((n) => new SSEClient(`${n.storageUrl}/activeledgerevents/events`));
+    await Promise.all(clients.map((c) => c.connect()));
+    clients.forEach((client, i) => {
+      client.onEvent((event) => {
+        try {
+          const parsed = JSON.parse(event.data);
+          if (parsed?.data?.correlationId === correlationId) {
+            seenOn.add(i);
+          }
+        } catch {
+          // ignore malformed/heartbeat frames
+        }
+      });
+    });
+
+    const { ms: emitterMs } = await timed(() =>
+      runContract(nodes[2].baseUrl, sseCheckIdentity, NAMESPACE, emitterId, {
+        message: "sse-check",
+        correlationId,
+      })
+    );
+
+    const sseDeadline = Date.now() + 8000;
+    while (seenOn.size < nodes.length && Date.now() < sseDeadline) {
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    clients.forEach((c) => c.close());
+
+    const sseOk = seenOn.size === nodes.length;
+    report.record("sse-delivery", sseOk, emitterMs);
+    if (sseOk) {
+      report.ok(`Event observed on all ${nodes.length} nodes' SSE feeds`);
+    } else {
+      report.fail(`Event only observed on ${seenOn.size}/${nodes.length} nodes: [${[...seenOn].join(", ")}]`);
+    }
+
+    await runSpiTests(report, nodes, identity, NAMESPACE, returnerId);
+
+    return report.summary();
+  } finally {
+    report.phase("Tearing down network");
+    await harness.stop();
+    harness.cleanup();
+    report.ok("Stopped and cleaned up");
+  }
+}
+
+/**
+ * Directly mutates the shared identity's own stream on one node's storage
+ * engine, bypassing consensus entirely (LevelMe.post()/put() recompute a
+ * fresh revision from whatever's currently stored regardless of the _rev
+ * given - see http.ts's storagePut()), then runs a real transaction
+ * touching that same stream - once with the desynced node as origin, once
+ * with a different node as origin - to exercise both SPI repair paths
+ * described in spi.md/architecture.md.
+ */
+async function runSpiTests(
+  report: Report,
+  nodes: NetworkNode[],
+  identity: Identity,
+  namespace: string,
+  returnerId: string
+): Promise<void> {
+  const desyncTarget = nodes[0];
+  const otherNodes = nodes.filter((n) => n.index !== desyncTarget.index);
+
+  async function desyncStream(): Promise<void> {
+    const current = await storageGet(desyncTarget.storageUrl, identity.streamId);
+    await storagePut(desyncTarget.storageUrl, identity.streamId, {
+      ...current,
+      spiTestMarker: `desync-${Date.now()}`,
+    });
+  }
+
+  // Reruns the (idempotent - just overwrites its own output field each
+  // time) returner contract against the identity's own stream, purely to
+  // exercise the normal revision-check/SPI path - not touchIdentity()'s
+  // earlier namespace-registration approach, which isn't idempotent
+  // (registering the same namespace twice legitimately fails with
+  // "Namespace Reserved").
+  //
+  // Retries once on an SPI-flavoured error before giving up - this is the
+  // documented, expected client behaviour (spi.md: "there's no separate
+  // handling to write for it: treat it like any other transient failure
+  // and retry the transaction yourself"), not a workaround. A single
+  // synchronous request/response can legitimately land mid-repair (the
+  // response.$summary reflects whichever nodes had already replied by the
+  // time it was formed, not the network's final converged state - see
+  // transactions.md), so asserting success on the very first attempt is a
+  // stricter bar than the mechanism itself claims to guarantee.
+  async function touchStream(baseUrl: string): Promise<any> {
+    const first = await runContract(baseUrl, identity, namespace, returnerId, { message: "spi-touch" });
+    if (!first.$summary?.errors) return first;
+    await new Promise((r) => setTimeout(r, 500));
+    return runContract(baseUrl, identity, namespace, returnerId, { message: "spi-touch-retry" });
+  }
+
+  report.phase(`SPI: desynced node (${desyncTarget.port}) as origin`);
+  await desyncStream();
+  {
+    const { result, ms } = await timed(() => touchStream(desyncTarget.baseUrl));
+    const ok = !result.$summary?.errors;
+    report.record("spi-origin", ok, ms);
+    ok
+      ? report.ok(`Transaction succeeded with the desynced node as origin (${ms}ms)`)
+      : report.fail(`Failed: ${JSON.stringify(result.$summary)}`);
+  }
+
+  // Let the network fully settle/converge after the previous repair cycle
+  // before injecting a fresh desync - SPI convergence is explicitly
+  // asynchronous/eventual (architecture.md: "There is no single moment
+  // when 'the network' agrees"), so starting a second fault injection
+  // immediately can catch nodes mid-transition and produce real,
+  // multi-way revision disagreement that's an artifact of the test's own
+  // pacing, not the mechanism being tested.
+  await new Promise((r) => setTimeout(r, 1500));
+
+  report.phase(`SPI: desynced node (${desyncTarget.port}) as a non-origin peer`);
+  await desyncStream();
+  {
+    const originNode = otherNodes[0];
+    const { result, ms } = await timed(() => touchStream(originNode.baseUrl));
+    const ok = !result.$summary?.errors;
+    report.record("spi-non-origin", ok, ms);
+    ok
+      ? report.ok(`Transaction succeeded via node ${originNode.port} as origin, desynced peer included (${ms}ms)`)
+      : report.fail(`Failed: ${JSON.stringify(result.$summary)}`);
+  }
+}
+
+main()
+  .then((allPassed) => process.exit(allPassed ? 0 : 1))
+  .catch((error) => {
+    console.error("Network test crashed:", error);
+    process.exit(1);
+  });

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -238,33 +238,60 @@ async function runNegativeTests(report: Report, nodes: NetworkNode[], returnerId
     // document - it doesn't exist yet straight after onboarding.
     await runContract(nodes[1].baseUrl, lockIdentity, namespace, returnerId, { message: "establish" });
 
-    const meta = await storageGet(nodes[1].storageUrl, `${lockIdentity.streamId}:stream`);
-    await storagePut(nodes[1].storageUrl, `${lockIdentity.streamId}:stream`, {
-      ...meta,
-      // A lock naming some other contract - not returnerId - so any
-      // transaction naming returnerId should be rejected.
-      contractlock: ["some-other-contract-id-not-returner"],
-    });
+    // Mutate the meta doc on every node, not just the origin - a real
+    // contractlock, set via normal consensus, would be visible identically
+    // everywhere. Mutating only one node (the technique the SPI tests
+    // deliberately use, since asymmetry is the whole point there) instead
+    // creates a mixed-consensus scenario here: 3 nodes still see the
+    // unlocked doc and vote to allow it, so with consensus.reached's
+    // default 60% threshold the network can commit anyway despite the
+    // mutated node's own correct rejection - found via a real, reproduced
+    // commit:1-alongside-the-error result before this fix.
+    for (const node of nodes) {
+      const meta = await storageGet(node.storageUrl, `${lockIdentity.streamId}:stream`);
+      await storagePut(node.storageUrl, `${lockIdentity.streamId}:stream`, {
+        ...meta,
+        // A lock naming some other contract - not returnerId - so any
+        // transaction naming returnerId should be rejected.
+        contractlock: ["some-other-contract-id-not-returner"],
+      });
+    }
 
-    const { result, ms } = await timed(() =>
+    // permissionsChecker.ts's buildPromises() used to mask this as a
+    // generic 950 "Stream(s) not found" regardless of what actually
+    // tripped - found while first writing this test, now fixed (protocol
+    // package) so the real, specific "Stream contract locked" reason
+    // actually reaches the client.
+    //
+    // One retry on a specific, separate, pre-existing transient: under
+    // load, a transaction's contract-file resolution (setupLocation() in
+    // process.ts - runs before permission checking even starts) can
+    // itself intermittently fail with an unrelated "Contract not found",
+    // most likely a worker-process-pool contract-path-cache race. This
+    // isn't caused by the fix above and isn't specific to locked
+    // streams - it was always possible, just previously indistinguishable
+    // from every other failure once everything got masked to the same
+    // generic 950. Found while building this test; flagged, not chased
+    // further - touches worker-pool/contract-caching internals well
+    // outside what was asked for here. Retrying once keeps this test
+    // meaningful (still fails loudly if the lock genuinely isn't
+    // enforced) without being flaky on an unrelated, pre-existing race.
+    let { result, ms } = await timed(() =>
       runContract(nodes[1].baseUrl, lockIdentity, namespace, returnerId, { message: "should-be-blocked" })
     );
-    const rejected = result.$summary?.commit === 0 && (result.$summary?.errors || []).length > 0;
+    if ((result.$summary?.errors || []).some((e: string) => e.includes("Contract not found"))) {
+      ({ result, ms } = await timed(() =>
+        runContract(nodes[1].baseUrl, lockIdentity, namespace, returnerId, { message: "should-be-blocked-retry" })
+      ));
+    }
+    const rejected =
+      result.$summary?.commit === 0 &&
+      (result.$summary?.errors || []).some((e: string) => e.includes("Stream contract locked"));
     report.record("negative-locked-contract", rejected, ms);
     if (rejected) {
-      // Real, confirmed bug found while writing this test (not the test's
-      // own fault): permissionsChecker.ts's buildPromises() throws
-      // { code: 1700, reason: "Stream contract locked" } for exactly this
-      // case, but the surrounding try/catch unconditionally overwrites
-      // error.code/error.reason to 950 "Stream(s) not found" before
-      // rethrowing - so the specific, documented 1700 never actually
-      // reaches a client, regardless of what tripped the lock check. This
-      // asserts the transaction is rejected at all (the actual guarantee
-      // that currently holds), not that it's rejected with 1700 (which it
-      // never is, even though the lock genuinely works).
-      report.ok(`Locked contract correctly rejected (as 950 "Stream(s) not found", not the documented 1700 - see comment) (${ms}ms)`);
+      report.ok(`Locked contract correctly rejected with "Stream contract locked" (${ms}ms)`);
     } else {
-      report.fail(`Expected a rejected result, got: ${JSON.stringify(result.$summary)}`);
+      report.fail(`Expected a rejected result with "Stream contract locked", got: ${JSON.stringify(result.$summary)}`);
     }
   }
 }

--- a/tests/network/sse.ts
+++ b/tests/network/sse.ts
@@ -1,0 +1,92 @@
+/**
+ * Minimal hand-rolled SSE client - deliberately not a new npm dependency,
+ * matching how SSE was verified manually throughout the hpe-13/hpe-14
+ * sessions (plain `http` + a small line parser). Connects to a node's
+ * self-hosted storage engine's `/<database>/events` endpoint (see
+ * storage.md on hpe-13 for the real, verified mechanism this targets).
+ */
+
+import * as http from "http";
+import { URL } from "url";
+
+export interface SSEEvent {
+  id?: string;
+  data: string;
+}
+
+export class SSEClient {
+  private req?: http.ClientRequest;
+  private buffer = "";
+  private closed = false;
+  private onEventHandlers: ((event: SSEEvent) => void)[] = [];
+
+  constructor(private url: string) {}
+
+  public onEvent(handler: (event: SSEEvent) => void): void {
+    this.onEventHandlers.push(handler);
+  }
+
+  /** Resolves once the connection is open (headers received). */
+  public connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const target = new URL(this.url);
+      const req = http.request(
+        {
+          hostname: target.hostname,
+          port: target.port,
+          path: target.pathname + target.search,
+          method: "GET",
+          headers: { Accept: "text/event-stream" },
+        },
+        (res) => {
+          if (res.statusCode !== 200) {
+            reject(new Error(`SSE connect failed: ${res.statusCode} for ${this.url}`));
+            return;
+          }
+          res.on("data", (chunk: Buffer) => this.handleChunk(chunk.toString("utf8")));
+          res.on("error", (e) => {
+            if (!this.closed) reject(e);
+          });
+          resolve();
+        }
+      );
+      req.on("error", (e) => {
+        if (!this.closed) reject(e);
+      });
+      req.end();
+      this.req = req;
+    });
+  }
+
+  private handleChunk(chunk: string): void {
+    this.buffer += chunk;
+    let boundary: number;
+    while ((boundary = this.buffer.indexOf("\n\n")) !== -1) {
+      const rawEvent = this.buffer.slice(0, boundary);
+      this.buffer = this.buffer.slice(boundary + 2);
+      this.parseEvent(rawEvent);
+    }
+  }
+
+  private parseEvent(raw: string): void {
+    let id: string | undefined;
+    const dataLines: string[] = [];
+    for (const line of raw.split("\n")) {
+      if (line.startsWith("id:")) {
+        id = line.slice(3).trim();
+      } else if (line.startsWith("data:")) {
+        dataLines.push(line.slice(5).trim());
+      }
+      // ":\n\n" heartbeat comments and "event: message" lines are ignored -
+      // we don't need to distinguish event types for this test.
+    }
+    if (dataLines.length === 0) return; // heartbeat, not a real event
+    const event: SSEEvent = { id, data: dataLines.join("\n") };
+    this.onEventHandlers.forEach((handler) => handler(event));
+  }
+
+  public close(): void {
+    this.closed = true;
+    this.req?.destroy();
+  }
+}

--- a/tests/process.test.ts
+++ b/tests/process.test.ts
@@ -11,10 +11,12 @@ describe("Process (Activeprotocol)", () => {
 
   it("should create process", () => {
 
-    // Make temporay vmscript.js
-    fs.writeFileSync("./packages/protocol/src/protocol/vmscript.js","{}");
+    // Make temporary vmscript.js - guaranteed cleanup even if construction throws
+    const vmscriptPath = "./packages/protocol/src/protocol/vmscript.js";
+    fs.writeFileSync(vmscriptPath, "{}");
 
-    process = new Process(
+    try {
+      process = new Process(
       {
         $nodes: {
           self: {}
@@ -53,10 +55,11 @@ describe("Process (Activeprotocol)", () => {
       {} as any,
       {} as any,
       new ActiveCrypto.Secured({} as IActiveDSConnect, [], {}) as any // Fix private type
-    );
-
-    // Remove temporay vmscript.js
-    fs.unlinkSync("./packages/protocol/src/protocol/vmscript.js");
+      );
+    } finally {
+      // Remove temporary vmscript.js - runs even if the constructor above threw
+      fs.unlinkSync(vmscriptPath);
+    }
 
     expect(process).to.be.an("object");
   });

--- a/tests/restore-helper.test.ts
+++ b/tests/restore-helper.test.ts
@@ -1,0 +1,79 @@
+import { Helper } from "../packages/restore/src/modules/helper/helper";
+import { Provider } from "../packages/restore/src/modules/provider/provider";
+import { expect } from "chai";
+import "mocha";
+
+describe("Restore Helper - replayEvents (Activerestore)", () => {
+  let posted: any[];
+
+  beforeEach(() => {
+    posted = [];
+    (Provider as any).eventDatabase = {
+      post: async (doc: any) => {
+        posted.push(doc);
+        return doc;
+      },
+    };
+  });
+
+  it("should replay every event attached to a restored umid document", async () => {
+    const umidDoc = {
+      _id: "abc123:umid",
+      umid: { $umid: "abc123" },
+      events: [
+        { _id: "event:1,abc123", name: "one", data: {} },
+        { _id: "event:2,abc123", name: "two", data: {} },
+      ],
+    };
+
+    await Helper.replayEvents(umidDoc);
+
+    expect(posted).to.have.length(2);
+    expect(posted[0]._id).to.equal("event:2,abc123");
+    expect(posted[1]._id).to.equal("event:1,abc123");
+  });
+
+  it("should do nothing when the umid document has no events", async () => {
+    await Helper.replayEvents({ _id: "abc123:umid", umid: { $umid: "abc123" } });
+    expect(posted).to.have.length(0);
+  });
+
+  it("should do nothing when events is not an array", async () => {
+    await Helper.replayEvents({
+      _id: "abc123:umid",
+      umid: { $umid: "abc123" },
+      events: "not-an-array",
+    });
+    expect(posted).to.have.length(0);
+  });
+
+  it("should not throw when an individual event fails to post, and should continue replaying the rest", async () => {
+    (Provider as any).eventDatabase = {
+      post: async (doc: any) => {
+        posted.push(doc);
+        if (doc._id === "event:2,abc123") {
+          throw new Error("simulated write failure");
+        }
+        return doc;
+      },
+    };
+
+    const umidDoc = {
+      _id: "abc123:umid",
+      umid: { $umid: "abc123" },
+      events: [
+        { _id: "event:1,abc123", name: "one", data: {} },
+        { _id: "event:2,abc123", name: "two", data: {} },
+      ],
+    };
+
+    await Helper.replayEvents(umidDoc);
+
+    expect(posted).to.have.length(2);
+  });
+
+  it("should do nothing when the umid document itself is undefined", async () => {
+    await Helper.replayEvents(undefined);
+    expect(posted).to.have.length(0);
+  });
+});

--- a/tests/shared.test.ts
+++ b/tests/shared.test.ts
@@ -1,0 +1,98 @@
+import { Shared } from "../packages/protocol/src/protocol/shared";
+import { ActiveCrypto } from "../packages/crypto/src";
+// shared.ts imports this via the "@activeledger/activeoptions" alias,
+// which only resolves from *within* a package's own node_modules (each
+// package gets its own local symlink - e.g.
+// packages/protocol/node_modules/@activeledger/activeoptions ->
+// packages/options); there's no such symlink at the repo root where this
+// test file lives, so the alias itself doesn't resolve here. Importing the
+// exact same resolved file directly (packages/options/lib/index.js, the
+// built output the alias points at) keeps this the same module instance -
+// and therefore the same static ActiveCacheManager.caches registry -
+// without needing the alias to resolve.
+import { ActiveCacheManager } from "../packages/options/lib";
+import { expect } from "chai";
+import "mocha";
+
+// Regression coverage for the hpe-14 fix (64d6f0f) that made the hpe-12
+// KeyPair.verify() parsed-key cache actually reachable. Shared.signatureCheck()
+// used to construct a fresh KeyPair on every call, so that cache never
+// engaged; this now reuses a cached KeyPair instance per (type, publicKey).
+describe("Shared.signatureCheck() - hpe-14 regression (64d6f0f)", () => {
+  it("validates a correct signature against the matching public key", () => {
+    const txBody = { $namespace: "default", $contract: "onboard", hello: "world" };
+    const shared = new Shared(false, { $tx: txBody } as any, {} as any, {} as any);
+
+    const kp = new ActiveCrypto.KeyPair("rsa");
+    const keys = kp.generate();
+    const sig = kp.sign(txBody);
+
+    expect(shared.signatureCheck(keys.pub.pkcs8pem, sig, "rsa")).to.equal(true);
+  });
+
+  it("rejects a signature checked against the wrong public key", () => {
+    const txBody = { $namespace: "default", $contract: "onboard", hello: "world" };
+    const shared = new Shared(false, { $tx: txBody } as any, {} as any, {} as any);
+
+    const kpA = new ActiveCrypto.KeyPair("rsa");
+    const keysA = kpA.generate();
+    const sigA = kpA.sign(txBody);
+
+    const kpB = new ActiveCrypto.KeyPair("rsa");
+    const keysB = kpB.generate();
+
+    expect(shared.signatureCheck(keysB.pub.pkcs8pem, sigA, "rsa")).to.equal(false);
+  });
+
+  it("rejects a tampered signature", () => {
+    const txBody = { $namespace: "default", $contract: "onboard", hello: "world" };
+    const shared = new Shared(false, { $tx: txBody } as any, {} as any, {} as any);
+
+    const kp = new ActiveCrypto.KeyPair("rsa");
+    const keys = kp.generate();
+    const sig = kp.sign(txBody);
+    const tampered = sig.slice(0, -4) + (sig.slice(-4) === "abcd" ? "dcba" : "abcd");
+
+    expect(shared.signatureCheck(keys.pub.pkcs8pem, tampered, "rsa")).to.equal(false);
+  });
+
+  it("still validates correctly across many repeated calls with the same key (cache reuse)", () => {
+    const txBody = { $namespace: "default", $contract: "onboard", hello: "world" };
+    const shared = new Shared(false, { $tx: txBody } as any, {} as any, {} as any);
+
+    const kp = new ActiveCrypto.KeyPair("rsa");
+    const keys = kp.generate();
+    const sig = kp.sign(txBody);
+
+    for (let i = 0; i < 20; i++) {
+      expect(shared.signatureCheck(keys.pub.pkcs8pem, sig, "rsa")).to.equal(true);
+    }
+  });
+
+  it("caches by the raw key material (type + public key), not by any caller-supplied identity", () => {
+    // The whole point of this cache: signatureCheck() never receives a
+    // streamId/identity at all, only (publicKey, signature, type) - see
+    // permissionsChecker.ts's call sites. Two distinct keys used against
+    // the same Shared instance must produce two distinct, independently
+    // correct cache entries, never conflated.
+    const txBody = { $namespace: "default", $contract: "onboard", hello: "world" };
+    const shared = new Shared(false, { $tx: txBody } as any, {} as any, {} as any);
+
+    const kpA = new ActiveCrypto.KeyPair("rsa");
+    const keysA = kpA.generate();
+    const sigA = kpA.sign(txBody);
+
+    const kpB = new ActiveCrypto.KeyPair("rsa");
+    const keysB = kpB.generate();
+    const sigB = kpB.sign(txBody);
+
+    expect(shared.signatureCheck(keysA.pub.pkcs8pem, sigA, "rsa")).to.equal(true);
+    expect(shared.signatureCheck(keysB.pub.pkcs8pem, sigB, "rsa")).to.equal(true);
+    // Cross-checking after both are cached still correctly fails.
+    expect(shared.signatureCheck(keysA.pub.pkcs8pem, sigB, "rsa")).to.equal(false);
+    expect(shared.signatureCheck(keysB.pub.pkcs8pem, sigA, "rsa")).to.equal(false);
+
+    const cache = ActiveCacheManager.fetch("verifyKeys", 30000);
+    expect(cache.size()).to.be.at.least(2);
+  });
+});

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -1,0 +1,148 @@
+import { LevelMe } from "../packages/storage/src/levelme";
+import { expect } from "chai";
+import "mocha";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+// Regression coverage for three real bugs found and fixed on hpe-14, none of
+// which were previously guarded by anything in this suite - each was only
+// caught by one-off manual verification scripts during that session. See
+// commits 29f6b17, ac05364, e81cd7c.
+describe("LevelMe write path (Activestorage) - hpe-14 regressions", () => {
+  let tmpDir: string;
+  let db: LevelMe;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "activeledger-storage-test-"));
+    db = new LevelMe(tmpDir + path.sep, "activeledger", "level");
+    await db.open();
+  });
+
+  afterEach(async () => {
+    await db.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("getMany() cache-hit / cache-miss consistency (29f6b17)", () => {
+    it("returns identical data whether a doc is freshly fetched or already cached", async () => {
+      await db.bulkDocs(
+        [{ _id: "streamA", name: "alpha", counter: 1 }],
+        { new_edits: true }
+      );
+
+      const [miss] = await db.getMany(["streamA"]);
+      const [hit] = await db.getMany(["streamA"]);
+
+      expect(miss.name).to.equal("alpha");
+      expect(hit.name).to.equal("alpha");
+      expect(hit).to.equal(miss); // same reference - the two paths are now consistent
+    });
+
+    it("filters out a genuinely missing key instead of crashing the whole batch", async () => {
+      await db.bulkDocs(
+        [{ _id: "streamA", name: "alpha", counter: 1 }],
+        { new_edits: true }
+      );
+
+      // streamA:stream deliberately doesn't exist - an optional companion doc
+      const result = await db.getMany(["streamA", "streamA:stream"]);
+      expect(result).to.have.length(1);
+      expect(result[0].name).to.equal("alpha");
+    });
+  });
+
+  describe("bulkDocs() change-event shape and error signalling (ac05364)", () => {
+    it("emits one flat object per document, not an array", async () => {
+      const received: any[] = [];
+      db.changes().on("change", (change) => received.push(change));
+
+      await db.bulkDocs(
+        [
+          { _id: "streamB", name: "beta" },
+          { _id: "streamB:meta", authorities: [] },
+        ],
+        { new_edits: true }
+      );
+
+      expect(received).to.have.length(2);
+      for (const change of received) {
+        expect(Array.isArray(change)).to.equal(false);
+        expect(change).to.have.property("id");
+      }
+    });
+
+    it("still returns true when a change listener throws on an unrelated bug", async () => {
+      db.changes().on("change", () => {
+        throw new Error("unrelated listener bug");
+      });
+
+      const result = await db.bulkDocs(
+        [{ _id: "streamC", name: "gamma" }],
+        { new_edits: true }
+      );
+
+      expect(result).to.equal(true);
+
+      const [readBack] = await db.getMany(["streamC"]);
+      expect(readBack.name).to.equal("gamma");
+    });
+
+    it("still returns false on a genuine write failure", async () => {
+      const realBatch = (db as any).driver.batch.bind((db as any).driver);
+      (db as any).driver.batch = async () => {
+        const chain = await realBatch();
+        chain.write = async () => {
+          throw new Error("simulated disk failure");
+        };
+        return chain;
+      };
+
+      const result = await db.bulkDocs(
+        [{ _id: "streamD", name: "delta" }],
+        { new_edits: true }
+      );
+
+      expect(result).to.equal(false);
+    });
+  });
+
+  describe("post() error signalling (e81cd7c)", () => {
+    it("resolves { ok: true } on success", async () => {
+      const result = await db.post({ _id: "streamE", name: "epsilon" });
+      expect(result.ok).to.equal(true);
+      expect(result.id).to.equal("streamE");
+    });
+
+    it("does not let a change listener bug affect the result either way", async () => {
+      db.changes().on("change", () => {
+        throw new Error("unrelated listener bug");
+      });
+
+      const result = await db.post({ _id: "streamF", name: "zeta" });
+      expect(result.ok).to.equal(true);
+
+      const [readBack] = await db.getMany(["streamF"]);
+      expect(readBack.name).to.equal("zeta");
+    });
+
+    it("rejects on a genuine write failure instead of silently reporting success", async () => {
+      const realBatch = (db as any).driver.batch.bind((db as any).driver);
+      (db as any).driver.batch = async () => {
+        const chain = await realBatch();
+        chain.write = async () => {
+          throw new Error("simulated disk failure");
+        };
+        return chain;
+      };
+
+      let threw = false;
+      try {
+        await db.post({ _id: "streamG", name: "eta" });
+      } catch {
+        threw = true;
+      }
+      expect(threw).to.equal(true);
+    });
+  });
+});

--- a/tests/utilities.test.ts
+++ b/tests/utilities.test.ts
@@ -1,0 +1,100 @@
+import { ActiveClone } from "../packages/utilities/src/clone";
+import { ActiveFrame } from "../packages/utilities/src/frame";
+import { expect } from "chai";
+import "mocha";
+
+// Regression coverage for two real hpe-14 perf fixes in the utilities
+// package, previously only verified via one-off manual scripts.
+describe("ActiveClone (Activeutilities) - hpe-14 regression (3fcfb13)", () => {
+  it("round-trips a small (uncompressed) object correctly", async () => {
+    const original = { hello: "world", n: 42 };
+    const buf = await ActiveClone.serialize(original);
+    expect(buf[0]).to.equal(0); // SerializationType.Uncompressed
+    const back = await ActiveClone.deserialize(buf);
+    expect(back).to.deep.equal(original);
+  });
+
+  it("round-trips a large (compressed) object correctly", async () => {
+    const original = { data: "x".repeat(5000), arr: Array.from({ length: 200 }, (_, i) => i) };
+    const buf = await ActiveClone.serialize(original);
+    expect(buf[0]).to.equal(1); // SerializationType.Gzip
+    const back = await ActiveClone.deserialize(buf);
+    expect(back).to.deep.equal(original);
+  });
+
+  it("respects enableCompression: false even for large payloads", async () => {
+    const original = { data: "x".repeat(5000) };
+    const buf = await ActiveClone.serialize(original, { enableCompression: false });
+    expect(buf[0]).to.equal(0);
+    const back = await ActiveClone.deserialize(buf);
+    expect(back).to.deep.equal(original);
+  });
+
+  it("still falls back to plain JSON.parse for pre-existing legacy documents", async () => {
+    const legacy = Buffer.from(JSON.stringify({ old: "format", _id: "doc1" }));
+    const back = await ActiveClone.deserialize(legacy);
+    expect(back).to.deep.equal({ old: "format", _id: "doc1" });
+  });
+});
+
+describe("ActiveFrame (Activeutilities) - hpe-14 regression (857b3e6)", () => {
+  function makeFrame(payload: string): Buffer {
+    const buf = Buffer.alloc(4 + payload.length);
+    buf.writeUInt32BE(payload.length, 0);
+    Buffer.from(payload).copy(buf, 4);
+    return buf;
+  }
+
+  it("reads a single complete frame delivered in one chunk", () => {
+    const frame = makeFrame("hello world");
+    const result = ActiveFrame.read([frame], frame.length);
+    expect(result).to.not.be.null;
+    expect(result!.item.toString()).to.equal("hello world");
+    expect(result!.remaining.length).to.equal(0);
+    expect(result!.consumed).to.equal(frame.length);
+  });
+
+  it("reassembles a frame split across ~700 tiny chunks without re-copying the whole backlog each time", () => {
+    const frame = makeFrame("x".repeat(5000));
+    const chunks: Buffer[] = [];
+    for (let i = 0; i < frame.length; i += 7) chunks.push(frame.slice(i, i + 7));
+
+    let buffered: Buffer[] = [];
+    let bufferLength = 0;
+    let result: ReturnType<typeof ActiveFrame.read> = null;
+    for (const chunk of chunks) {
+      buffered.push(chunk);
+      bufferLength += chunk.length;
+      result = ActiveFrame.read(buffered, bufferLength);
+      if (result) break;
+    }
+    expect(result).to.not.be.null;
+    expect(result!.item.length).to.equal(5000);
+    expect(result!.item.toString()).to.equal("x".repeat(5000));
+  });
+
+  it("extracts two back-to-back frames delivered in a single chunk", () => {
+    const first = makeFrame("first");
+    const second = makeFrame("second");
+    const combined = Buffer.concat([first, second]);
+
+    const r1 = ActiveFrame.read([combined], combined.length);
+    expect(r1!.item.toString()).to.equal("first");
+
+    const remainingChunks = r1!.remaining.length > 0 ? [r1!.remaining] : [];
+    const r2 = ActiveFrame.read(remainingChunks, r1!.remaining.length);
+    expect(r2!.item.toString()).to.equal("second");
+  });
+
+  it("returns null when fewer than 4 bytes are buffered (can't read the length prefix yet)", () => {
+    const frame = makeFrame("hello");
+    const partial = frame.slice(0, 3);
+    expect(ActiveFrame.read([partial], partial.length)).to.be.null;
+  });
+
+  it("returns null when the header is present but the body isn't fully buffered yet", () => {
+    const frame = makeFrame("hello world");
+    const partial = frame.slice(0, 6);
+    expect(ActiveFrame.read([partial], partial.length)).to.be.null;
+  });
+});


### PR DESCRIPTION
## Summary
- Contract events raised in `commit()` are now stored on the transaction's `<umid>:umid` document and replayed into a node's local events database whenever that umid is restored (interagent's per-error path and quick-restore's bulk catch-up), so SSE subscribers on a restoring node no longer silently miss them.
- Fixes a bug where the lock-check catch block in `permissionsChecker.ts` masked the specific 1700/1710 error codes ("Stream contract locked"/"Namespace locked") into a generic 950.
- Fixes a bug where a raw `Error` instance on a 500 response serialized to `{}`, blanking the error body sent to the client.
- Fixes `activeledger --stop` hanging forever instead of exiting - the unconditional `SIGTERM` listener keeps the event loop alive, so `--stop` now calls `process.exit()` explicitly once done, matching `backup`/`restore`.
- Cleans up several stale/already-resolved TODO comments.
- Merges in `hpe-15`: hardened unit test suite (35 -> 67 tests) and a new `tests/network/` live 4-node integration suite (`npm run test:network` - 120 real transactions, `returnToRemote()`, SSE delivery, bad-signature/locked-contract rejection, SPI self-healing).
- README rewrite: accurate architecture description, Node 24.x requirement, drops `@activeledger/activecore` from the default install, documents both test suites.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` - 67/67 passing
- [x] `npm run test:network` - all 8 categories passing (~36s wall time)
- [x] Live-verified umid event replay on a 4-node bare-host network
- [x] Live-verified `--stop` now exits in ~300ms instead of hanging
- [ ] Full test pass on another session/machine before tagging