### PR TITLE
fix(network): origin node ran the expensive SPI lookup for unrelated errors

### DIFF
--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -240,16 +240,10 @@ export class Endpoints {
                           `SPI Checking - Origin Node, Is it wrong? umid: ${tx.$umid}`
                         );
                         if (
-                          // Other nodes telling me I am wrong (as I am origin)
-                          // so more than 50% should say that otherwise only 1 of them could be wrong
-                          (summary.errors?.filter(
-                            (e) => e.indexOf("Stream Position Incorrect") !== -1
-                          ).length || 0) >=
-                          Math.floor((summary.errors?.length || 0) / 3) || // the majority disagreed
-                          // However what about I am the only one that is wrong (As they may send via me)
-                          tx.$nodes[Home.reference].error?.indexOf(
-                            "Stream Position Incorrect"
-                          ) !== -1
+                          Endpoints.shouldTriggerSpiLookup(
+                            summary.errors,
+                            tx.$nodes[Home.reference].error
+                          )
                         ) {
                           ActiveLogger.warn(
                             `SPI Checked - Origin Node, Wrong. Starting lookup umid: ${tx.$umid}`
@@ -675,6 +669,51 @@ export class Endpoints {
   // Method is copied around a lot need to normalise this.
   // Just updated to filter out labled selfsign which should fix the SPI
   // process instead of getting "unknown" errors
+  /**
+   * Decides whether the origin node should run the expensive SPI recovery
+   * lookup, given the errors the network returned for a transaction it
+   * originated. Only genuine "Stream Position Incorrect" disagreement is a
+   * signal this node might be desynced - any other error (e.g. a real
+   * "Deterministic Stream Name Exists" collision) is an outcome we already
+   * know and gains nothing from a lookup.
+   *
+   * requiring spiErrorCount > 0 matters: with a small errors.length (1 or
+   * 2, common when not every node's response has come back yet)
+   * Math.floor(length / 3) is 0, so "0 >= 0" used to be trivially true for
+   * ANY error type - sending totally unrelated terminal errors through the
+   * lookup for nothing, every time.
+   *
+   * A second, previously-hidden bug lived in the "am I the only one
+   * that's wrong" check: `selfError?.indexOf(...) !== -1` evaluates to
+   * `true` whenever selfError is undefined (optional chaining short-
+   * circuits to undefined, and undefined !== -1) - so the lookup used to
+   * trigger essentially every time the origin node itself had no error at
+   * all, i.e. whenever it voted/committed fine while other nodes
+   * disagreed - the single most common shape of a consensus failure. Only
+   * ever treat a real "Stream Position Incorrect" match on selfError as a
+   * trigger.
+   *
+   * @private
+   * @static
+   */
+  public static shouldTriggerSpiLookup(
+    errors: string[] | undefined,
+    selfError?: string
+  ): boolean {
+    const spiErrorCount =
+      errors?.filter((e) => e.indexOf("Stream Position Incorrect") !== -1)
+        .length || 0;
+    return (
+      // Other nodes telling me I am wrong (as I am origin) - the majority
+      // disagreed
+      (spiErrorCount > 0 &&
+        spiErrorCount >= Math.floor((errors?.length || 0) / 3)) ||
+      // However what about I am the only one that is wrong (As they may send via me)
+      (selfError !== undefined &&
+        selfError.indexOf("Stream Position Incorrect") !== -1)
+    );
+  }
+
   public static labelOrKey(txIO: any): string[] {
     // Get reference for input or output
     const keys = Object.keys(txIO || {});

--- a/tests/endpoints.test.ts
+++ b/tests/endpoints.test.ts
@@ -1,0 +1,78 @@
+import { Endpoints } from "../packages/network/src/network/endpoints";
+import { expect } from "chai";
+import "mocha";
+
+// Regression coverage for the hpe-19 fix: Endpoints.shouldTriggerSpiLookup()
+// used to be inline boolean logic in InternalInitalise() that decided
+// whether the origin node should run the expensive SPI recovery lookup.
+// With a small errors.length (1 or 2 - common when not every node's
+// response has come back yet) Math.floor(length / 3) is 0, so
+// "spiErrorCount >= 0" was trivially true for ANY error type, not just a
+// real "Stream Position Incorrect" one - sending totally unrelated
+// terminal errors (e.g. a real "Deterministic Stream Name Exists"
+// collision, see [[project_hpe18_deterministic_stream_bug]]) through the
+// lookup for an outcome already known, wasting real wall-clock time for
+// nothing.
+describe("Endpoints.shouldTriggerSpiLookup (Activenetwork) - hpe-19", () => {
+  it("does not trigger for a single unrelated error (previously a false positive)", () => {
+    expect(
+      Endpoints.shouldTriggerSpiLookup(["Deterministic Stream Name Exists"])
+    ).to.equal(false);
+  });
+
+  it("does not trigger for two unrelated errors (previously a false positive)", () => {
+    expect(
+      Endpoints.shouldTriggerSpiLookup([
+        "Deterministic Stream Name Exists",
+        "Deterministic Stream Name Exists",
+      ])
+    ).to.equal(false);
+  });
+
+  it("does not trigger when all nodes agree on the same unrelated error", () => {
+    expect(
+      Endpoints.shouldTriggerSpiLookup([
+        "Deterministic Stream Name Exists",
+        "Deterministic Stream Name Exists",
+        "Deterministic Stream Name Exists",
+        "Deterministic Stream Name Exists",
+      ])
+    ).to.equal(false);
+  });
+
+  it("triggers when a genuine Stream Position Incorrect error meets the majority threshold", () => {
+    expect(
+      Endpoints.shouldTriggerSpiLookup([
+        "Stream Position Incorrect",
+        "Stream Position Incorrect",
+        "Stream Position Incorrect",
+      ])
+    ).to.equal(true);
+  });
+
+  it("does not trigger when only a minority of many errors are Stream Position Incorrect", () => {
+    expect(
+      Endpoints.shouldTriggerSpiLookup([
+        "Stream Position Incorrect",
+        "Some Other Error",
+        "Some Other Error",
+        "Some Other Error",
+        "Some Other Error",
+        "Some Other Error",
+      ])
+    ).to.equal(false);
+  });
+
+  it("triggers when this node's own error is Stream Position Incorrect, regardless of the others", () => {
+    expect(
+      Endpoints.shouldTriggerSpiLookup(
+        ["Deterministic Stream Name Exists"],
+        "Stream Position Incorrect"
+      )
+    ).to.equal(true);
+  });
+
+  it("does not trigger with no errors at all", () => {
+    expect(Endpoints.shouldTriggerSpiLookup(undefined)).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #46 / v4.3.1. Even with that fix, a genuine `Deterministic Stream Name Exists` collision (or any other unrelated error) could still trigger the origin node's expensive SPI recovery lookup for no reason - wasted time for an outcome already known.

`Endpoints.InternalInitalise()`'s origin-side flow decided whether to run the SPI lookup via:

```js
(errors.filter(spiRelated).length >= Math.floor(errors.length / 3)) ||
selfError?.indexOf("Stream Position Incorrect") !== -1
```

Two independent bugs found in this one condition:

1. **The reported issue.** With a small `errors.length` (1 or 2 - common when not every node's response has come back yet), `Math.floor(length / 3)` is `0`, so `spiErrorCount >= 0` was trivially true for *any* error type, not just a real `Stream Position Incorrect` one.
2. **A second, previously-hidden bug found while writing the regression test.** `selfError?.indexOf(...) !== -1` evaluates to `true` whenever `selfError` is `undefined` - optional chaining short-circuits to `undefined`, and `undefined !== -1`. So the lookup also fired whenever the origin node itself had *no error at all* (voted/committed fine while other nodes disagreed) - the single most common shape of a consensus failure.

## Fix

Extracted the decision into `Endpoints.shouldTriggerSpiLookup(errors, selfError)` so it's directly unit-testable, and fixed both bugs: the lookup now only runs when at least one error genuinely contains `"Stream Position Incorrect"`.

## Verification

- 7 new unit tests directly exercising the extracted function (including the exact false-positive shapes from both bugs) - full suite 104/104 passing.
- Full monorepo build clean.
- Live 4-node network suite (`npm run test:network`) passes clean, including:
  - Both genuine SPI-desync scenarios (still correctly recovered - the fix doesn't suppress real SPI recovery)
  - The deterministic-stream collision case from #46 (fast, no wasted lookup)

## Test plan

- [x] `npm run build` - clean
- [x] `npm test` - 104/104 passing (7 new)
- [x] `npm run test:network` - all phases pass