### PR TITLE
fix(protocol): deterministic streams always false-positived as existing collisions

### DIFF
--- a/packages/protocol/src/protocol/streamUpdater.ts
+++ b/packages/protocol/src/protocol/streamUpdater.ts
@@ -128,7 +128,6 @@ export class StreamUpdater {
     // this.inputs = this.virtualMachine.getInputs(this.entry.$umid);
   }
 
-  // TODO - manage async if it is really needed
   public async updateStreams(earlyCommit?: Function): Promise<void> {
     if (earlyCommit) this.earlyCommit = earlyCommit;
 
@@ -186,7 +185,6 @@ export class StreamUpdater {
     }
   }
 
-  // TODO - manage async if it is really needed
   private async processStreams() {
     this.docs = [];
 
@@ -210,7 +208,12 @@ export class StreamUpdater {
       events: this.virtualMachine.getEvents(this.entry.$umid),
     });
 
-    this.detectCollisions();
+    // Was previously fire-and-forget (unawaited). Since detectCollisions()
+    // is what actually decides commit/reject and calls append() (the real
+    // stream write), not awaiting it let updateStreams() resolve before
+    // that decision existed yet - the caller (Process.commit()) would move
+    // on believing the streams step was done while it was still in flight.
+    await this.detectCollisions();
   }
 
   /**
@@ -410,16 +413,22 @@ export class StreamUpdater {
       ActiveLogger.info("Deterministic streams to be checked");
 
       // Store the promises to wait on.
-      const existenceChecks: Promise<boolean>[] = [];
+      const existenceChecks: Promise<Boolean>[] = [];
 
       let i = this.collisions.length;
       while (i--) {
         const streamId: string = this.collisions[i];
 
-        // Query datastore for streams, resolve true if found, false if not
-        existenceChecks.push(
-          this.db.get(streamId).then(() => true).catch(() => false)
-        );
+        // Query datastore for streams. ActiveRequest.send() (the transport
+        // underneath ActiveDSConnect.get()) never rejects on a non-2xx
+        // status - it resolves { data: <body> } for a 404 the same as a
+        // 200, by design (see its own "deposit wants to treat 404 as 200"
+        // comment). get().then(() => true).catch(() => false) therefore
+        // always resolved true here, even for a genuinely missing stream -
+        // exists() is the version of this check that's actually correct,
+        // since it inspects the resolved body for a real _id instead of
+        // relying on rejection to mean "not found".
+        existenceChecks.push(this.db.exists(streamId));
       }
 
       // Wait for all the checks
@@ -441,16 +450,16 @@ export class StreamUpdater {
           );
         } else {
           // No collisions found
-          this.append();
+          await this.append();
         }
       } catch (error) {
         // This block should ideally not be reached if errors are caught in the map
         // But as a fallback, assume no collision and proceed.
-        this.append();
+        await this.append();
       }
     } else {
       // Continue
-      this.append();
+      await this.append();
     }
   }
 }

--- a/tests/network/contracts/deterministic-contract.ts
+++ b/tests/network/contracts/deterministic-contract.ts
@@ -1,0 +1,57 @@
+import { Standard, Activity } from "@activeledger/activecontracts";
+
+/**
+ * Exercises this.newActivityStream(name, deterministic) - the deterministic
+ * id feature investigated for the false-positive "Deterministic Stream Name
+ * Exists" (1530) bug (see streamUpdater.ts's detectCollisions()). Takes the
+ * deterministic seed and a stream name from $o so the test runner can drive
+ * both a genuinely-fresh seed (expected: commit succeeds) and a repeated
+ * seed (expected: a real 1530 collision).
+ */
+export default class DeterministicStream extends Standard {
+  private seed: string;
+  private name: string;
+
+  public verify(selfsigned: boolean): Promise<boolean> {
+    return new Promise<boolean>((resolve, reject) => {
+      if (selfsigned) {
+        reject("No self sign");
+      } else {
+        resolve(true);
+      }
+    });
+  }
+
+  public vote(): Promise<boolean> {
+    return new Promise<boolean>((resolve, reject) => {
+      const oStreams = Object.keys(this.transactions.$o);
+      if (!oStreams.length) {
+        reject("Need an output stream");
+        return;
+      }
+      const payload = this.transactions.$o[oStreams[0]] as {
+        seed?: string;
+        name?: string;
+      };
+      this.seed = payload.seed as string;
+      this.name = payload.name as string;
+      if (!this.seed || !this.name) {
+        reject("Need seed and name");
+        return;
+      }
+      resolve(true);
+    });
+  }
+
+  public commit(): Promise<any> {
+    return new Promise<any>((resolve) => {
+      const activity: Activity = this.newActivityStream(this.name, this.seed);
+      const state = activity.getState();
+      state.seed = this.seed;
+      activity.setState(state);
+
+      this.returnToRemote({ via: "deterministic-contract", streamId: activity.getState()._id });
+      resolve(true);
+    });
+  }
+}

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -190,6 +190,8 @@ async function main(): Promise<boolean> {
 
     await runNegativeTests(report, nodes, returnerId);
 
+    await runDeterministicStreamTests(report, nodes);
+
     await runSpiTests(report, nodes, identity, NAMESPACE, returnerId);
 
     return report.summary();
@@ -293,6 +295,66 @@ async function runNegativeTests(report: Report, nodes: NetworkNode[], returnerId
     } else {
       report.fail(`Expected a rejected result with "Stream contract locked", got: ${JSON.stringify(result.$summary)}`);
     }
+  }
+}
+
+/**
+ * Deterministic stream ids (this.newActivityStream(name, deterministic)):
+ * a genuinely fresh seed must commit cleanly, and a repeated seed must be
+ * rejected with a real "Deterministic Stream Name Exists" (1530). Covers
+ * the false-positive bug where every deterministic stream, fresh or not,
+ * was rejected as an "existing" collision - root-caused to
+ * ActiveDSConnect.get() always resolving (ActiveRequest.send() never
+ * rejects on a non-2xx status), so detectCollisions()'s
+ * get().then(() => true).catch(() => false) always evaluated to true
+ * regardless of whether the stream actually existed. Fixed by using
+ * ActiveDSConnect.exists() (which checks the resolved body for a real
+ * _id) instead, in packages/protocol/src/protocol/streamUpdater.ts.
+ *
+ * Uses a different origin node for each call (nodes[0] then nodes[1]) so
+ * this also confirms the write from the first call is visible
+ * network-wide by the time the second call's collision check runs, not
+ * just self-consistent on a single node.
+ */
+async function runDeterministicStreamTests(report: Report, nodes: NetworkNode[]): Promise<void> {
+  report.phase("Deterministic streams: fresh seed commits, repeated seed correctly collides");
+
+  const detIdentity = await onboard(nodes[0].baseUrl);
+  const namespace = "dettest";
+  await registerNamespace(nodes[0].baseUrl, detIdentity, namespace);
+  const detContractId = await deployContract(
+    nodes[0].baseUrl,
+    detIdentity,
+    namespace,
+    "deterministic",
+    path.join(__dirname, "contracts/deterministic-contract.ts")
+  );
+
+  const seed = `det-seed-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const streamName = "notabox.identity";
+
+  const { result: first, ms: firstMs } = await timed(() =>
+    runContract(nodes[0].baseUrl, detIdentity, namespace, detContractId, { seed, name: streamName })
+  );
+  const firstOk = !first.$summary?.errors && first.$summary?.commit >= 1;
+  report.record("deterministic-fresh-seed", firstOk, firstMs);
+  if (firstOk) {
+    report.ok(`Fresh deterministic seed committed cleanly via node ${nodes[0].port} (${firstMs}ms)`);
+  } else {
+    report.fail(`Fresh seed unexpectedly rejected: ${JSON.stringify(first.$summary)}`);
+  }
+
+  const { result: second, ms: secondMs } = await timed(() =>
+    runContract(nodes[1].baseUrl, detIdentity, namespace, detContractId, { seed, name: streamName })
+  );
+  const collided =
+    second.$summary?.commit === 0 &&
+    (second.$summary?.errors || []).some((e: string) => e.includes("Deterministic Stream Name Exists"));
+  report.record("deterministic-real-collision", collided, secondMs);
+  if (collided) {
+    report.ok(`Repeated seed correctly rejected with "Deterministic Stream Name Exists" via node ${nodes[1].port} (${secondMs}ms)`);
+  } else {
+    report.fail(`Expected a real collision rejection, got: ${JSON.stringify(second.$summary)}`);
   }
 }
 


### PR DESCRIPTION
## Summary

`this.newActivityStream(name, deterministic)` was completely broken: every deterministic stream, including a genuinely fresh one that had never existed, was rejected with a false `1530 Deterministic Stream Name Exists`.

**Root cause**: `detectCollisions()` in `streamUpdater.ts` checked existence via `db.get(streamId).then(() => true).catch(() => false)`, relying on the promise *rejecting* to mean "not found". But `ActiveDSConnect.get()` sits on top of `ActiveRequest.send()`, which never rejects on a non-2xx HTTP status - it always resolves `{ data: <body> }`, 404 included (see its own `"deposit wants to treat 404 as 200"` comment). So this existence check always resolved `true`, regardless of whether the stream actually existed.

**Fix**: use `ActiveDSConnect.exists()` instead - already the correct version of this check elsewhere in the codebase, since it inspects the resolved body for a real `_id` rather than trusting rejection.

**Secondary, related bug also fixed**: `processStreams()` called `detectCollisions()` without awaiting it, and `detectCollisions()` itself called `append()` without awaiting it in all three of its branches. Since `detectCollisions()` decides commit/reject and `append()` does the actual stream write, the caller (`Process.commit()`) could move past the streams step believing it was done while the real decision/write was still in flight - a second, independent source of the cross-node timing variance described in the original report.

The originally-suspected missing `await this.detectCollisions();` turned out *not* to be the primary cause of the reported false positive (that's the `get()`/`exists()` bug above), but it's a real bug in its own right and is fixed here too.

## Verification

Live-verified against a real 4-node network, before and after, using a new dedicated contract (`tests/network/contracts/deterministic-contract.ts`) that calls `newActivityStream(name, deterministic)`:

- **Unpatched code**: a genuinely fresh, never-before-used seed was rejected on the very first attempt with `1530 Deterministic Stream Name Exists` - reproducing the report exactly.
- **Patched code**: the same fresh seed commits cleanly, and a truly repeated seed is still correctly rejected with a real `1530`.

Added a permanent regression phase (`runDeterministicStreamTests`) to `tests/network/run.ts` covering both cases, run across two different origin nodes to also confirm cross-node consistency. Full suite (120 transactions + all existing phases) passes cleanly with the fix.

Also ran the full unit suite (97/97 passing) and a full monorepo build with no errors.

## Test plan

- [x] `npm run build` - clean
- [x] `npm test` (mocha unit suite) - 97/97 passing
- [x] `npm run test:network` - all phases pass, including the new deterministic-stream regression phase
- [x] Manually confirmed the bug reproduces on unpatched code and is fixed on patched code, live, twice