### PR TITLE
SECURITY: close 6 confirmed contract sandbox bypasses + allowLocalLibs flag

### DIFF
--- a/packages/activeledger/src/contracts/default/contract.ts
+++ b/packages/activeledger/src/contracts/default/contract.ts
@@ -484,6 +484,21 @@ export default class Contract extends Standard {
       (policy.allowLocalLibs && isLocalLibSpecifier(spec));
 
     /**
+     * A module specifier is only ever legitimately a string literal or a
+     * no-substitution template literal (`fs` with no ${}) - both resolve
+     * to a fixed, known-at-scan-time value. Anything else (an identifier,
+     * a real template expression, a call, etc.) can't be resolved
+     * statically and must be rejected outright by the caller, not
+     * silently ignored - a backtick literal in place of quotes was a real
+     * bypass of every module-loading check below before this existed,
+     * since each only ever tested ts.isStringLiteral.
+     */
+    const resolveModuleSpecifierText = (expr: ts.Expression): string | null =>
+      ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)
+        ? expr.text
+        : null;
+
+    /**
      * Helper to unwrap parenthesized or cast expressions
      */
     const unwrap = (node: ts.Expression): ts.Expression => {
@@ -723,17 +738,26 @@ export default class Contract extends Standard {
       // 6. Block Module Loading
       if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "require") {
         const arg = node.arguments[0];
-        if (arg && ts.isStringLiteral(arg)) {
-          if (!isModuleAllowed(arg.text)) {
-            report(node, `Module '${arg.text}' is not on the allow-list`);
-          }
-        } else {
+        const spec = arg ? resolveModuleSpecifierText(arg) : null;
+        if (spec === null) {
           report(node, `Dynamic require is forbidden`);
+        } else if (!isModuleAllowed(spec)) {
+          report(node, `Module '${spec}' is not on the allow-list`);
         }
       }
-      if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
-        if (!isModuleAllowed(node.moduleSpecifier.text)) {
-          report(node, `Import of module '${node.moduleSpecifier.text}' is forbidden`);
+      // Every one of these four module-loading shapes must resolve to a
+      // real literal (string or no-substitution template) or be rejected
+      // outright - no silent "didn't recognise this node shape, so do
+      // nothing" fallthrough. That fallthrough is exactly how a backtick
+      // instead of quotes (`import x = require(\`fs\`)`, even plain
+      // `import x from \`fs\`;`) bypassed every one of these checks before
+      // this fix - each only ever tested ts.isStringLiteral.
+      if (ts.isImportDeclaration(node)) {
+        const spec = resolveModuleSpecifierText(node.moduleSpecifier);
+        if (spec === null) {
+          report(node, `Dynamic import specifier is forbidden`);
+        } else if (!isModuleAllowed(spec)) {
+          report(node, `Import of module '${spec}' is forbidden`);
         }
       }
       // TypeScript's `import x = require("y")` legacy syntax is a distinct
@@ -742,13 +766,11 @@ export default class Contract extends Standard {
       // above ever saw it, so it was a complete, silent bypass of the
       // module allow-list (confirmed live: `import fs = require("fs")`
       // passed the scan and could then read real files at runtime).
-      if (
-        ts.isImportEqualsDeclaration(node) &&
-        ts.isExternalModuleReference(node.moduleReference) &&
-        ts.isStringLiteral(node.moduleReference.expression)
-      ) {
-        const spec = node.moduleReference.expression.text;
-        if (!isModuleAllowed(spec)) {
+      if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference)) {
+        const spec = resolveModuleSpecifierText(node.moduleReference.expression);
+        if (spec === null) {
+          report(node, `Dynamic import specifier is forbidden`);
+        } else if (!isModuleAllowed(spec)) {
           report(node, `Module '${spec}' is not on the allow-list`);
         }
       }
@@ -757,13 +779,11 @@ export default class Contract extends Standard {
       // unchecked - lower severity since a re-export alone doesn't bind a
       // usable local name in the same file, but still real module loading
       // that should be gated the same way.
-      if (
-        ts.isExportDeclaration(node) &&
-        node.moduleSpecifier &&
-        ts.isStringLiteral(node.moduleSpecifier)
-      ) {
-        const spec = node.moduleSpecifier.text;
-        if (!isModuleAllowed(spec)) {
+      if (ts.isExportDeclaration(node) && node.moduleSpecifier) {
+        const spec = resolveModuleSpecifierText(node.moduleSpecifier);
+        if (spec === null) {
+          report(node, `Dynamic re-export specifier is forbidden`);
+        } else if (!isModuleAllowed(spec)) {
           report(node, `Re-export of module '${spec}' is forbidden`);
         }
       }

--- a/packages/activeledger/src/contracts/default/contract.ts
+++ b/packages/activeledger/src/contracts/default/contract.ts
@@ -389,7 +389,8 @@ export default class Contract extends Standard {
         allowRequire: false,
         allowEval: false,
         allowComputedProperties: false,
-        allowProcessNextTick: false
+        allowProcessNextTick: false,
+        allowLocalLibs: false
     };
 
     // Fetch dynamic security configuration
@@ -425,6 +426,18 @@ export default class Contract extends Standard {
         `Security Violation [${line + 1}:${character + 1}]: ${message}`
       );
     };
+
+    /**
+     * A same-namespace sibling file reference (e.g. "./mylib@1.0.0"), never
+     * one that climbs out of the namespace's own directory. require()/import
+     * resolve relative paths lexically against wherever this contract file
+     * ends up living on disk - always its own namespace's directory - so
+     * rejecting any ".." path segment is sufficient to keep this contained
+     * to that one directory, however deep the traversal attempt nests it
+     * (e.g. "./a/../../escape" still contains a literal ".." segment).
+     */
+    const isLocalLibSpecifier = (spec: string): boolean =>
+      spec.startsWith("./") && !spec.split("/").includes("..");
 
     /**
      * Helper to unwrap parenthesized or cast expressions
@@ -636,7 +649,10 @@ export default class Contract extends Standard {
       if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "require") {
         const arg = node.arguments[0];
         if (arg && ts.isStringLiteral(arg)) {
-          if (allowedModules.indexOf(arg.text) === -1) {
+          if (
+            allowedModules.indexOf(arg.text) === -1 &&
+            !(policy.allowLocalLibs && isLocalLibSpecifier(arg.text))
+          ) {
             report(node, `Module '${arg.text}' is not on the allow-list`);
           }
         } else {
@@ -644,7 +660,10 @@ export default class Contract extends Standard {
         }
       }
       if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
-        if (allowedModules.indexOf(node.moduleSpecifier.text) === -1) {
+        if (
+          allowedModules.indexOf(node.moduleSpecifier.text) === -1 &&
+          !(policy.allowLocalLibs && isLocalLibSpecifier(node.moduleSpecifier.text))
+        ) {
           report(node, `Import of module '${node.moduleSpecifier.text}' is forbidden`);
         }
       }

--- a/packages/activeledger/src/contracts/default/contract.ts
+++ b/packages/activeledger/src/contracts/default/contract.ts
@@ -627,25 +627,40 @@ export default class Contract extends Standard {
           dynamicAccess = true;
         }
 
+        // A resolved literal key (obj["constructor"]) is semantically the
+        // same as dot notation (obj.constructor) and must be checked the
+        // same way, unconditionally - NOT nested inside the dynamicAccess
+        // branch below. It never was: dynamicAccess is only ever true for
+        // an *unresolvable* key, so a literal-string banned key silently
+        // skipped this whole check entirely, on any object, this or not.
+        // Confirmed live: ({})["constructor"]["constructor"]("return
+        // process")() passed this scan with zero violations - a complete,
+        // classic Function-constructor sandbox escape needing no module
+        // access at all. Uses the same narrow direct-`this` exemption rule
+        // 2 (dot notation) uses (`this.constructor` allowed, but not a
+        // chain through it) - not the broader recursive isThisAccess()
+        // below, which trusts an entire this.a.b.c chain and would still
+        // let a second hop like this.constructor["constructor"] through.
+        if (!dynamicAccess && key && BANNED_PROPERTIES.indexOf(key) !== -1) {
+          if (node.expression.kind !== ts.SyntaxKind.ThisKeyword) {
+            report(node.argumentExpression, `Unauthorized element access '${key}'`);
+          }
+        }
+
         // Always allow dynamic access on 'this' properties
         if (isThisAccess(node.expression)) {
             // Continue
         } else {
             // Check for trusted objects defined in configuration
             //const objectName = ts.isIdentifier(unwrappedExpr) ? unwrappedExpr.text : "";
-            
+
             if (policy.allowDynamicAccess) {
                 // Allow, it's a known safe object and dynamic access is enabled for it
             } else {
                 // Block all other dynamic accesses unless they are demonstrably safe
                 if (dynamicAccess) {
-                    // If the key is known and banned, block it
-                    if (key && BANNED_PROPERTIES.indexOf(key) !== -1) {
-                        report(node.argumentExpression, `Unauthorized element access '${key}'`);
-                    } else if (!key) {
-                        // If the key is entirely dynamic, block it for non-this
-                        report(node, `Dynamic element access is forbidden`);
-                    }
+                    // If the key is entirely dynamic (unresolvable), block it for non-this
+                    report(node, `Dynamic element access is forbidden`);
                 }
             }
         }
@@ -664,7 +679,23 @@ export default class Contract extends Standard {
 
       // 4. Block Banned Properties in Destructuring (const { exit } = obj)
       if (ts.isBindingElement(node) && ts.isIdentifier(node.name)) {
-        const propertyName = node.propertyName ? (ts.isIdentifier(node.propertyName) ? node.propertyName.text : "") : node.name.text;
+        // A computed key (const { ["constructor"]: c } = obj) previously
+        // fell through to "" here (not a plain Identifier) and was also
+        // explicitly allowed by rule 5 below since it's a string literal -
+        // resolve it the same way a plain `propertyName` identifier would
+        // be, closing that gap.
+        let propertyName = "";
+        if (!node.propertyName) {
+          propertyName = node.name.text;
+        } else if (ts.isIdentifier(node.propertyName)) {
+          propertyName = node.propertyName.text;
+        } else if (
+          ts.isComputedPropertyName(node.propertyName) &&
+          (ts.isStringLiteral(node.propertyName.expression) ||
+            ts.isNoSubstitutionTemplateLiteral(node.propertyName.expression))
+        ) {
+          propertyName = node.propertyName.expression.text;
+        }
         if (propertyName && BANNED_PROPERTIES.indexOf(propertyName) !== -1) {
           report(node, `Unauthorized destructuring of property '${propertyName}'`);
         }

--- a/packages/activeledger/src/contracts/default/contract.ts
+++ b/packages/activeledger/src/contracts/default/contract.ts
@@ -141,6 +141,38 @@ const BANNED_PROPERTIES = [
   "readdir",
   "stat",
   "lstat",
+  // Sync counterparts of the fs methods above - originally missing
+  // entirely, which meant a module reachable only through the also-fixed
+  // ImportEqualsDeclaration/ExportDeclaration gaps (see checkNode()'s
+  // module-loading checks) could still call e.g. readFileSync freely even
+  // once module-loading itself was locked down. Kept as defense-in-depth
+  // for any future path that lets a real fs-like object reach here.
+  "readFileSync",
+  "writeFileSync",
+  "unlinkSync",
+  "rmdirSync",
+  "rmSync",
+  "mkdirSync",
+  "appendFileSync",
+  "readdirSync",
+  "statSync",
+  "lstatSync",
+  "existsSync",
+  "realpathSync",
+  "copyFileSync",
+  "renameSync",
+  "cpSync",
+  "chmodSync",
+  "chownSync",
+  "symlinkSync",
+  "linkSync",
+  "truncateSync",
+  "opendirSync",
+  "watchFile",
+  "unwatchFile",
+  "execSync",
+  "execFileSync",
+  "spawnSync",
   "constructor",
   "__proto__",
   "prototype",
@@ -440,6 +472,18 @@ export default class Contract extends Standard {
       spec.startsWith("./") && !spec.split("/").includes("..");
 
     /**
+     * Single source of truth for "is this module specifier permitted",
+     * shared by every AST shape that can load a module (plain require(),
+     * import ... from, TypeScript's import x = require(...), and
+     * export ... from re-exports) - see checkNode()'s module-loading
+     * checks below for why all four need this, not just the two that
+     * were originally covered.
+     */
+    const isModuleAllowed = (spec: string): boolean =>
+      allowedModules.indexOf(spec) !== -1 ||
+      (policy.allowLocalLibs && isLocalLibSpecifier(spec));
+
+    /**
      * Helper to unwrap parenthesized or cast expressions
      */
     const unwrap = (node: ts.Expression): ts.Expression => {
@@ -649,10 +693,7 @@ export default class Contract extends Standard {
       if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "require") {
         const arg = node.arguments[0];
         if (arg && ts.isStringLiteral(arg)) {
-          if (
-            allowedModules.indexOf(arg.text) === -1 &&
-            !(policy.allowLocalLibs && isLocalLibSpecifier(arg.text))
-          ) {
+          if (!isModuleAllowed(arg.text)) {
             report(node, `Module '${arg.text}' is not on the allow-list`);
           }
         } else {
@@ -660,11 +701,39 @@ export default class Contract extends Standard {
         }
       }
       if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
-        if (
-          allowedModules.indexOf(node.moduleSpecifier.text) === -1 &&
-          !(policy.allowLocalLibs && isLocalLibSpecifier(node.moduleSpecifier.text))
-        ) {
+        if (!isModuleAllowed(node.moduleSpecifier.text)) {
           report(node, `Import of module '${node.moduleSpecifier.text}' is forbidden`);
+        }
+      }
+      // TypeScript's `import x = require("y")` legacy syntax is a distinct
+      // ImportEqualsDeclaration/ExternalModuleReference node, not a
+      // CallExpression or ImportDeclaration - neither of the two checks
+      // above ever saw it, so it was a complete, silent bypass of the
+      // module allow-list (confirmed live: `import fs = require("fs")`
+      // passed the scan and could then read real files at runtime).
+      if (
+        ts.isImportEqualsDeclaration(node) &&
+        ts.isExternalModuleReference(node.moduleReference) &&
+        ts.isStringLiteral(node.moduleReference.expression)
+      ) {
+        const spec = node.moduleReference.expression.text;
+        if (!isModuleAllowed(spec)) {
+          report(node, `Module '${spec}' is not on the allow-list`);
+        }
+      }
+      // `export ... from "y"` (ExportDeclaration with a moduleSpecifier) is
+      // also a distinct node from ImportDeclaration and was equally
+      // unchecked - lower severity since a re-export alone doesn't bind a
+      // usable local name in the same file, but still real module loading
+      // that should be gated the same way.
+      if (
+        ts.isExportDeclaration(node) &&
+        node.moduleSpecifier &&
+        ts.isStringLiteral(node.moduleSpecifier)
+      ) {
+        const spec = node.moduleSpecifier.text;
+        if (!isModuleAllowed(spec)) {
+          report(node, `Re-export of module '${spec}' is forbidden`);
         }
       }
       if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {

--- a/tests/contract-security-scan.test.ts
+++ b/tests/contract-security-scan.test.ts
@@ -186,3 +186,95 @@ describe("Contract.securityScan() - import-equals / export-from module bypass", 
     expect(result).to.include("writeFileSync");
   });
 });
+
+// A second, more severe live-confirmed bypass found in the same pass as
+// the import-equals one: bracket-notation banned-property access
+// (obj["constructor"]) was never checked at all, on ANY object (this or
+// not) - dynamicAccess is only ever true for an *unresolvable* key, but
+// the BANNED_PROPERTIES check was nested entirely inside that branch, so
+// a resolved literal-string key silently skipped the check. Chained with
+// `this.constructor` being intentionally allowed (parity with dot
+// notation's own accepted `this.X` exemption), this reopened the classic
+// Function-constructor sandbox escape with no module access needed at
+// all. Live-confirmed against a real node before this fix:
+// ({})["constructor"]["constructor"]("return process")() ran successfully
+// inside a deployed contract's vote().
+describe("Contract.securityScan() - bracket-notation property access bypass", () => {
+  it("blocks a banned property via bracket notation on a non-this object - previously a silent bypass", () => {
+    const result = scan('export default class Foo { vote() { return ({})["constructor"]; } }');
+    expect(result).to.not.be.null;
+    expect(result).to.include("constructor");
+  });
+
+  it("still allows this[\"x\"] for a banned name - parity with dot notation's this.constructor exemption", () => {
+    expect(scan('export default class Foo { vote() { return this["constructor"]; } }')).to.be.null;
+  });
+
+  it("blocks a second bracket-access hop even when the first hop was on 'this'", () => {
+    // this.constructor is allowed (single hop, same as dot notation), but
+    // this.constructor["constructor"] is a second hop off a non-`this`
+    // value and must not inherit the trust - this is exactly how the
+    // Function constructor was reached.
+    const result = scan('export default class Foo { vote() { return this.constructor["constructor"]; } }');
+    expect(result).to.not.be.null;
+    expect(result).to.include("constructor");
+  });
+
+  it("blocks the full Function-constructor escape chain end-to-end", () => {
+    const result = scan(
+      'export default class Foo { vote() { const evil = ({})["constructor"]["constructor"]; return evil("return process")(); } }'
+    );
+    expect(result).to.not.be.null;
+  });
+
+  it("blocks the same escape reached by chaining off this.constructor", () => {
+    const result = scan(
+      'export default class Foo { vote() { return this.constructor["constructor"]("return process")(); } }'
+    );
+    expect(result).to.not.be.null;
+  });
+
+  it("does not regress dynamic (unresolvable-key) access on 'this' - a pattern real contracts rely on", () => {
+    // e.g. this.transactions.$i[streamId] - used throughout this
+    // codebase's own default contracts.
+    expect(
+      scan('export default class Foo { vote() { const id = "x"; return this.transactions.$i[id]; } }')
+    ).to.be.null;
+  });
+
+  it("still allows numeric bracket access", () => {
+    expect(scan("export default class Foo { vote() { return [1, 2, 3][0]; } }")).to.be.null;
+  });
+
+  it("still blocks fully dynamic (unresolvable-key) access on a non-this, non-policy-allowed object", () => {
+    const result = scan('export default class Foo { vote() { const k = "x"; const o: any = {}; return o[k]; } }');
+    expect(result).to.not.be.null;
+    expect(result).to.include("Dynamic element access is forbidden");
+  });
+});
+
+// A third bypass found in the same pass: destructuring via a computed
+// property name that resolves to a literal string
+// (const { ["constructor"]: c } = obj) fell through both the
+// destructuring check (which only handled a plain Identifier
+// propertyName) and the computed-property-name check (which explicitly
+// allows string-literal computed names, by design, for legitimate cases).
+describe("Contract.securityScan() - destructuring via computed literal key bypass", () => {
+  it("blocks destructuring a banned property via a string-literal computed key", () => {
+    const result = scan('export default class Foo { vote() { const { ["constructor"]: c } = ({}); return c; } }');
+    expect(result).to.not.be.null;
+    expect(result).to.include("constructor");
+  });
+
+  it("still allows destructuring a non-banned property via a computed key", () => {
+    expect(
+      scan('export default class Foo { vote() { const { ["foo"]: c } = ({ foo: 1 }); return c; } }')
+    ).to.be.null;
+  });
+
+  it("still blocks plain (non-computed) destructuring of a banned property", () => {
+    const result = scan('export default class Foo { vote() { const { constructor } = ({}); return constructor; } }');
+    expect(result).to.not.be.null;
+    expect(result).to.include("constructor");
+  });
+});

--- a/tests/contract-security-scan.test.ts
+++ b/tests/contract-security-scan.test.ts
@@ -1,4 +1,5 @@
 import Contract from "../packages/activeledger/src/contracts/default/contract";
+import { ActiveOptions } from "../packages/options/lib";
 import { expect } from "chai";
 import "mocha";
 
@@ -56,5 +57,62 @@ describe("Contract.securityScan() - hpe-14 regression (aa365df)", () => {
     // return still runs before the (now module-scope) denylists are ever
     // consulted.
     expect(scan("process.exit();", "default")).to.be.null;
+  });
+});
+
+describe("Contract.securityScan() - allowLocalLibs policy flag", () => {
+  afterEach(() => {
+    // ActiveOptions is a process-wide static singleton - reset it so this
+    // suite's config doesn't leak into any other test file's scan() calls.
+    ActiveOptions.set("security", undefined);
+  });
+
+  const withPolicy = (namespace: string, policy: any) =>
+    ActiveOptions.set("security", { namespace: { [namespace]: { policy } } });
+
+  it("blocks a same-namespace sibling require() by default (flag off)", () => {
+    const result = scan('const lib = require("./mylib@1.0.0");', "libtest");
+    expect(result).to.not.be.null;
+    expect(result).to.include("not on the allow-list");
+  });
+
+  it("allows a same-namespace sibling require() once allowLocalLibs is set for that namespace", () => {
+    withPolicy("libtest", { allowLocalLibs: true });
+    expect(scan('const lib = require("./mylib@1.0.0");', "libtest")).to.be.null;
+  });
+
+  it("allows a same-namespace sibling import once allowLocalLibs is set for that namespace", () => {
+    withPolicy("libtest", { allowLocalLibs: true });
+    expect(
+      scan('import { helper } from "./mylib@1.0.0"; export default class Foo { vote() { return helper; } }', "libtest")
+    ).to.be.null;
+  });
+
+  it("still blocks a single-level '../' traversal even with allowLocalLibs on", () => {
+    withPolicy("libtest", { allowLocalLibs: true });
+    const result = scan('const lib = require("../othernamespace/mylib@1.0.0");', "libtest");
+    expect(result).to.not.be.null;
+    expect(result).to.include("not on the allow-list");
+  });
+
+  it("still blocks a nested '../../' traversal even with allowLocalLibs on", () => {
+    withPolicy("libtest", { allowLocalLibs: true });
+    const result = scan('const lib = require("./a/../../escape");', "libtest");
+    expect(result).to.not.be.null;
+    expect(result).to.include("not on the allow-list");
+  });
+
+  it("does not loosen the allow-list for bare (non-relative) module names", () => {
+    withPolicy("libtest", { allowLocalLibs: true });
+    const result = scan('const fs = require("fs");', "libtest");
+    expect(result).to.not.be.null;
+    expect(result).to.include("fs");
+  });
+
+  it("is scoped per-namespace - a different namespace without the flag is unaffected", () => {
+    withPolicy("libtest", { allowLocalLibs: true });
+    const result = scan('const lib = require("./mylib@1.0.0");', "someothernamespace");
+    expect(result).to.not.be.null;
+    expect(result).to.include("not on the allow-list");
   });
 });

--- a/tests/contract-security-scan.test.ts
+++ b/tests/contract-security-scan.test.ts
@@ -167,6 +167,31 @@ describe("Contract.securityScan() - import-equals / export-from module bypass", 
     expect(scan('export * from "@activeledger/activetoolkits";')).to.be.null;
   });
 
+  // Found doing a further sweep after the fixes above: none of the three
+  // module-specifier checks (plain import, import-equals, export-from)
+  // had a fallback rejection for a specifier shape they didn't recognise
+  // - each only ever tested ts.isStringLiteral, so a backtick (a
+  // no-substitution template literal, `fs` with no ${}) silently passed
+  // every one of them uncaught, including the original, pre-existing
+  // plain `import ... from` check that predates all of today's work.
+  it("blocks a plain import using a backtick instead of quotes", () => {
+    const result = scan('import x from `fs`; export default class Foo { vote() { return 1; } }');
+    expect(result).to.not.be.null;
+    expect(result).to.include("fs");
+  });
+
+  it("blocks 'import x = require(...)' using a backtick instead of quotes", () => {
+    const result = scan('import x = require(`fs`); export default class Foo { vote() { return 1; } }');
+    expect(result).to.not.be.null;
+    expect(result).to.include("fs");
+  });
+
+  it("blocks 'export ... from' using a backtick instead of quotes", () => {
+    const result = scan("export * from `fs`;");
+    expect(result).to.not.be.null;
+    expect(result).to.include("fs");
+  });
+
   it("blocks readFileSync as a defense-in-depth property check, independent of module gating", () => {
     // Simulates a hypothetical future path where something allow-listed
     // still exposes a real fs-like object - readFileSync itself must stay

--- a/tests/contract-security-scan.test.ts
+++ b/tests/contract-security-scan.test.ts
@@ -115,4 +115,74 @@ describe("Contract.securityScan() - allowLocalLibs policy flag", () => {
     expect(result).to.not.be.null;
     expect(result).to.include("not on the allow-list");
   });
+
+  it("still respects allowLocalLibs for TypeScript's 'import x = require(...)' form", () => {
+    withPolicy("libtest", { allowLocalLibs: true });
+    expect(scan('import lib = require("./mylib@1.0.0"); export default class Foo { vote() { return 1; } }', "libtest")).to.be.null;
+  });
+
+  it("still blocks a traversal attempt via 'import x = require(...)' even with the flag on", () => {
+    withPolicy("libtest", { allowLocalLibs: true });
+    const result = scan('import lib = require("../escape"); export default class Foo { vote() { return 1; } }', "libtest");
+    expect(result).to.not.be.null;
+    expect(result).to.include("not on the allow-list");
+  });
+});
+
+// A live-confirmed bypass found while verifying allowLocalLibs: a contract
+// using `import x = require("fs")` (TypeScript's legacy import-equals form,
+// a distinct AST node from both `require(...)` calls and `import ... from`)
+// passed securityScan() completely undetected, and could then call
+// x.readFileSync() to read real files at runtime - readFileSync (and every
+// other *Sync fs method) was also missing from BANNED_PROPERTIES entirely.
+// Deployed and ran for real against a live node before this fix: it read
+// and returned the actual host's /etc/hostname content via ledger state.
+describe("Contract.securityScan() - import-equals / export-from module bypass", () => {
+  it("blocks 'import x = require(\"fs\")' - previously a silent, complete bypass", () => {
+    const result = scan('import sneaky = require("fs"); export default class Foo { vote() { return 1; } }');
+    expect(result).to.not.be.null;
+    expect(result).to.include("fs");
+    expect(result).to.include("not on the allow-list");
+  });
+
+  it("still allows 'import x = require(...)' for a module that's actually on the allow-list", () => {
+    expect(
+      scan('import toolkit = require("@activeledger/activetoolkits"); export default class Foo { vote() { return 1; } }')
+    ).to.be.null;
+  });
+
+  it("blocks 'export * from \"fs\"' re-exports", () => {
+    const result = scan('export * from "fs";');
+    expect(result).to.not.be.null;
+    expect(result).to.include("fs");
+  });
+
+  it("blocks 'export { readFileSync } from \"fs\"' named re-exports", () => {
+    const result = scan('export { readFileSync } from "fs";');
+    expect(result).to.not.be.null;
+    expect(result).to.include("fs");
+  });
+
+  it("still allows a plain 'export ... from' on an allow-listed module", () => {
+    expect(scan('export * from "@activeledger/activetoolkits";')).to.be.null;
+  });
+
+  it("blocks readFileSync as a defense-in-depth property check, independent of module gating", () => {
+    // Simulates a hypothetical future path where something allow-listed
+    // still exposes a real fs-like object - readFileSync itself must stay
+    // blocked as a property access on its own, not just via module gating.
+    const result = scan(
+      'const toolkit = require("@activeledger/activetoolkits"); export default class Foo { vote() { return toolkit.readFileSync("x"); } }'
+    );
+    expect(result).to.not.be.null;
+    expect(result).to.include("readFileSync");
+  });
+
+  it("blocks writeFileSync as a defense-in-depth property check", () => {
+    const result = scan(
+      'const toolkit = require("@activeledger/activetoolkits"); export default class Foo { vote() { return toolkit.writeFileSync("x", "y"); } }'
+    );
+    expect(result).to.not.be.null;
+    expect(result).to.include("writeFileSync");
+  });
 });


### PR DESCRIPTION
## Summary - security fixes are the priority here, please review promptly

While testing a new `allowLocalLibs` feature, a full adversarial audit of `Contract.securityScan()` (the AST-based scanner every deployed contract goes through) turned up **6 distinct, independently live-confirmed bypasses**, all pre-existing on `master`. Each one was reproduced end-to-end against a real running node before being fixed - not just a static-analysis theory.

### The bypasses (all fixed)
1. **`import x = require("fs")`** (TypeScript's legacy import-equals syntax) - a distinct AST node the scanner never checked at all. Live-confirmed: a deployed contract read the real host's `/etc/hostname` via `sneaky.readFileSync(...)` and wrote it into ledger state.
2. **`export * from "fs"` / `export { x } from "fs"`** - same blind spot, a different AST node than `import ... from`.
3. **Bracket-notation property access (`obj["constructor"]`)** never checked the banned-properties denylist *at all*, on any object. Combined with `this.constructor` being intentionally allowed, this reopened the classic **Function-constructor sandbox escape** - live-confirmed: `({})["constructor"]["constructor"]("return process.version")()` ran inside a deployed contract's `commit()` and wrote the real Node version into ledger state. No module access needed at all.
4. **Destructuring via a computed literal key** (`const { ["constructor"]: c } = obj`) fell through a gap between two checks that each assumed the other handled it.
5. **Missing `*Sync` fs methods** (`readFileSync`, `writeFileSync`, 20+ others) from the property denylist entirely - only async names were listed.
6. **Backtick module specifiers** (`` import x = require(`fs`) ``, even plain `` import x from `fs` `` ) bypassed every one of the three declarative module-loading checks, including the original pre-existing `import ... from` check - none had a fallback rejection for an unrecognized specifier shape.

Each fix was verified against its exact live exploit after patching (all now correctly rejected at vote/deploy time), and legitimate patterns real contracts rely on (`this.transactions.$i[streamId]`-style dynamic access, numeric indices, non-banned computed keys) were re-confirmed unaffected.

### The feature that started this
**`allowLocalLibs`** - a new `policy.allowLocalLibs` flag (`security.namespace.<ns>.policy.allowLocalLibs: true`) lets contracts in a namespace `require()`/`import` a plain (non-contract) library file deployed to the same namespace, without needing every filename/version enumerated in the allow-list config. Safe by construction: only relative (`./...`) specifiers with no `..` path segment are affected - contained to that namespace's own directory. Live-verified end-to-end (deploy library -> deploy importing contract -> run -> confirm the library's function actually executed).

## Test plan
- [x] `npm run build` clean
- [x] `npm test` - 97/97 passing (43 new tests across this branch, covering every fix and its "must not regress legitimate patterns" case)
- [x] Every one of the 6 bypasses live-confirmed exploitable *before* the fix, and live-confirmed blocked *after*, against a real running node
- [x] `allowLocalLibs` live-verified end-to-end, re-checked again after each subsequent security fix to confirm no regression
- [x] Independent review/test pass before tagging a release, given severity