### PR TITLE
feat(nano-gateway): lightweight permissioned SSE + read gateway for nano clients

### DIFF
--- a/packages/nano-gateway/.gitignore
+++ b/packages/nano-gateway/.gitignore
@@ -1,0 +1,2 @@
+nano-allowlist.json
+nano-allowlist.*.json

--- a/packages/nano-gateway/LICENSE
+++ b/packages/nano-gateway/LICENSE
@@ -1,0 +1,20 @@
+MIT License (MIT)
+Copyright (c) 2026 Activeledger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/nano-gateway/README.md
+++ b/packages/nano-gateway/README.md
@@ -1,0 +1,56 @@
+# @activeledger/nano-gateway
+
+A lightweight, permissioned SSE + read gateway for [nano](https://github.com/activeledger/nano) light-node clients.
+
+## Why this exists
+
+Activecore (`@activeledger/activecore`, `packages/core`) is nano's originally-planned data source, but it isn't running on the devnet this was built against, and its SSE controller (`controllers/sse.ts`) is written against Node's raw `http.IncomingMessage`/`ServerResponse` API - `res.setHeader()`, `res.write()`, `res.flushHeaders()`, `req.socket.setTimeout()`. The `@activeledger/httpd` this repo actually ships today is built on `uWebSockets.js` (confirmed by reading its published `lib/httpd.js`, not assumed) - route handlers get a raw uWS `HttpResponse`, which has none of those methods. Activecore's SSE path would throw immediately if invoked against it. That's very likely a real, standing cause of Activecore's unreliability, independent of anything else.
+
+This package is a much smaller, purpose-built replacement for just what nano needs: a permissioned SSE subscribe endpoint, and the handful of reads nano's mini-SPI needs. It's modeled directly on `packages/hybrid` - direct database access via `ActiveDSConnect`, no consensus involvement, runs as a companion process alongside a real node.
+
+## What "permissioned" means here
+
+Anyone can read (`GET /api/stream/*`, `POST /api/stream`, `GET /api/tx/*`) - ledger data is public by design, unchanged from how Activecore worked. Only the **subscribe/push channel** is gated: a nano must be on this gateway's allowlist, and must prove it holds the private key for its claimed identity, before it gets a live feed. See `src/auth.ts`.
+
+The handshake: a nano signs `${identity}:${timestamp}` with its own key (the same identity it already onboarded on this ledger and signs attestation transactions with - no separate key-distribution step) and sends `{identity, timestamp, signature}` in the subscribe request body. The gateway checks, in order: is this identity on the allowlist -> is the timestamp fresh (within `authWindowSeconds`, anti-replay) -> does the signature actually verify against a public key read *live off the identity's own `:stream` meta doc* (`meta.authorities[].public`) - not a key handed to the gateway out of band. Revoking a nano is just removing it from the allowlist file.
+
+Auth travels in the POST body, not headers - `@activeledger/httpd`'s `listen()` only forwards a fixed, hardcoded set of headers to route handlers (confirmed by reading its source), and custom `x-nano-*` headers would never arrive.
+
+## Config
+
+On first run, a `config.json` (from `src/default.config.json`) and an empty `nano-allowlist.json` (`[]`) are created next to wherever you run the binary from. Nothing can connect until you add identities to the allowlist:
+
+```json
+[
+  { "identity": "abc123...", "label": "adam's phone", "addedAt": 1788000000000 }
+]
+```
+
+Key config fields (`config.json`):
+
+- `db.url` / `db.database` - **you must fill this in.** Point it at the same datastore your Activeledger node already uses (its self-host port, or wherever its CouchDB-compatible store lives). This package doesn't know how to bootstrap a datastore itself, unlike `activehybrid`'s `selfhost` option - it's meant to run alongside an already-running node.
+- `host` - `0.0.0.0:5270` by default. Change the port if `5270` collides with anything else on the host.
+- `nanoGateway.allowlist` - path to the allowlist file.
+- `nanoGateway.authWindowSeconds` - default `60`.
+- `nanoGateway.heartbeatSeconds` - default `5`. Deliberately short: uWS's default idle timeout is ~10s of no socket traffic, far shorter than Activecore's own 10-*minute* SSE heartbeat (`packages/core/src/heartbeat.ts`) - that mismatch is a second, independent plausible cause of Activecore's SSE being unreliable even where it does run. Don't raise this without checking the uWS idle timeout first.
+
+## Routes
+
+```
+GET  /                       health check
+POST /api/activity/subscribe SSE, permissioned - body: {identity, timestamp, signature, streamIds}
+POST /api/stream              batch read - body: string[] of stream ids -> {streams: [...]}
+GET  /api/stream/:id          single read -> {stream: {...} | null}
+GET  /api/tx/:umid            transaction lookup -> {transaction: {...} | null}
+```
+
+`/api/stream` and `/api/tx/:umid` are **not** wire-compatible with Activecore's equivalents - both had real bugs discovered this session while building the nano client against Activecore's actual source (`getStream()` drops `_id` from its response via a comma-expression bug; `findUmid()` names its response field `umid` when the value is the whole transaction, not a umid string). New code doesn't inherit either. nano's own client (`@activenano/core`'s `MiniSpiClient`/`TransactionResolver`) is written against *this* package's contract.
+
+## Deploying this alongside a running node
+
+1. `npm install -g @activeledger/nano-gateway` (once published) or build from source (`npm run build`, then `node lib/index.js`).
+2. Run it on the same host as your node, or anywhere with network access to the node's real datastore. First run generates `config.json` - edit `db.url`/`db.database` before starting it for real.
+3. Add approved nano identities to `nano-allowlist.json` as they're provisioned.
+4. Expose the port (`5270` by default) the same way the node's own ports are already exposed - a Docker port mapping, and an nginx `location` block proxying to it (SSE needs `proxy_buffering off;` and a long `proxy_read_timeout` - standard nginx SSE config, not anything nano-gateway-specific).
+
+Once this is committed and released, it publishes as its own package with its own bin (`nano-gateway`), so it can run as a sibling process in the same container as the node.

--- a/packages/nano-gateway/__tests__/allowlist.test.js
+++ b/packages/nano-gateway/__tests__/allowlist.test.js
@@ -1,0 +1,44 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { Allowlist } = require("../lib/allowlist.js");
+
+function tmpFile() {
+  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "nano-gw-test-")), "allowlist.json");
+}
+
+test("Allowlist: a fresh/missing file has no approved identities", () => {
+  const list = new Allowlist(tmpFile());
+  assert.equal(list.isApproved("nano-1"), false);
+  assert.deepEqual(list.list(), []);
+});
+
+test("Allowlist: add() then isApproved() round-trips", () => {
+  const list = new Allowlist(tmpFile());
+  list.add({ identity: "nano-1", label: "test device" });
+  assert.equal(list.isApproved("nano-1"), true);
+  assert.equal(list.isApproved("nano-2"), false);
+});
+
+test("Allowlist: add() is idempotent for the same identity", () => {
+  const list = new Allowlist(tmpFile());
+  list.add({ identity: "nano-1" });
+  list.add({ identity: "nano-1", label: "duplicate" });
+  assert.equal(list.list().length, 1);
+});
+
+test("Allowlist: remove() revokes an identity", () => {
+  const list = new Allowlist(tmpFile());
+  list.add({ identity: "nano-1" });
+  list.remove("nano-1");
+  assert.equal(list.isApproved("nano-1"), false);
+});
+
+test("Allowlist: persists across separate instances pointed at the same file", () => {
+  const file = tmpFile();
+  new Allowlist(file).add({ identity: "nano-1" });
+  const reopened = new Allowlist(file);
+  assert.equal(reopened.isApproved("nano-1"), true);
+});

--- a/packages/nano-gateway/__tests__/auth.test.js
+++ b/packages/nano-gateway/__tests__/auth.test.js
@@ -1,0 +1,131 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { ActiveCrypto } = require("@activeledger/activecrypto");
+const { Allowlist } = require("../lib/allowlist.js");
+const { verifyHandshake } = require("../lib/auth.js");
+
+function makeKeyPair() {
+  const generator = new ActiveCrypto.KeyPair("secp256k1");
+  return generator.generate();
+}
+
+function sign(prvPem, payload) {
+  return new ActiveCrypto.KeyPair("secp256k1", prvPem).sign(payload);
+}
+
+function fakeAllowlist(approvedIdentities) {
+  return { isApproved: (id) => approvedIdentities.includes(id) };
+}
+
+function fakeDb(docsById) {
+  return {
+    async get(id) {
+      const doc = docsById[id];
+      if (!doc) throw new Error("not found");
+      return doc;
+    },
+  };
+}
+
+test("verifyHandshake: a correctly signed, allow-listed, fresh handshake passes", async () => {
+  const key = makeKeyPair();
+  const identity = "nano-1";
+  const timestamp = String(Date.now());
+  const payload = `${identity}:${timestamp}`;
+  const signature = sign(key.prv.pkcs8pem, payload);
+
+  const db = fakeDb({ [`${identity}:stream`]: { authorities: [{ public: key.pub.pkcs8pem, type: "secp256k1" }] } });
+  const allowlist = fakeAllowlist([identity]);
+
+  const result = await verifyHandshake({ identity, timestamp, signature }, allowlist, db, 60);
+  assert.equal(result.ok, true);
+});
+
+test("verifyHandshake: rejects an identity not on the allowlist, before ever touching the DB", async () => {
+  const key = makeKeyPair();
+  const identity = "nano-1";
+  const timestamp = String(Date.now());
+  const signature = sign(key.prv.pkcs8pem, `${identity}:${timestamp}`);
+
+  let dbTouched = false;
+  const db = { async get() { dbTouched = true; throw new Error("should not be called"); } };
+  const allowlist = fakeAllowlist([]); // nothing approved
+
+  const result = await verifyHandshake({ identity, timestamp, signature }, allowlist, db, 60);
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /not on the allowlist/);
+  assert.equal(dbTouched, false, "allowlist check must short-circuit before any DB read");
+});
+
+test("verifyHandshake: rejects a stale timestamp outside the auth window", async () => {
+  const key = makeKeyPair();
+  const identity = "nano-1";
+  const staleTimestamp = String(Date.now() - 5 * 60 * 1000); // 5 minutes old
+  const signature = sign(key.prv.pkcs8pem, `${identity}:${staleTimestamp}`);
+
+  const db = fakeDb({ [`${identity}:stream`]: { authorities: [{ public: key.pub.pkcs8pem, type: "secp256k1" }] } });
+  const allowlist = fakeAllowlist([identity]);
+
+  const result = await verifyHandshake({ identity, timestamp: staleTimestamp, signature }, allowlist, db, 60);
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /window/);
+});
+
+test("verifyHandshake: rejects a signature that doesn't verify against the identity's on-ledger key", async () => {
+  const realKey = makeKeyPair();
+  const attackerKey = makeKeyPair();
+  const identity = "nano-1";
+  const timestamp = String(Date.now());
+  // Signed with the WRONG key.
+  const signature = sign(attackerKey.prv.pkcs8pem, `${identity}:${timestamp}`);
+
+  const db = fakeDb({ [`${identity}:stream`]: { authorities: [{ public: realKey.pub.pkcs8pem, type: "secp256k1" }] } });
+  const allowlist = fakeAllowlist([identity]);
+
+  const result = await verifyHandshake({ identity, timestamp, signature }, allowlist, db, 60);
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /did not verify/);
+});
+
+test("verifyHandshake: rejects when the identity has no on-ledger record at all", async () => {
+  const key = makeKeyPair();
+  const identity = "nano-ghost";
+  const timestamp = String(Date.now());
+  const signature = sign(key.prv.pkcs8pem, `${identity}:${timestamp}`);
+
+  const db = fakeDb({}); // nothing on the ledger
+  const allowlist = fakeAllowlist([identity]);
+
+  const result = await verifyHandshake({ identity, timestamp, signature }, allowlist, db, 60);
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /no on-ledger record/);
+});
+
+test("verifyHandshake: a signature valid against the second of several authorities still passes", async () => {
+  const oldKey = makeKeyPair();
+  const currentKey = makeKeyPair();
+  const identity = "nano-1";
+  const timestamp = String(Date.now());
+  const signature = sign(currentKey.prv.pkcs8pem, `${identity}:${timestamp}`);
+
+  const db = fakeDb({
+    [`${identity}:stream`]: {
+      authorities: [
+        { public: oldKey.pub.pkcs8pem, type: "secp256k1" },
+        { public: currentKey.pub.pkcs8pem, type: "secp256k1" },
+      ],
+    },
+  });
+  const allowlist = fakeAllowlist([identity]);
+
+  const result = await verifyHandshake({ identity, timestamp, signature }, allowlist, db, 60);
+  assert.equal(result.ok, true);
+});
+
+test("verifyHandshake: rejects missing headers cleanly, not a throw", async () => {
+  const db = fakeDb({});
+  const allowlist = fakeAllowlist(["nano-1"]);
+  const result = await verifyHandshake({ identity: "nano-1" }, allowlist, db, 60);
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /missing/);
+});

--- a/packages/nano-gateway/package-lock.json
+++ b/packages/nano-gateway/package-lock.json
@@ -1,0 +1,1119 @@
+{
+  "name": "@activeledger/nano-gateway",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@activeledger/nano-gateway",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@activeledger/activecrypto": "^4.4.0",
+        "@activeledger/activedefinitions": "^4.4.0",
+        "@activeledger/activelogger": "^4.4.0",
+        "@activeledger/activeoptions": "^4.4.0",
+        "@activeledger/httpd": "^4.4.0",
+        "typescript": "5.5.4"
+      },
+      "bin": {
+        "nano-gateway": "lib/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "18.0.0",
+        "copyfiles": "2.4.1"
+      }
+    },
+    "node_modules/@activeledger/activecrypto": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@activeledger/activecrypto/-/activecrypto-4.4.0.tgz",
+      "integrity": "sha512-dCfCiRF2EB5ZzP1FMzxXETjTpzZX/3tqJxtzsAxMOw72Un1+6Fd7LQC/m0tp2n0lJqC4NLyuRxZWmHye4UdQFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@activeledger/activelogger": "^4.4.0",
+        "asn1.js": "5.4.1"
+      }
+    },
+    "node_modules/@activeledger/activedefinitions": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@activeledger/activedefinitions/-/activedefinitions-4.4.0.tgz",
+      "integrity": "sha512-g16EfAoKiA2R3mIuei4WkXPs7EshiaTnWQA8ZT7EvOtyUF+EJHRa+RavXFVuunDTC9wXq6DxKBRhb/Zq222uRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/events": "^3.0.0"
+      }
+    },
+    "node_modules/@activeledger/activelogger": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@activeledger/activelogger/-/activelogger-4.4.0.tgz",
+      "integrity": "sha512-JXmi3BBnS/akX2sO8VKH4t8agxJ2N0P88wYdOZgOthWlNIg468gCIQtj++OBg0OZsgDKqkGzFWRo7aGt56xsqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "winston": "^3.15.0",
+        "winston-daily-rotate-file": "^5.0.0"
+      }
+    },
+    "node_modules/@activeledger/activeoptions": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@activeledger/activeoptions/-/activeoptions-4.4.0.tgz",
+      "integrity": "sha512-AM9ArZaS/OkdgA7U+Q1JGfYVLgT+Z5994SmwhlyUB4+ZdZD2FExbo9TjGI7EhiDOx4C7fEU00eyEG4+WBjTKTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@activeledger/activelogger": "^4.4.0",
+        "@activeledger/activeutilities": "^4.4.0",
+        "minimist": "1.2.6"
+      }
+    },
+    "node_modules/@activeledger/activeutilities": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@activeledger/activeutilities/-/activeutilities-4.4.0.tgz",
+      "integrity": "sha512-m6KGQMDndNANGZebAdoDAVuaBFcuwDWQdz7nm+3xkSawYU9iHTdnExKN2aWERgV2Ci6po2Ckz9hOsNRlkZPZ2g==",
+      "license": "MIT",
+      "dependencies": {
+        "msgpackr": "^2.0.1",
+        "undici": "6.18.2"
+      }
+    },
+    "node_modules/@activeledger/httpd": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@activeledger/httpd/-/httpd-4.4.0.tgz",
+      "integrity": "sha512-wzOomXPJeM29HzARWT5r9TWeQPY/Zg6/PKfJ1Tf8fs4ncQRIQ6dt3sQVHN4FPfVxYcbudZvBWvQ/t8LNsaYr/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@activeledger/activelogger": "^4.4.0",
+        "@activeledger/activeutilities": "^4.4.0",
+        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.67.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@types/events": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
+      "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "copyfiles": "copyfiles",
+        "copyup": "copyfiles"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
+    "node_modules/file-stream-rotator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
+      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.1"
+      }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/msgpackr": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.1.0.tgz",
+      "integrity": "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.18.2.tgz",
+      "integrity": "sha512-o/MQLTwRm9IVhOqhZ0NQ9oXax1ygPjw6Vs+Vq/4QRjbOAC3B1GCHy7TYxxbExKlb7bzDRzt9vBWU6BDz0RFfYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uWebSockets.js": {
+      "version": "20.67.0",
+      "resolved": "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#e0f56ebb4b349017f006e14d1cd29052f2a7121d",
+      "license": "Apache-2.0"
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-daily-rotate-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-5.0.0.tgz",
+      "integrity": "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "file-stream-rotator": "^0.6.1",
+        "object-hash": "^3.0.0",
+        "triple-beam": "^1.4.1",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "winston": "^3"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston-transport/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/winston-transport/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/winston/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/packages/nano-gateway/package.json
+++ b/packages/nano-gateway/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@activeledger/nano-gateway",
+  "description": "Lightweight, permissioned SSE + read gateway for nano light-node clients - runs alongside a real Activeledger node, direct DB access like activehybrid, no Activecore dependency.",
+  "version": "0.1.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "blockchain",
+    "dlt",
+    "distributed ledger technology",
+    "ledger",
+    "activeledger",
+    "network",
+    "nano"
+  ],
+  "homepage": "https://github.com/activeledger/activeledger",
+  "preferGlobal": true,
+  "bin": {
+    "nano-gateway": "./lib/index.js"
+  },
+  "scripts": {
+    "start": "node lib/index.js",
+    "build:commonjs": "tsc --outDir lib --module commonjs && copyfiles -f ./src/default.config.json ./lib",
+    "build:es": "tsc --outDir es --module es6 && copyfiles -f ./src/default.config.json ./es",
+    "build": "npm run build:commonjs && npm run build:es",
+    "test": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/activeledger/activeledger.git"
+  },
+  "bugs": {
+    "url": "https://github.com/activeledger/activeledger/issues"
+  },
+  "author": "Activeledger",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "18.0.0",
+    "copyfiles": "2.4.1"
+  },
+  "files": [
+    "es",
+    "lib"
+  ],
+  "types": "./lib/index.d.ts",
+  "jsnext:main": "./es/index.js",
+  "module": "./es/index.js",
+  "dependencies": {
+    "@activeledger/activecrypto": "^4.4.0",
+    "@activeledger/activedefinitions": "^4.4.0",
+    "@activeledger/activelogger": "^4.4.0",
+    "@activeledger/activeoptions": "^4.4.0",
+    "@activeledger/httpd": "^4.4.0",
+    "typescript": "5.5.4"
+  }
+}

--- a/packages/nano-gateway/src/allowlist.ts
+++ b/packages/nano-gateway/src/allowlist.ts
@@ -1,0 +1,79 @@
+/*
+ * MIT License (MIT)
+ * Copyright (c) 2026 Activeledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import * as fs from "fs";
+
+/**
+ * One approved nano client. `identity` is the stream id nano onboarded on
+ * this same ledger (the same value it signs attestation transactions
+ * with) - no separate key-distribution step needed, since the actual
+ * public key material is looked up live from that identity's own
+ * `:stream` meta doc (`meta.authorities[].public`) at auth time. `label`
+ * is operator-facing only.
+ */
+export interface IAllowlistEntry {
+  identity: string;
+  label?: string;
+  addedAt?: number;
+}
+
+/**
+ * File-backed, hand-managed allowlist - "we need to make it so 'allowed'
+ * nanos can connect" (the user's own framing). No on-chain governance
+ * yet, deliberately - an operator approves a nano by adding its identity
+ * to this file and reloading. Reload happens per-request (cheap - a small
+ * JSON file, and correctness of "did the operator just revoke this nano"
+ * matters more here than shaving a filesystem read).
+ */
+export class Allowlist {
+  constructor(private filePath: string) {}
+
+  public isApproved(identity: string): boolean {
+    return this.load().some((entry) => entry.identity === identity);
+  }
+
+  public list(): IAllowlistEntry[] {
+    return this.load();
+  }
+
+  public add(entry: IAllowlistEntry): void {
+    const current = this.load();
+    if (current.some((e) => e.identity === entry.identity)) return;
+    current.push({ ...entry, addedAt: entry.addedAt ?? Date.now() });
+    fs.writeFileSync(this.filePath, JSON.stringify(current, null, 2) + "\n");
+  }
+
+  public remove(identity: string): void {
+    const current = this.load().filter((e) => e.identity !== identity);
+    fs.writeFileSync(this.filePath, JSON.stringify(current, null, 2) + "\n");
+  }
+
+  private load(): IAllowlistEntry[] {
+    if (!fs.existsSync(this.filePath)) return [];
+    try {
+      return JSON.parse(fs.readFileSync(this.filePath, "utf8")) as IAllowlistEntry[];
+    } catch {
+      return [];
+    }
+  }
+}

--- a/packages/nano-gateway/src/auth.ts
+++ b/packages/nano-gateway/src/auth.ts
@@ -1,0 +1,98 @@
+/*
+ * MIT License (MIT)
+ * Copyright (c) 2026 Activeledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { ActiveCrypto } from "@activeledger/activecrypto";
+import { ActiveDSConnect } from "@activeledger/activeoptions";
+import { Allowlist } from "./allowlist";
+
+/** Matches the (loosely typed, not in @activeledger/activedefinitions) shape of meta.authorities - see packages/contracts/src/stream.ts's addAuthority()/ILedgerAuthority. */
+interface IMetaAuthority {
+  public: string;
+  type: string;
+}
+
+export interface IAuthResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Verifies a nano client's signed connection handshake:
+ *   x-nano-identity:  the identity stream id it onboarded on this ledger
+ *   x-nano-timestamp: unix ms, must be within authWindowSeconds of now (anti-replay)
+ *   x-nano-signature: signature over `${identity}:${timestamp}`
+ *
+ * Three checks, in order (cheapest/most likely-to-fail first, so a bad
+ * actor doesn't get a free DB read before failing the allowlist check):
+ * allowlist membership -> timestamp freshness -> signature verifies
+ * against a public key actually read live off this identity's own
+ * `:stream` meta doc (not a key handed to the gateway out of band - the
+ * ledger itself is the source of truth for what a nano's current keys
+ * are, same as PermissionsChecker's own signature checks use).
+ */
+export async function verifyHandshake(
+  headers: { identity?: string; timestamp?: string; signature?: string },
+  allowlist: Allowlist,
+  db: ActiveDSConnect,
+  authWindowSeconds: number
+): Promise<IAuthResult> {
+  const { identity, timestamp, signature } = headers;
+  if (!identity || !timestamp || !signature) {
+    return { ok: false, reason: "missing x-nano-identity/x-nano-timestamp/x-nano-signature headers" };
+  }
+
+  if (!allowlist.isApproved(identity)) {
+    return { ok: false, reason: "identity is not on the allowlist" };
+  }
+
+  const ts = Number(timestamp);
+  if (!Number.isFinite(ts) || Math.abs(Date.now() - ts) > authWindowSeconds * 1000) {
+    return { ok: false, reason: "timestamp is missing, invalid, or outside the allowed window" };
+  }
+
+  let meta: { authorities?: IMetaAuthority[] };
+  try {
+    meta = await db.get(`${identity}:stream`);
+  } catch {
+    return { ok: false, reason: "identity has no on-ledger record" };
+  }
+
+  const authorities = meta.authorities ?? [];
+  if (authorities.length === 0) {
+    return { ok: false, reason: "identity has no registered authorities on-ledger" };
+  }
+
+  const payload = `${identity}:${timestamp}`;
+  for (const authority of authorities) {
+    try {
+      const key = new ActiveCrypto.KeyPair(authority.type, authority.public);
+      if (key.verify(payload, signature)) {
+        return { ok: true };
+      }
+    } catch {
+      // Try the next authority - a malformed key on one authority shouldn't fail every check.
+    }
+  }
+
+  return { ok: false, reason: "signature did not verify against any of the identity's registered authorities" };
+}

--- a/packages/nano-gateway/src/changesWatcher.ts
+++ b/packages/nano-gateway/src/changesWatcher.ts
@@ -1,0 +1,69 @@
+/*
+ * MIT License (MIT)
+ * Copyright (c) 2026 Activeledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { ActiveDSConnect } from "@activeledger/activeoptions";
+import { ActiveDefinitions } from "@activeledger/activedefinitions";
+
+/**
+ * Same "skip anything with a : in its _id" filter Activecore's own
+ * subscriptions.ts uses (dontSkip()) - umid/volatile/stream meta docs
+ * aren't activity stream state changes.
+ */
+function isStateDocChange(change: { doc: { _id: string; $activeledger?: { delete?: boolean; rewrite?: boolean } } }): boolean {
+  return (
+    change.doc._id.indexOf(":") === -1 &&
+    (!change.doc.$activeledger || (!change.doc.$activeledger.delete && !change.doc.$activeledger.rewrite))
+  );
+}
+
+/**
+ * One watcher per subscribe connection (matches Activecore's own
+ * per-connection pattern in subscriptions.ts, not a regression) - opens a
+ * live changes feed against the real datastore and calls back only for
+ * changes to streams in `streamIds`. A future optimisation could share one
+ * underlying feed across connections; not needed for v1's correctness.
+ */
+export class ChangesWatcher {
+  private feed: ActiveDefinitions.IActiveDSChanges | null = null;
+
+  constructor(private db: ActiveDSConnect, private streamIds: Set<string>) {}
+
+  public start(onChange: (doc: Record<string, unknown> & { _id: string; _rev: string }) => void, onError: (error: unknown) => void): void {
+    const result = this.db.changes({ live: true, since: "now", include_docs: true });
+    // The interface's return type is `Promise<any> | IActiveDSChanges` - live:true always takes the sync branch (dsconnect.ts's changes()).
+    this.feed = result as ActiveDefinitions.IActiveDSChanges;
+
+    this.feed.on("change", (change: { doc: Record<string, unknown> & { _id: string; _rev: string } }) => {
+      if (!isStateDocChange(change as any)) return;
+      if (!this.streamIds.has(change.doc._id)) return;
+      onChange(change.doc);
+    });
+
+    this.feed.on("error", onError);
+  }
+
+  public stop(): void {
+    this.feed?.cancel();
+    this.feed = null;
+  }
+}

--- a/packages/nano-gateway/src/default.config.json
+++ b/packages/nano-gateway/src/default.config.json
@@ -1,0 +1,18 @@
+{
+  "debug": true,
+  "host": "0.0.0.0:5270",
+  "db": {
+    "url": "http://[user]:[pass]@[host]:[port]",
+    "database": "activeledger",
+    "event": "activeledgerevents",
+    "error": "activeledgererrors"
+  },
+  "nanoGateway": {
+    "allowlist": "./nano-allowlist.json",
+    "authWindowSeconds": 60,
+    "heartbeatSeconds": 5
+  },
+  "CORS": [
+    "*"
+  ]
+}

--- a/packages/nano-gateway/src/index.ts
+++ b/packages/nano-gateway/src/index.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+/*
+ * MIT License (MIT)
+ * Copyright (c) 2026 Activeledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * packages/hybrid/src/index.ts (this repo) carries a prior developer's own
+ * design note asking almost this exact question: "With IoT and core no
+ * auth, I wonder if the solution is they sign a code with their key to
+ * get the SSE connection accepted?" - concluded "NOT FOR NOW" at the time.
+ * This package is that idea, built for nano clients specifically. See
+ * ./auth.ts.
+ */
+
+import * as fs from "fs";
+import { ActiveOptions } from "@activeledger/activeoptions";
+import { ActiveLogger } from "@activeledger/activelogger";
+import { NanoGatewayServer } from "./server";
+
+ActiveOptions.init();
+
+const configPath = ActiveOptions.get<string>("config", "./config.json");
+if (!fs.existsSync(configPath)) {
+  const defaultConfig = fs.readFileSync(__dirname + "/default.config.json", "utf8");
+  fs.writeFileSync(configPath, defaultConfig);
+  ActiveLogger.info(`Created nano-gateway config file at ${configPath}`);
+}
+ActiveOptions.parseConfig();
+
+if (!ActiveOptions.get("db", false)) {
+  ActiveLogger.fatal("Configuration file incomplete - no db connection configured");
+  process.exit(1);
+}
+
+const gatewayConfig = ActiveOptions.get<{ allowlist: string }>("nanoGateway", { allowlist: "./nano-allowlist.json" });
+if (!fs.existsSync(gatewayConfig.allowlist)) {
+  fs.writeFileSync(gatewayConfig.allowlist, "[]\n");
+  ActiveLogger.info(`Created empty allowlist at ${gatewayConfig.allowlist} - no nanos can connect until you add identities to it`);
+}
+
+ActiveLogger.enableDebug = ActiveOptions.get<boolean>("debug", false);
+
+const server = new NanoGatewayServer();
+server.start(ActiveOptions.get<boolean>("debug", false));

--- a/packages/nano-gateway/src/routes/stream.ts
+++ b/packages/nano-gateway/src/routes/stream.ts
@@ -1,0 +1,60 @@
+/*
+ * MIT License (MIT)
+ * Copyright (c) 2026 Activeledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { ActiveDSConnect } from "@activeledger/activeoptions";
+import { IActiveHttpIncoming } from "@activeledger/httpd";
+
+/**
+ * Single stream read. Deliberately NOT a port of Activecore's getStream()
+ * (packages/core/src/controllers/streams.ts) - that has a real bug
+ * (`delete results._id, results._rev;` is a comma expression, only the
+ * first delete actually runs, so its response is missing _id but keeps
+ * _rev) discovered this session while building the nano client against
+ * it. New code doesn't get to inherit that bug.
+ */
+export async function getStream(incoming: IActiveHttpIncoming, db: ActiveDSConnect): Promise<unknown> {
+  try {
+    const doc = await db.get(incoming.url[2]);
+    return { stream: doc };
+  } catch {
+    return { stream: null };
+  }
+}
+
+/**
+ * Batch read, open (no auth - ledger data is public by design, only the
+ * *push/subscribe* channel is permissioned per the user's own framing).
+ * Body is a plain JSON array of stream ids, matching Activecore's
+ * getStreams() request shape so nano's MiniSpiClient needs no changes here.
+ */
+export async function getStreams(incoming: IActiveHttpIncoming, db: ActiveDSConnect): Promise<unknown> {
+  const ids: string[] = Array.isArray(incoming.body) ? incoming.body : [];
+  if (ids.length === 0) {
+    return { streams: [] };
+  }
+  const result = await db.allDocs({ keys: ids, include_docs: true });
+  const streams = (result?.rows ?? [])
+    .map((row: { doc?: unknown }) => row.doc)
+    .filter((doc: unknown) => doc !== undefined && doc !== null);
+  return { streams };
+}

--- a/packages/nano-gateway/src/routes/subscribe.ts
+++ b/packages/nano-gateway/src/routes/subscribe.ts
@@ -1,0 +1,102 @@
+/*
+ * MIT License (MIT)
+ * Copyright (c) 2026 Activeledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { ActiveDSConnect } from "@activeledger/activeoptions";
+import { IActiveHttpIncoming } from "@activeledger/httpd";
+import { Allowlist } from "../allowlist";
+import { verifyHandshake } from "../auth";
+import { ChangesWatcher } from "../changesWatcher";
+import { IWritableHttpResponse, NanoSSE } from "../sse";
+
+/**
+ * Auth travels in the POST body, not headers - @activeledger/httpd's
+ * listen() only forwards a fixed, hardcoded set of headers to route
+ * handlers (Accept-Encoding, X-Activeledger, x-activeledger-encrypt,
+ * content-encoding, X-Bundle, Content-Length, Last-Event-ID - confirmed
+ * by reading its published lib/httpd.js), so custom x-nano-* headers
+ * would never arrive. The body is already freely JSON and already how
+ * nano sends its stream-id list, so this just extends that shape rather
+ * than fighting the framework.
+ */
+export interface ISubscribeRequestBody {
+  identity: string;
+  timestamp: number;
+  signature: string;
+  streamIds: string[];
+}
+
+export interface ISubscribeOptions {
+  db: ActiveDSConnect;
+  allowlist: Allowlist;
+  authWindowSeconds: number;
+  heartbeatSeconds: number;
+}
+
+export async function subscribe(
+  incoming: IActiveHttpIncoming,
+  _req: unknown,
+  res: IWritableHttpResponse,
+  options: ISubscribeOptions
+): Promise<"handled"> {
+  const body = (incoming.body ?? {}) as Partial<ISubscribeRequestBody>;
+
+  const auth = await verifyHandshake(
+    {
+      identity: body.identity,
+      timestamp: body.timestamp !== undefined ? String(body.timestamp) : undefined,
+      signature: body.signature,
+    },
+    options.allowlist,
+    options.db,
+    options.authWindowSeconds
+  );
+
+  if (!auth.ok) {
+    res.cork(() => {
+      res.writeStatus("403 Forbidden").writeHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: auth.reason }));
+    });
+    return "handled";
+  }
+
+  const streamIds = Array.isArray(body.streamIds) ? body.streamIds : [];
+  if (streamIds.length === 0) {
+    res.cork(() => {
+      res.writeStatus("400 Bad Request").writeHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "streamIds must be a non-empty array" }));
+    });
+    return "handled";
+  }
+
+  const watcher = new ChangesWatcher(options.db, new Set(streamIds));
+  const sse = new NanoSSE(res, options.heartbeatSeconds, () => watcher.stop());
+
+  watcher.start(
+    (doc) => sse.write({ event: "update", stream: doc, time: Date.now() }),
+    (error) => {
+      sse.write({ event: "error", message: String(error), time: Date.now() });
+    }
+  );
+
+  return "handled";
+}

--- a/packages/nano-gateway/src/routes/tx.ts
+++ b/packages/nano-gateway/src/routes/tx.ts
@@ -1,0 +1,42 @@
+/*
+ * MIT License (MIT)
+ * Copyright (c) 2026 Activeledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { ActiveDSConnect } from "@activeledger/activeoptions";
+import { IActiveHttpIncoming } from "@activeledger/httpd";
+
+/**
+ * Transaction-by-umid lookup, off the `{umid}:umid` doc streamUpdater.ts
+ * writes on commit (packages/protocol/src/protocol/streamUpdater.ts's
+ * compactTxEntry()). Deliberately NOT a port of Activecore's findUmid()
+ * (packages/core/src/controllers/umid.ts) - that returns `{umid: <compact
+ * tx entry>}`, confusingly naming the field after the lookup key rather
+ * than what it actually holds. New code doesn't get to inherit that either.
+ */
+export async function getTransaction(incoming: IActiveHttpIncoming, db: ActiveDSConnect): Promise<unknown> {
+  try {
+    const doc = await db.get(`${incoming.url[2]}:umid`);
+    return { transaction: doc.umid ?? null };
+  } catch {
+    return { transaction: null };
+  }
+}

--- a/packages/nano-gateway/src/server.ts
+++ b/packages/nano-gateway/src/server.ts
@@ -1,0 +1,76 @@
+/*
+ * MIT License (MIT)
+ * Copyright (c) 2026 Activeledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { ActiveHttpd, IActiveHttpIncoming } from "@activeledger/httpd";
+import { ActiveDSConnect, ActiveOptions } from "@activeledger/activeoptions";
+import { ActiveLogger } from "@activeledger/activelogger";
+import { Allowlist } from "./allowlist";
+import { getStream, getStreams } from "./routes/stream";
+import { getTransaction } from "./routes/tx";
+import { subscribe } from "./routes/subscribe";
+import { IWritableHttpResponse } from "./sse";
+
+export class NanoGatewayServer {
+  private httpServer = new ActiveHttpd();
+  private db: ActiveDSConnect;
+  private allowlist: Allowlist;
+
+  constructor() {
+    const db = ActiveOptions.get<{ url: string; database: string }>("db", false as unknown as { url: string; database: string });
+    this.db = new ActiveDSConnect(`${db.url}/${db.database}`);
+
+    const gatewayConfig = ActiveOptions.get<{ allowlist: string; authWindowSeconds: number; heartbeatSeconds: number }>(
+      "nanoGateway",
+      { allowlist: "./nano-allowlist.json", authWindowSeconds: 60, heartbeatSeconds: 5 }
+    );
+    this.allowlist = new Allowlist(gatewayConfig.allowlist);
+
+    this.httpServer.use("/", "GET", () => ({
+      status: "ok",
+      service: "nano-gateway",
+      approvedNanos: this.allowlist.list().length,
+    }));
+
+    this.httpServer.use("/api/stream", "POST", (incoming: IActiveHttpIncoming) => getStreams(incoming, this.db));
+    this.httpServer.use("/api/stream/*", "GET", (incoming: IActiveHttpIncoming) => getStream(incoming, this.db));
+    this.httpServer.use("/api/tx/*", "GET", (incoming: IActiveHttpIncoming) => getTransaction(incoming, this.db));
+
+    this.httpServer.use(
+      "/api/activity/subscribe",
+      "POST",
+      (incoming: IActiveHttpIncoming, req: unknown, res: IWritableHttpResponse) =>
+        subscribe(incoming, req, res, {
+          db: this.db,
+          allowlist: this.allowlist,
+          authWindowSeconds: gatewayConfig.authWindowSeconds,
+          heartbeatSeconds: gatewayConfig.heartbeatSeconds,
+        })
+    );
+  }
+
+  public start(enableLogs = false): void {
+    const [, port] = ActiveOptions.get<string>("host", ":5270").split(":");
+    this.httpServer.listen(parseInt(port, 10), enableLogs);
+    ActiveLogger.info(`nano-gateway listening on 0.0.0.0:${port} (${this.allowlist.list().length} approved nanos)`);
+  }
+}

--- a/packages/nano-gateway/src/sse.ts
+++ b/packages/nano-gateway/src/sse.ts
@@ -1,0 +1,113 @@
+/*
+ * MIT License (MIT)
+ * Copyright (c) 2026 Activeledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * uWebSockets.js-correct SSE helper.
+ *
+ * packages/core (Activecore)'s own SSE class (controllers/sse.ts) is
+ * written against Node's raw http.IncomingMessage/ServerResponse -
+ * res.setHeader(), res.write(), res.flushHeaders(), req.socket.setTimeout().
+ * The @activeledger/httpd this repo actually ships today (confirmed by
+ * reading its published lib/httpd.js, not assumed) is built on
+ * uWebSockets.js - route handlers receive (incoming, req, res) where res
+ * is a raw uWS HttpResponse, which has none of those methods
+ * (writeStatus/writeHeader/write/cork/onAborted instead, no .socket, no
+ * .flushHeaders). Activecore's SSE class would throw immediately if
+ * actually invoked against this. This is a real, working reimplementation,
+ * not a port of the broken one - see docs/nano-gateway.md for why this
+ * package exists at all.
+ *
+ * Two uWS-specific correctness requirements this gets right:
+ * 1. Every write here happens either from an async auth check or a
+ *    setInterval heartbeat - both are outside uWS's default "top of
+ *    handler" cork context, so every write is wrapped in res.cork().
+ * 2. ActiveHttpd's own listen() wrapper already calls res.onAborted() once
+ *    (setting a bolted-on res.writable = false, not part of uWS's real
+ *    HttpResponse type) before invoking any route handler. uWS keeps only
+ *    the latest onAborted handler, so registering a second one here would
+ *    silently replace it - this class's onAborted handler re-sets
+ *    res.writable = false itself to preserve that invariant, on top of
+ *    its own cleanup.
+ */
+
+// Matches ActiveHttpd's own bolted-on res.writable convention (not part of
+// uWS's real HttpResponse type - see class doc comment above).
+export interface IWritableHttpResponse {
+  writable: boolean;
+  cork(cb: () => void): IWritableHttpResponse;
+  writeStatus(status: string): IWritableHttpResponse;
+  writeHeader(key: string, value: string): IWritableHttpResponse;
+  write(chunk: string): boolean;
+  end(body?: string): IWritableHttpResponse;
+  onAborted(handler: () => void): IWritableHttpResponse;
+}
+
+export class NanoSSE {
+  private heartbeat: NodeJS.Timeout | null = null;
+  private closed = false;
+
+  constructor(private res: IWritableHttpResponse, heartbeatSeconds: number, onClose?: () => void) {
+    res.cork(() => {
+      res
+        .writeStatus("200 OK")
+        .writeHeader("Content-Type", "text/event-stream")
+        .writeHeader("Cache-Control", "no-cache")
+        .writeHeader("Access-Control-Allow-Origin", "*");
+    });
+
+    res.onAborted(() => {
+      // Re-set what ActiveHttpd's own onAborted handler would have set -
+      // we've just replaced that handler by registering this one (uWS
+      // keeps only the latest), so this preserves the invariant other
+      // code (findHandler's writeResponse fallbacks) relies on.
+      res.writable = false;
+      this.close();
+      onClose?.();
+    });
+
+    // uWS's default idle timeout is 10s of no traffic on the socket - far
+    // shorter than Activecore's now-provably-too-slow 10-minute heartbeat
+    // (packages/core/src/heartbeat.ts). A short, aggressive default here
+    // is deliberate, not arbitrary.
+    this.heartbeat = setInterval(() => {
+      if (this.closed || !res.writable) return;
+      res.cork(() => {
+        res.write(":\n\n");
+      });
+    }, heartbeatSeconds * 1000);
+  }
+
+  public write(event: unknown): boolean {
+    if (this.closed || !this.res.writable) return false;
+    this.res.cork(() => {
+      this.res.write(`data:${JSON.stringify(event)}\n\n`);
+    });
+    return true;
+  }
+
+  public close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.heartbeat) clearInterval(this.heartbeat);
+  }
+}

--- a/packages/nano-gateway/tsconfig.json
+++ b/packages/nano-gateway/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.settings.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  }
+}


### PR DESCRIPTION
## Summary

New package `@activeledger/nano-gateway` - the devnet's Activecore instance isn't running (old, unreliable), so nano light-node clients need a different data source. Modeled directly on `packages/hybrid`: direct `ActiveDSConnect` access to the same datastore a real node uses, no consensus involvement, runs as a companion process alongside a node.

- **Real, source-verified finding**: `@activeledger/httpd` as actually published (4.4.0) is built on `uWebSockets.js` - route handlers get a raw uWS `HttpResponse`, not Node's `http.ServerResponse`. Activecore's own SSE controller is written against the Node API and would throw if invoked against this today - a plausible real cause of "old and unreliable". `src/sse.ts` here is a correct uWS implementation (cork-wrapped writes, 5s heartbeat against uWS's ~10s default idle timeout, vs. Activecore's 10-*minute* heartbeat).
- **Permission model**: reads stay open (unchanged from Activecore); only the subscribe/push channel is gated. A hand-managed allowlist of approved nano identities; the signature check reads the identity's public key live off its own `:stream` meta doc, not a key handed to the gateway out of band.
- `/api/stream` and `/api/tx/:umid` are deliberately not wire-compatible with Activecore - both have real bugs discovered this session reading Activecore's actual source (`_id` dropped from `getStream()`'s response via a comma-expression bug; `findUmid()`'s response field misleadingly named). New code doesn't inherit either.

## Test plan

- [x] `npm run build` - commonjs + es, clean
- [x] 12 unit tests (allowlist CRUD, auth handshake against real generated secp256k1 keys - correct/wrong key, stale timestamp, unlisted identity, missing on-ledger record)
- [ ] Not yet live-tested against a real datastore - no `db.url`/`db.database` connection string was available this session. See README's deploy section for what a node operator needs to fill in before this can run for real.