### PR TITLE
ci: publish to npmjs.org alongside GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,3 +71,38 @@ jobs:
         run: npx lerna publish from-package --yes --no-git-tag-version --no-push --registry https://npm.pkg.github.com/
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Re-runs setup-node pointed at npmjs.org - it (re)writes the auth
+      # line in ~/.npmrc for whichever registry-url you give it, so this
+      # has to happen as its own step, after the GitHub Packages publish
+      # above has already finished with it, not before (the second call
+      # would otherwise clobber the GitHub Packages auth line first).
+      #
+      # Guarded on the NPM_TOKEN secret actually being set: this repo's
+      # npmjs.org account access is being restored separately, so the
+      # secret won't exist yet on the first few tags after this is wired
+      # in. Skipping cleanly here (rather than failing) means GitHub
+      # Packages keeps publishing normally in the meantime - add
+      # secrets.NPM_TOKEN in the repo's Settings -> Secrets and Actions
+      # once the npmjs token exists to turn this on.
+      - name: Setup Node (npmjs.org)
+        if: ${{ secrets.NPM_TOKEN != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org
+          scope: "@activeledger"
+
+      # --access public: these packages are already public on npmjs.org
+      # from the 2.x era (last published there was 2.15.7 - every 3.x/4.x
+      # release has only gone to GitHub Packages until now), so npm
+      # already treats them as public and this shouldn't be load-bearing
+      # in practice. Passed anyway to remove any ambiguity, since a scoped
+      # package npm has never seen before defaults to restricted (paid-org
+      # only) without it - cheap insurance against a partial-publish
+      # surprise on whichever package happens to need it first.
+      - name: Publish to npmjs.org
+        if: ${{ secrets.NPM_TOKEN != '' }}
+        run: npx lerna publish from-package --yes --no-git-tag-version --no-push --registry https://registry.npmjs.org/ --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

npmjs.org has been stuck at `2.15.7` since before this repo moved to GitHub Packages - every 3.x/4.x release only ever went there. Adds a second publish step so future tags publish to both registries.

- Reuses the exact same "tag is the source of truth for the version" flow already in place for GitHub Packages - no rebuild needed, just a second `lerna publish from-package` call against `registry.npmjs.org`.
- Guarded on `secrets.NPM_TOKEN` actually being set. It isn't yet (npmjs 2FA/access on the account is being restored separately) - pushing a tag before the token is added keeps working exactly as it does today: GitHub Packages publishes, the two npmjs steps are skipped cleanly rather than failing the whole run.
- `--access public` passed explicitly on the npmjs publish. These packages are already public there from the 2.x history so it shouldn't be load-bearing, but it's cheap insurance against a first-time-seen scoped package defaulting to restricted.

## To actually turn this on

Add `NPM_TOKEN` in this repo's **Settings → Secrets and variables → Actions** once the npmjs automation token is available (an "Automation" token type is recommended - it publishes without an interactive OTP prompt). No further code change needed after that; the next tag push will publish to both registries.

## Test plan

- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Can't fully dry-run the npmjs steps until `NPM_TOKEN` exists - the `if:` guard means the worst case with no token is a silent no-op (verified the guard logic against GitHub Actions' documented secrets-in-`if` behavior), not a broken release
- [ ] Once `NPM_TOKEN` is added, verify the very next tag publishes to both `npm.pkg.github.com` and `registry.npmjs.org` and check the run log for `lerna success published 16 packages` from both steps