### PR TITLE
perf(network): reactive neighbourhood health checks instead of routine full-mesh polling

### DIFF
--- a/packages/network/src/network/maintain.ts
+++ b/packages/network/src/network/maintain.ts
@@ -60,6 +60,20 @@ export class Maintain {
   private static rebasing: boolean = false;
 
   /**
+   * The left/right candidates pairing() last actually acted on - compared
+   * against on each call to detect a genuine change, independent of
+   * Home.left/Home.right (which only update on a truthy candidate, so
+   * comparing directly against them can never represent "still nothing
+   * found yet" as a stable, no-change state - every call before a
+   * neighbour is first found would otherwise look like a change).
+   *
+   * @private
+   * @type {string | null}
+   */
+  private static lastPairedLeft: string | null = null;
+  private static lastPairedRight: string | null = null;
+
+  /**
    * How many seconds between service calls
    * There is a random assignment of +/- 10 seconds.
    *
@@ -74,6 +88,22 @@ export class Maintain {
     (20 + Math.floor(Math.random() * 15) + -10) * 1000;
 
   private static home: Home;
+
+  /**
+   * True while a healthTimer() polling chain is actively running (started,
+   * not yet stopped by full discovery). Guards against two independent
+   * chains running in parallel - Maintain.init() (called once from cli.ts
+   * at process boot) and Host's own listener-ready callback both call
+   * healthTimer(true) for the very same process, which otherwise starts a
+   * second, fully redundant chain of its own recursive setTimeout calls -
+   * doubling every discovery knock and log line for no benefit. Reset once
+   * a chain naturally stops (full discovery), so a later legitimate
+   * restart still works.
+   *
+   * @private
+   * @type {boolean}
+   */
+  private static timerActive: boolean = false;
 
   /**
    * Creates an instance of Maintain
@@ -114,7 +144,28 @@ export class Maintain {
    * @param {boolean} [boot=false]
    */
   public static healthTimer(boot: boolean = false) {
+    if (boot) {
+      if (Maintain.timerActive) {
+        // A chain is already running (see timerActive's own comment) -
+        // starting a second one would just double every discovery knock
+        // and log line for the rest of the discovery phase, for no
+        // benefit.
+        return;
+      }
+      Maintain.timerActive = true;
+    }
     if (Maintain.allNeighboursDiscovered()) {
+      // First tick where every configured neighbour is accounted for -
+      // routine full-mesh polling stops here for good (health tracking
+      // continues reactively instead, see Neighbour's own knock()
+      // failure handling). Worth a real log line since it won't fire
+      // again until a fresh boot or network reset.
+      const home = Maintain.neighbourOrder.filter((n) => n.isHome).length;
+      const leaving = Maintain.neighbourOrder.filter((n) => n.graceStop).length;
+      ActiveLogger.info(
+        `Neighbourhood fully discovered (${home} home, ${leaving} leaving, ${Maintain.neighbourOrder.length} configured) - routine polling stopped, health now tracked reactively`
+      );
+      Maintain.timerActive = false;
       return;
     }
     setTimeout(() => {
@@ -352,17 +403,29 @@ export class Maintain {
       if (isRight && isLeft) break;
     }
 
-    if (
-      (isLeft && Home.left.reference != isLeft.reference) ||
-      Home.right.reference != isRight?.reference
-    ) {
-      // Set direct neighbours onto home
-      ActiveLogger.debug(
-        { left: isLeft?.reference, right: isRight?.reference },
-        "New Neighbour Update"
+    const leftRef = isLeft?.reference ?? null;
+    const rightRef = isRight?.reference ?? null;
+
+    if (leftRef !== Maintain.lastPairedLeft || rightRef !== Maintain.lastPairedRight) {
+      // Compared against lastPairedLeft/Right, not Home.left/Home.right -
+      // those only update on a truthy candidate (setNeighbours() is a
+      // no-op for null), so they can never represent "still nothing found
+      // yet" as a stable value. Comparing directly against them meant
+      // every single call before a neighbour was first found looked like
+      // a change, logging (and redundantly calling setNeighbours(), with
+      // its subprocess IPC update) on every tick instead of only on an
+      // actual topology change.
+      Maintain.lastPairedLeft = leftRef;
+      Maintain.lastPairedRight = rightRef;
+
+      // A real topology change (who this node routes consensus through),
+      // worth an INFO line with host:port rather than raw reference
+      // hashes, which aren't meaningful at a glance.
+      ActiveLogger.info(
+        `Left/right neighbour update - left=${isLeft ? `${isLeft.host}:${isLeft.port}` : "none"} right=${isRight ? `${isRight.host}:${isRight.port}` : "none"}`
       );
       try {
-        Maintain.home.setNeighbours(isLeft?.reference || null, isRight?.reference || null);
+        Maintain.home.setNeighbours(leftRef, rightRef);
       }catch{
         ActiveLogger.fatal("Problem setting Right, Try again next loop");
         //this.pairing();

--- a/packages/network/src/network/maintain.ts
+++ b/packages/network/src/network/maintain.ts
@@ -94,34 +94,94 @@ export class Maintain {
   /**
    * Maintain Network health
    *
+   * Poll fast (300ms) until this node is Stable (paired with a
+   * left/right), then at the normal ~10-25s cadence until every
+   * *configured* neighbour has actually been discovered - not just the
+   * two needed to pair. Stable only means "found 2" - on a network with
+   * 3+ neighbours, stopping as soon as that's true left a genuine, live
+   * neighbour that just hadn't answered yet permanently undiscovered
+   * (nothing left to ever knock it, since reactive tracking only kicks
+   * in for a neighbour that's already been marked home at least once).
+   * Once every neighbour is accounted for (home or gracefully stopping),
+   * this routine full-mesh poll stops entirely: health from then on is
+   * tracked reactively instead (see Neighbour's own knock() failure
+   * handling, which marks a specific neighbour down and self-polls just
+   * that one node until it recovers - and checkNeighbourhood()'s own
+   * failure path below, which does the equivalent for a neighbour this
+   * node has never yet reached at all).
+   *
    * @public
    * @param {boolean} [boot=false]
    */
   public static healthTimer(boot: boolean = false) {
+    if (Maintain.allNeighboursDiscovered()) {
+      return;
+    }
     setTimeout(() => {
       Maintain.healthTimer();
     }, Maintain.getInterval());
     if (!boot) {
-      if (Maintain.home && Maintain.home.getStatus() !== NeighbourStatus.Stable) {
-        ActiveLogger.debug("Checking Neighbourhood");
-      }
+      ActiveLogger.debug("Checking Neighbourhood");
       Maintain.checkNeighbourhood();
     }
   }
 
   /**
-   * Cold boot connection to network faster
+   * True once every configured neighbour is either home or intentionally
+   * leaving (graceStop) - the point past which the routine full-mesh
+   * poll has nothing left to discover.
+   *
+   * @private
+   * @static
+   * @returns {boolean}
+   */
+  private static allNeighboursDiscovered(): boolean {
+    return (
+      !!Maintain.neighbourOrder &&
+      Maintain.neighbourOrder.every(
+        (neighbour) => neighbour.isHome || neighbour.graceStop
+      )
+    );
+  }
+
+  /**
+   * Cold boot connection to network faster.
+   *
+   * Was gated on Stable (just 2 paired neighbours - enough for left/right,
+   * not enough to have found every configured neighbour on a 3+-node
+   * network), not on full discovery - so on a network where Stable is
+   * reached before every neighbour has actually responded once, this could
+   * jump straight from the fast 300ms boot cadence to the slow 10-25s
+   * cadence while neighbours were still genuinely undiscovered. Since
+   * healthTimer() already stops polling entirely once
+   * allNeighboursDiscovered() is true, there's no reason for an
+   * intermediate slow-but-still-polling phase at all - stay fast for the
+   * whole discovery phase, however long that takes, then stop.
    *
    * @private
    * @static
    * @returns {number}
    */
   private static getInterval(): number {
-    if (Maintain.home.getStatus() != NeighbourStatus.Stable) {
+    if (!Maintain.allNeighboursDiscovered()) {
       return 300;
     } else {
       return Maintain.interval;
     }
+  }
+
+  /**
+   * Re-runs pairing with each neighbour's current isHome state, without
+   * a network re-knock. Called whenever a neighbour's own reactive health
+   * tracking flips its isHome flag (see Neighbour), so left/right update
+   * immediately instead of waiting on a routine recheck that no longer
+   * runs once Stable.
+   *
+   * @public
+   * @static
+   */
+  public static pairNow(): void {
+    Maintain.pairing();
   }
 
   /**
@@ -217,12 +277,12 @@ export class Maintain {
               resolve();
             })
             .catch(() => {
-              // Still the same network?
-              if (currentRef == Home.reference) {
-                // Node isn't home (Any error is a bad error)
-                // TODO redo all of this
-                //neighbour.isHome = false;
-              }
+              // Not home yet - nothing more to do here. allNeighboursDiscovered()
+              // (above) keeps this fast (300ms) periodic check running until
+              // every configured neighbour has been found, so a neighbour that
+              // simply hasn't started listening yet just gets retried on the
+              // next tick - no need for the separate, much slower (3s) per-
+              // neighbour recovery-poll loop to also chase it during boot.
               // This isn't a failure so resolve to move on.
               resolve();
             });

--- a/packages/network/src/network/neighbour.ts
+++ b/packages/network/src/network/neighbour.ts
@@ -29,6 +29,13 @@ import { ActiveClone } from "@activeledger/activeutilities";
 import { Home } from "./home";
 import { Neighbourhood } from "./neighbourhood";
 import { P2PClient } from "./p2pClient";
+import { Maintain } from "./maintain";
+
+// How often to re-check a neighbour that's been marked unavailable, once
+// it's known to be down. Deliberately much tighter than the old routine
+// full-mesh interval (~10-25s) since this only ever runs for a neighbour
+// already suspected down, not the whole neighbourhood on a schedule.
+const RECOVERY_CHECK_INTERVAL = 3 * 1000;
 
 /**
  * Manages Node Connection Information
@@ -58,6 +65,18 @@ export class Neighbour implements ActiveDefinitions.INeighbourBase {
    * @type {boolean}
    */
   public graceStop: boolean = false;
+
+  /**
+   * True while a recovery poll loop is actively re-checking this
+   * neighbour after being marked unavailable. Guards against
+   * markUnavailable() spawning a second concurrent poll loop if further
+   * knocks to this same down neighbour keep failing while one is already
+   * running.
+   *
+   * @private
+   * @type {boolean}
+   */
+  private recovering: boolean = false;
 
   /**
    * Creates an instance of NodeNeighbour.
@@ -171,7 +190,19 @@ export class Neighbour implements ActiveDefinitions.INeighbourBase {
           false,
           60
         )
-          .then(resolve)
+          .then((response: any) => {
+            // Same reasoning as the bundled branch below - ActiveRequest.send()
+            // never rejects, even on a genuine connection failure, resolving
+            // { data: null } instead. Without this check, knock("status")
+            // against a genuinely down neighbour would resolve "successfully"
+            // with null data - which is exactly what checkNeighbourhood() and
+            // Neighbour's own recovery poll use to decide a node is home.
+            if (response?.data === null) {
+              reject(new Error("Request Failed"));
+            } else {
+              resolve(response);
+            }
+          })
           .catch(reject);
       });
     } else {
@@ -221,23 +252,42 @@ export class Neighbour implements ActiveDefinitions.INeighbourBase {
               60
             )
               .then((response: any) => {
-                if (!bundle) {
-                  if (response.data?.$enc && response.data.$packet) {
-                    response.data = JSON.parse(
-                      Buffer.from(
-                        Home.identity.decrypt(response.data.$packet),
-                        "base64"
-                      ).toString()
-                    );
+                if (bundle) {
+                  // ActiveRequest.send() never rejects, even on a genuine
+                  // connection failure (ECONNREFUSED, timeout, etc.) - it
+                  // resolves { data: null } instead (see
+                  // packages/utilities/src/request.ts). That's the only
+                  // failure signal available here. This branch previously
+                  // never called resolve()/reject() at all regardless of
+                  // outcome, so a bundled knock's returned promise just
+                  // hung forever - silently swallowing every bundled-
+                  // broadcast failure rather than surfacing it.
+                  if (response?.data === null) {
+                    this.markUnavailable();
+                    reject(new Error("Bundled Request Failed"));
+                  } else {
+                    resolve({ ok: 1 });
                   }
-                  resolve(response);
+                  return;
                 }
+                if (response.data?.$enc && response.data.$packet) {
+                  response.data = JSON.parse(
+                    Buffer.from(
+                      Home.identity.decrypt(response.data.$packet),
+                      "base64"
+                    ).toString()
+                  );
+                }
+                resolve(response);
               })
               .catch((error: any) => {
+                // In practice unreachable while ActiveRequest.send() never
+                // rejects (see above) - kept as a defensive fallback in
+                // case that ever changes, or for a genuinely synchronous
+                // throw elsewhere in this chain.
                 if (error && error.response && error.response.data) {
                   reject(error.response.data);
                 } else {
-                  // TODO : If connection failure rebase neighbourhood?
                   if (
                     resend &&
                     resend >= attempts &&
@@ -253,6 +303,14 @@ export class Neighbour implements ActiveDefinitions.INeighbourBase {
                       error,
                       `Network Error - ${this.host}:${this.port}/${endpoint}`
                     );
+                    // Retries (if any) are exhausted - a genuine,
+                    // unrecoverable-for-now connection failure to this
+                    // specific neighbour. This is the reactive signal
+                    // that replaces routine health polling: mark it down
+                    // and start re-checking just this one node until it
+                    // comes back, instead of blind-knocking the whole
+                    // neighbourhood on a timer.
+                    this.markUnavailable();
                     if (extraHeader !== "X-Bundle: 1") {
                       reject("Network Communication Error");
                     } else {
@@ -309,6 +367,74 @@ export class Neighbour implements ActiveDefinitions.INeighbourBase {
         return sender(Buffer.from(JSON.stringify(post)), "X-Null: 0");
       }
     }
+  }
+
+  /**
+   * Marks this neighbour as unavailable (it was previously home, a real
+   * knock to it just failed) and starts monitoring it for recovery. A
+   * no-op if it's already known down or is intentionally leaving the
+   * network (graceStop).
+   *
+   * @private
+   */
+  private markUnavailable(): void {
+    if (!this.isHome || this.graceStop) {
+      return;
+    }
+    this.isHome = false;
+    ActiveLogger.warn(
+      `Neighbour unavailable, starting recovery checks: ${this.host}:${this.port}`
+    );
+    // Left/right may need to route around this neighbour right away,
+    // rather than waiting on the next scheduled check (which no longer
+    // routinely runs once Stable - see Maintain.healthTimer()).
+    Maintain.pairNow();
+    this.ensureMonitored();
+  }
+
+  /**
+   * Starts recovery polling if this neighbour isn't home and isn't
+   * already being checked - a no-op otherwise.
+   *
+   * @private
+   */
+  private ensureMonitored(): void {
+    if (this.isHome || this.recovering || this.graceStop) {
+      return;
+    }
+    this.recovering = true;
+    this.recoveryCheck();
+  }
+
+  /**
+   * Recovery poll loop for a neighbour marked unavailable. Re-knocks just
+   * this node every RECOVERY_CHECK_INTERVAL until it responds, then marks
+   * it home again and stops. Bails out without resolving if the neighbour
+   * starts gracefully stopping while still down.
+   *
+   * @private
+   */
+  private recoveryCheck(): void {
+    setTimeout(() => {
+      if (this.graceStop) {
+        this.recovering = false;
+        return;
+      }
+      this.knock("status")
+        .then(() => {
+          this.isHome = true;
+          this.recovering = false;
+          ActiveLogger.info(
+            `Neighbour recovered: ${this.host}:${this.port}`
+          );
+          // Reconsider left/right now this neighbour is available again.
+          Maintain.pairNow();
+        })
+        .catch(() => {
+          // Still down - keep checking.
+          this.recoveryCheck();
+        });
+    }, RECOVERY_CHECK_INTERVAL);
   }
 
   /**

--- a/tests/network/harness.ts
+++ b/tests/network/harness.ts
@@ -359,6 +359,115 @@ export class NetworkHarness {
     }
   }
 
+  /**
+   * Stops a single node the same safe way stop() stops all of them
+   * (`activeledger --stop` plus explicit worker-pool cleanup - see stop()'s
+   * own comment for why a raw SIGTERM/kill isn't enough), leaving the rest
+   * of the network running. For simulating one neighbour becoming
+   * unreachable - restartNode() brings it back.
+   *
+   * @param {number} index
+   */
+  public async killNode(index: number): Promise<void> {
+    const node = this.nodes[index];
+    if (!node) {
+      throw new Error(`No node at index ${index}`);
+    }
+
+    const workerPids = node.child.pid ? collectDescendantPids(node.child.pid) : [];
+
+    if (node.child.exitCode === null && !node.child.killed) {
+      await runStop(node.dataDir);
+    }
+
+    await new Promise<void>((resolve) => {
+      if (node.child.exitCode !== null || node.child.killed) {
+        resolve();
+        return;
+      }
+      const timer = setTimeout(() => {
+        try {
+          node.child.kill("SIGKILL");
+        } catch {
+          // already gone
+        }
+      }, 5000);
+      node.child.once("exit", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+
+    try {
+      const pidPath = path.join(node.dataDir, ".PID");
+      const pidData = JSON.parse(fs.readFileSync(pidPath, "utf8"));
+      for (const key of ["activeledger", "activestorage", "activecore", "activerestore"]) {
+        const pid = pidData[key];
+        if (pid && pid !== 0 && isProcessAlive(pid)) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {
+            // already gone
+          }
+        }
+      }
+    } catch {
+      // No .PID file, or already cleaned up - nothing to do.
+    }
+
+    for (const pid of workerPids) {
+      if (isProcessAlive(pid)) {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          // already gone
+        }
+      }
+    }
+  }
+
+  /**
+   * Respawns a node previously stopped via killNode() at the same port,
+   * against the same on-disk data/config (never touched by killNode()),
+   * and waits for it to report status:4 again. Updates this.nodes[index]'s
+   * child handle in place so a later stop()/killNode() call tracks the new
+   * process, not the one killNode() already reaped.
+   *
+   * @param {number} index
+   */
+  public async restartNode(index: number): Promise<void> {
+    const node = this.nodes[index];
+    if (!node) {
+      throw new Error(`No node at index ${index}`);
+    }
+
+    const logFd = fs.openSync(node.logPath, "a");
+    const child = spawn(process.execPath, [LEDGER_ENTRY, "--port", String(node.port)], {
+      cwd: node.dataDir,
+      stdio: ["ignore", logFd, logFd],
+    });
+    this.nodes[index] = { ...node, child };
+
+    const deadline = Date.now() + this.opts.readyTimeoutMs;
+    while (true) {
+      if (Date.now() > deadline) {
+        throw new Error(`Timed out waiting for node ${index} to become ready again`);
+      }
+      if (child.exitCode !== null) {
+        throw new Error(`Node ${index} exited early on restart (code ${child.exitCode}) - see ${node.logPath}`);
+      }
+      try {
+        const status = await httpGetJson(`${node.baseUrl}/a/status`);
+        if (status.status === 4) {
+          return;
+        }
+      } catch {
+        // Not up yet, try again next tick
+      }
+      await sleep(300);
+    }
+  }
+
   public cleanup(): void {
     fs.rmSync(this.rootDir, { recursive: true, force: true });
   }

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -196,6 +196,8 @@ async function main(): Promise<boolean> {
 
     await runSpiTests(report, nodes, identity, NAMESPACE, returnerId);
 
+    await runNodeRecoveryTests(report, harness, nodes, identity, NAMESPACE, returnerId);
+
     return report.summary();
   } finally {
     report.phase("Tearing down network");
@@ -540,6 +542,87 @@ async function runSpiTests(
     report.record("spi-non-origin", ok, ms);
     ok
       ? report.ok(`Transaction succeeded via node ${originNode.port} as origin, desynced peer included (${ms}ms)`)
+      : report.fail(`Failed: ${JSON.stringify(result.$summary)}`);
+  }
+}
+
+/**
+ * Exercises the reactive neighbourhood health-check end to end - the one
+ * scenario that was, until now, only ever verified manually (kill a node
+ * by hand, read the logs). Everything else in this suite tests the happy
+ * path; this is the actual point of the redesign, so it gets its own
+ * automated regression guard against both halves of the failure mode this
+ * session's work fixed:
+ *
+ * - A transaction submitted while a neighbour is down must still complete
+ *   promptly via the remaining nodes, not silently hang waiting on a
+ *   neighbour nothing is going to mark unavailable (the original
+ *   ActiveRequest.send()-never-rejects bug) or on stale/incomplete
+ *   discovery racing the harness's own readiness check (the
+ *   getInterval()/Stable bug) - both fixed earlier in this same PR.
+ * - The network must actually recover once the neighbour comes back, not
+ *   just correctly notice it went away.
+ */
+async function runNodeRecoveryTests(
+  report: Report,
+  harness: NetworkHarness,
+  nodes: NetworkNode[],
+  identity: Identity,
+  namespace: string,
+  returnerId: string
+): Promise<void> {
+  const downNode = nodes[1];
+  const originNode = nodes[0];
+
+  report.phase(`Node recovery: killing node ${downNode.port} mid-operation`);
+  await harness.killNode(downNode.index);
+  report.ok(`Node ${downNode.port} stopped`);
+
+  report.phase(`Node recovery: transaction via node ${originNode.port} with node ${downNode.port} down`);
+  {
+    // Generous relative to the ~1-2s typical transaction time seen
+    // elsewhere in this suite, but a small, deliberate fraction of the
+    // harness's own 20s HTTP timeout - the exact symptom being guarded
+    // against here is a transaction silently riding that timeout out
+    // instead of completing promptly via the 3 remaining nodes.
+    const REGRESSION_THRESHOLD_MS = 12000;
+    try {
+      const { result, ms } = await timed(() =>
+        runContract(originNode.baseUrl, identity, namespace, returnerId, { message: "node-down-recovery" })
+      );
+      const ok = !result.$summary?.errors && ms < REGRESSION_THRESHOLD_MS;
+      report.record("node-down-transaction", ok, ms);
+      if (!result.$summary?.errors && ms < REGRESSION_THRESHOLD_MS) {
+        report.ok(`Transaction completed in ${ms}ms with node ${downNode.port} down (well under the ${REGRESSION_THRESHOLD_MS}ms regression threshold)`);
+      } else if (result.$summary?.errors) {
+        report.fail(`Failed: ${JSON.stringify(result.$summary)}`);
+      } else {
+        report.fail(`Completed in ${ms}ms - at or over the ${REGRESSION_THRESHOLD_MS}ms regression threshold, the network isn't routing around the down node promptly`);
+      }
+    } catch (error) {
+      report.record("node-down-transaction", false, 0);
+      report.fail(`Transaction threw instead of completing - likely hung until the harness's own HTTP timeout: ${error}`);
+    }
+  }
+
+  report.phase(`Node recovery: restarting node ${downNode.port}`);
+  await harness.restartNode(downNode.index);
+  report.ok(`Node ${downNode.port} back up and reporting Stable`);
+
+  // Give the reactive recovery-poll loop (RECOVERY_CHECK_INTERVAL, 3s) a
+  // beat to actually notice and re-mark the node home on the other
+  // nodes' side, not just confirm the restarted node's own status.
+  await new Promise((r) => setTimeout(r, 4000));
+
+  report.phase(`Node recovery: transaction via node ${originNode.port} after node ${downNode.port} recovered`);
+  {
+    const { result, ms } = await timed(() =>
+      runContract(originNode.baseUrl, identity, namespace, returnerId, { message: "node-recovered" })
+    );
+    const ok = !result.$summary?.errors;
+    report.record("node-recovered-transaction", ok, ms);
+    ok
+      ? report.ok(`Transaction succeeded after node ${downNode.port} recovered (${ms}ms)`)
       : report.fail(`Failed: ${JSON.stringify(result.$summary)}`);
   }
 }


### PR DESCRIPTION
## Summary

Stop routinely full-mesh-polling every neighbour every ~10-25s once the network is stable, and instead track health reactively - a neighbour is assumed connected until a real broadcast to it actually fails, at which point it's marked down and individually re-polled every few seconds until it recovers. One fewer permanently-running timer/job per node.

This picks up and completes a previous WIP attempt (branch history squashed - the old commit was explicitly marked "NOT WORKING, do not merge"; this one is verified working).

## Two real bugs found and fixed along the way

1. **`ActiveRequest.send()` never signals failure at all** - not even a rejected promise - for any failure mode, including a genuine dead connection; it always resolves with `{ data: null }` instead. Two places in `neighbour.ts`'s `knock()` assumed a failure would reject and silently swallowed it:
   - The bundled-broadcast sender (every `host.ts` `broadcast()` call): its `.then()` handler only called `resolve()`/`reject()` for the non-bundled case - the bundled branch did neither, so a bundled knock's returned promise just hung forever with zero signal to anyone.
   - The plain GET-without-params path (`knock("status")`, used by `checkNeighbourhood()` and the new recovery poll): resolved "successfully" with null data even against a genuinely dead neighbour - the pre-existing `checkNeighbourhood()` could mark an actually-down node as home.

   Both fixed to treat `response.data === null` as a real failure and reject. Live-verified independently: killed a node in a real network, confirmed both surviving nodes correctly detected the failure and, separately, the later recovery.

2. **`getInterval()`'s fast-boot-vs-normal-cadence switch was gated on `Stable`** (just 2 paired neighbours - not full discovery of every configured neighbour on a 3+-node network). On a network where `Stable` is reached before every neighbour has actually responded once, this jumped straight from the fast 300ms boot cadence to a slow, randomized 10-25s cadence while neighbours were still genuinely undiscovered - a **pre-existing race**, not introduced by this change, but one this change's own `allNeighboursDiscovered()` gate makes straightforward to close properly.

   Caught via live 4-node harness runs and targeted debug logging (since removed): one node discovered only 1 of its 3 real peers, then had a **10-second gap with zero discovery activity** right as the harness (which also only waits for `Stable`) submitted the first transaction - so that transaction's broadcast only reached 1 of 3 peers and stalled, racing the harness's 20s client-side timeout. This explains the exact intermittent symptom (roughly 1-in-4 in testing) that a previous attempt at this left unresolved. That attempt's "self-entry never marked home" theory turned out to be a red herring - self does get marked home correctly, just not instantly.

   Fixed by gating `getInterval()` on `allNeighboursDiscovered()` instead of `Stable` - simpler than a three-phase design too, since `healthTimer()` already stops polling entirely once that's true, so there's no reason for an intermediate slow-but-still-polling phase.

## Test plan

- [x] 15 consecutive clean live 4-node harness runs (`npm run test:network`) after the `getInterval()` fix, versus intermittent ~20s transaction timeouts before it
- [x] Full unit suite: 121/121
- [x] Live-verified the transport-layer fix independently: killed a node in a real 3-node network, confirmed both surviving nodes correctly detected the failure (and later recovery)