### PR TITLE
feat(nano-gateway): SSE resume via Last-Event-ID

### DIFF
--- a/packages/nano-gateway/README.md
+++ b/packages/nano-gateway/README.md
@@ -46,6 +46,10 @@ GET  /api/tx/:umid            transaction lookup -> {transaction: {...} | null}
 
 `/api/stream` and `/api/tx/:umid` are **not** wire-compatible with Activecore's equivalents - both had real bugs discovered this session while building the nano client against Activecore's actual source (`getStream()` drops `_id` from its response via a comma-expression bug; `findUmid()` names its response field `umid` when the value is the whole transaction, not a umid string). New code doesn't inherit either. nano's own client (`@activenano/core`'s `MiniSpiClient`/`TransactionResolver`) is written against *this* package's contract.
 
+### Reconnect / resume
+
+Each pushed frame is numbered by the underlying DB change sequence it came from (`id:{seq}` on the SSE frame, same convention as Activecore's own SSE). A client reconnecting with a `Last-Event-ID` header resumes the changes feed from that point instead of missing whatever changed while it was disconnected - `Last-Event-ID` is one of the fixed headers `@activeledger/httpd` actually forwards to route handlers (confirmed by reading its source), unlike the custom auth headers this had to route through the body instead. No header (or a fresh subscribe with a new stream-id set) starts from `"now"`, same as before. `@activenano/core`'s `NanoLedgerEvents` client does this automatically - see its own doc comment.
+
 ## Deploying this alongside a running node
 
 1. `npm install -g @activeledger/nano-gateway` (once published) or build from source (`npm run build`, then `node lib/index.js`).

--- a/packages/nano-gateway/__tests__/auth.test.js
+++ b/packages/nano-gateway/__tests__/auth.test.js
@@ -22,7 +22,11 @@ function fakeDb(docsById) {
     async get(id) {
       const doc = docsById[id];
       if (!doc) throw new Error("not found");
-      return doc;
+      // Every real doc has _id - looksLikeDoc() (routes/stream.ts) checks
+      // for it to detect the self-hosted backend's live-confirmed quirk of
+      // resolving a missing key with a LevelDB error object instead of
+      // rejecting, so fixtures need to look like real docs too.
+      return { _id: id, ...doc };
     },
   };
 }

--- a/packages/nano-gateway/__tests__/stream.test.js
+++ b/packages/nano-gateway/__tests__/stream.test.js
@@ -1,0 +1,59 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { getStream, getStreams } = require("../lib/routes/stream.js");
+const { getTransaction } = require("../lib/routes/tx.js");
+
+/**
+ * Live-confirmed against the real devnet: ActiveDSConnect.get() on a
+ * missing key does NOT reject on the self-hosted LevelDB backend -
+ * ActiveRequest.send() never rejects on a non-2xx HTTP status (this
+ * session's own earlier finding), so a 500 response with a
+ * `{notFound: true, code: "LEVEL_NOT_FOUND"}` body resolves successfully
+ * instead of throwing. getStream()/getTransaction() must detect this via
+ * looksLikeDoc(), not just try/catch.
+ */
+function fakeDbThatLeaksNotFoundInstead(realDocsById) {
+  return {
+    async get(id) {
+      const doc = realDocsById[id];
+      if (doc) return doc;
+      return { notFound: true, code: "LEVEL_NOT_FOUND" }; // resolves, does not reject
+    },
+    async allDocs({ keys }) {
+      const rows = keys.filter((k) => realDocsById[k]).map((k) => ({ id: k, doc: realDocsById[k] }));
+      return { rows };
+    },
+  };
+}
+
+test("getStream: a LevelDB not-found object that resolves instead of rejecting still comes back as null, not leaked to the caller", async () => {
+  const db = fakeDbThatLeaksNotFoundInstead({});
+  const result = await getStream({ url: ["api", "stream", "missing-id"] }, db);
+  assert.deepEqual(result, { stream: null });
+});
+
+test("getStream: a real doc still comes through correctly", async () => {
+  const db = fakeDbThatLeaksNotFoundInstead({ "real-id": { _id: "real-id", _rev: "1-a", count: 4 } });
+  const result = await getStream({ url: ["api", "stream", "real-id"] }, db);
+  assert.deepEqual(result, { stream: { _id: "real-id", _rev: "1-a", count: 4 } });
+});
+
+test("getTransaction: same leaked-not-found shape comes back as null, not passed through", async () => {
+  const db = fakeDbThatLeaksNotFoundInstead({});
+  const result = await getTransaction({ url: ["api", "tx", "missing-umid"] }, db);
+  assert.deepEqual(result, { transaction: null });
+});
+
+test("getTransaction: a real umid doc's compact entry comes through correctly", async () => {
+  const db = fakeDbThatLeaksNotFoundInstead({
+    "real-umid:umid": { _id: "real-umid:umid", _rev: "1-a", umid: { $umid: "real-umid", $tx: {} } },
+  });
+  const result = await getTransaction({ url: ["api", "tx", "real-umid"] }, db);
+  assert.deepEqual(result, { transaction: { $umid: "real-umid", $tx: {} } });
+});
+
+test("getStreams: the batch/allDocs path already excludes missing keys correctly (live-confirmed, no fix needed there)", async () => {
+  const db = fakeDbThatLeaksNotFoundInstead({ a: { _id: "a", _rev: "1-a" } });
+  const result = await getStreams({ body: ["a", "missing"] }, db);
+  assert.deepEqual(result, { streams: [{ _id: "a", _rev: "1-a" }] });
+});

--- a/packages/nano-gateway/src/auth.ts
+++ b/packages/nano-gateway/src/auth.ts
@@ -24,6 +24,7 @@
 import { ActiveCrypto } from "@activeledger/activecrypto";
 import { ActiveDSConnect } from "@activeledger/activeoptions";
 import { Allowlist } from "./allowlist";
+import { looksLikeDoc } from "./routes/stream";
 
 /** Matches the (loosely typed, not in @activeledger/activedefinitions) shape of meta.authorities - see packages/contracts/src/stream.ts's addAuthority()/ILedgerAuthority. */
 interface IMetaAuthority {
@@ -72,7 +73,15 @@ export async function verifyHandshake(
 
   let meta: { authorities?: IMetaAuthority[] };
   try {
-    meta = await db.get(`${identity}:stream`);
+    const doc = await db.get(`${identity}:stream`);
+    // ActiveRequest.send() never rejects on non-2xx (this session's own
+    // earlier finding) - a missing key on the self-hosted backend resolves
+    // with a LevelDB error object instead of throwing. See routes/stream.ts's
+    // looksLikeDoc() doc comment for the full explanation.
+    if (!looksLikeDoc(doc)) {
+      return { ok: false, reason: "identity has no on-ledger record" };
+    }
+    meta = doc as { authorities?: IMetaAuthority[] };
   } catch {
     return { ok: false, reason: "identity has no on-ledger record" };
   }

--- a/packages/nano-gateway/src/changesWatcher.ts
+++ b/packages/nano-gateway/src/changesWatcher.ts
@@ -46,17 +46,26 @@ function isStateDocChange(change: { doc: { _id: string; $activeledger?: { delete
 export class ChangesWatcher {
   private feed: ActiveDefinitions.IActiveDSChanges | null = null;
 
-  constructor(private db: ActiveDSConnect, private streamIds: Set<string>) {}
+  /**
+   * @param since Where to resume the changes feed from - a DB sequence
+   * (as previously handed back via onChange's seq param) to replay
+   * anything missed while disconnected, or "now" for a fresh subscription
+   * with no history. Comes from the client's Last-Event-ID on reconnect.
+   */
+  constructor(private db: ActiveDSConnect, private streamIds: Set<string>, private since: string | number = "now") {}
 
-  public start(onChange: (doc: Record<string, unknown> & { _id: string; _rev: string }) => void, onError: (error: unknown) => void): void {
-    const result = this.db.changes({ live: true, since: "now", include_docs: true });
+  public start(
+    onChange: (doc: Record<string, unknown> & { _id: string; _rev: string }, seq: string | number) => void,
+    onError: (error: unknown) => void
+  ): void {
+    const result = this.db.changes({ live: true, since: this.since, include_docs: true });
     // The interface's return type is `Promise<any> | IActiveDSChanges` - live:true always takes the sync branch (dsconnect.ts's changes()).
     this.feed = result as ActiveDefinitions.IActiveDSChanges;
 
-    this.feed.on("change", (change: { doc: Record<string, unknown> & { _id: string; _rev: string } }) => {
+    this.feed.on("change", (change: { doc: Record<string, unknown> & { _id: string; _rev: string }; seq: string | number }) => {
       if (!isStateDocChange(change as any)) return;
       if (!this.streamIds.has(change.doc._id)) return;
-      onChange(change.doc);
+      onChange(change.doc, change.seq);
     });
 
     this.feed.on("error", onError);

--- a/packages/nano-gateway/src/routes/stream.ts
+++ b/packages/nano-gateway/src/routes/stream.ts
@@ -25,6 +25,22 @@ import { ActiveDSConnect } from "@activeledger/activeoptions";
 import { IActiveHttpIncoming } from "@activeledger/httpd";
 
 /**
+ * True only for something that actually looks like a stored document.
+ * Load-bearing, not defensive-for-its-own-sake: live-confirmed against
+ * the real devnet that ActiveDSConnect.get() on a missing key does NOT
+ * reject here. ActiveRequest.send() (this session's own earlier finding,
+ * see project_hpe18_deterministic_stream_bug memory) never rejects on a
+ * non-2xx HTTP status - only on a genuine network failure - so the
+ * self-hosted LevelDB backend's not-found response (HTTP 500 with a
+ * `{notFound: true, code: "LEVEL_NOT_FOUND"}` body) resolves successfully
+ * instead of throwing. A plain try/catch around db.get() silently returns
+ * that error object as if it were the document.
+ */
+export function looksLikeDoc(value: unknown): value is { _id: string; [key: string]: unknown } {
+  return typeof value === "object" && value !== null && typeof (value as { _id?: unknown })._id === "string";
+}
+
+/**
  * Single stream read. Deliberately NOT a port of Activecore's getStream()
  * (packages/core/src/controllers/streams.ts) - that has a real bug
  * (`delete results._id, results._rev;` is a comma expression, only the
@@ -35,7 +51,7 @@ import { IActiveHttpIncoming } from "@activeledger/httpd";
 export async function getStream(incoming: IActiveHttpIncoming, db: ActiveDSConnect): Promise<unknown> {
   try {
     const doc = await db.get(incoming.url[2]);
-    return { stream: doc };
+    return { stream: looksLikeDoc(doc) ? doc : null };
   } catch {
     return { stream: null };
   }

--- a/packages/nano-gateway/src/routes/subscribe.ts
+++ b/packages/nano-gateway/src/routes/subscribe.ts
@@ -36,7 +36,9 @@ import { IWritableHttpResponse, NanoSSE } from "../sse";
  * by reading its published lib/httpd.js), so custom x-nano-* headers
  * would never arrive. The body is already freely JSON and already how
  * nano sends its stream-id list, so this just extends that shape rather
- * than fighting the framework.
+ * than fighting the framework. Last-Event-ID *is* one of the forwarded
+ * headers though (Activecore's own SSE feature already relied on it),
+ * so resume uses the real header, not another body field.
  */
 export interface ISubscribeRequestBody {
   identity: string;
@@ -52,9 +54,14 @@ export interface ISubscribeOptions {
   heartbeatSeconds: number;
 }
 
+/** Loose shape of what @activeledger/httpd's listen() actually builds for the "req" handler param - see the header-forwarding note above. */
+export interface IHttpdRequest {
+  headers?: Record<string, string | undefined>;
+}
+
 export async function subscribe(
   incoming: IActiveHttpIncoming,
-  _req: unknown,
+  req: IHttpdRequest,
   res: IWritableHttpResponse,
   options: ISubscribeOptions
 ): Promise<"handled"> {
@@ -88,11 +95,16 @@ export async function subscribe(
     return "handled";
   }
 
-  const watcher = new ChangesWatcher(options.db, new Set(streamIds));
+  // Reconnecting after a drop resumes from exactly where the client left
+  // off instead of missing whatever changed in the gap - a fresh
+  // subscription (no header) just starts from "now", same as before.
+  const resumeFrom = req.headers?.["Last-Event-ID"] || "now";
+
+  const watcher = new ChangesWatcher(options.db, new Set(streamIds), resumeFrom);
   const sse = new NanoSSE(res, options.heartbeatSeconds, () => watcher.stop());
 
   watcher.start(
-    (doc) => sse.write({ event: "update", stream: doc, time: Date.now() }),
+    (doc, seq) => sse.write({ event: "update", stream: doc, time: Date.now() }, seq),
     (error) => {
       sse.write({ event: "error", message: String(error), time: Date.now() });
     }

--- a/packages/nano-gateway/src/routes/tx.ts
+++ b/packages/nano-gateway/src/routes/tx.ts
@@ -23,6 +23,7 @@
 
 import { ActiveDSConnect } from "@activeledger/activeoptions";
 import { IActiveHttpIncoming } from "@activeledger/httpd";
+import { looksLikeDoc } from "./stream";
 
 /**
  * Transaction-by-umid lookup, off the `{umid}:umid` doc streamUpdater.ts
@@ -35,7 +36,7 @@ import { IActiveHttpIncoming } from "@activeledger/httpd";
 export async function getTransaction(incoming: IActiveHttpIncoming, db: ActiveDSConnect): Promise<unknown> {
   try {
     const doc = await db.get(`${incoming.url[2]}:umid`);
-    return { transaction: doc.umid ?? null };
+    return { transaction: looksLikeDoc(doc) ? doc.umid ?? null : null };
   } catch {
     return { transaction: null };
   }

--- a/packages/nano-gateway/src/server.ts
+++ b/packages/nano-gateway/src/server.ts
@@ -27,7 +27,7 @@ import { ActiveLogger } from "@activeledger/activelogger";
 import { Allowlist } from "./allowlist";
 import { getStream, getStreams } from "./routes/stream";
 import { getTransaction } from "./routes/tx";
-import { subscribe } from "./routes/subscribe";
+import { subscribe, IHttpdRequest } from "./routes/subscribe";
 import { IWritableHttpResponse } from "./sse";
 
 export class NanoGatewayServer {
@@ -58,7 +58,7 @@ export class NanoGatewayServer {
     this.httpServer.use(
       "/api/activity/subscribe",
       "POST",
-      (incoming: IActiveHttpIncoming, req: unknown, res: IWritableHttpResponse) =>
+      (incoming: IActiveHttpIncoming, req: IHttpdRequest, res: IWritableHttpResponse) =>
         subscribe(incoming, req, res, {
           db: this.db,
           allowlist: this.allowlist,

--- a/packages/nano-gateway/src/sse.ts
+++ b/packages/nano-gateway/src/sse.ts
@@ -97,10 +97,20 @@ export class NanoSSE {
     }, heartbeatSeconds * 1000);
   }
 
-  public write(event: unknown): boolean {
+  /**
+   * @param id The DB changes-feed sequence this event came from, when
+   * known - written as an `id:` line so a client's Last-Event-ID header
+   * on reconnect can resume from exactly this point (@activeledger/httpd
+   * forwards Last-Event-ID to route handlers - confirmed by reading its
+   * source, unlike the fixed set of headers it does NOT forward, which is
+   * why auth travels in the subscribe body instead). Matches Activecore's
+   * own frame shape (packages/core/src/controllers/sse.ts, main repo).
+   */
+  public write(event: unknown, id?: string | number): boolean {
     if (this.closed || !this.res.writable) return false;
     this.res.cork(() => {
-      this.res.write(`data:${JSON.stringify(event)}\n\n`);
+      const idLine = id !== undefined ? `id:${id}\n` : "";
+      this.res.write(`${idLine}data:${JSON.stringify(event)}\n\n`);
     });
     return true;
   }

--- a/packages/options/src/dsconnect.ts
+++ b/packages/options/src/dsconnect.ts
@@ -544,7 +544,20 @@ export class ActiveDSChanges
         if (!this.stop) {
           // Map last_seq -> seq (Matches Pouch Connector)
           // and update since for next round of listening
-          this.opts.since = response.id;
+          //
+          // `response` here is the raw ActiveRequest/axios wrapper - it
+          // has no top-level `.id` at all (that was always undefined).
+          // The server writes `last_seq` inside the JSON body itself
+          // (selfhost.ts's longpoll handler: `res.write('],\n"last_seq":'
+          // + change.seq + "}\n")`), i.e. under `.data`, not `.id`. Every
+          // round after the first therefore requested `since=undefined`
+          // -> parseInt(undefined) = NaN server-side - live-confirmed as
+          // part of the same investigation that found the longpoll
+          // handler's response was never being finalised at all (see
+          // that fix in packages/storage/src/selfhost.ts) - fixing just
+          // that bug wasn't enough on its own, this one still silently
+          // broke every round after the first.
+          this.opts.since = response.data?.last_seq ?? this.opts.since;
 
           if (this.bulk) {
             // Emit all changed data

--- a/packages/storage/src/selfhost.ts
+++ b/packages/storage/src/selfhost.ts
@@ -784,8 +784,21 @@ import { IActiveHttpResponse } from "@activeledger/httpd/lib/httpd";
                   res.write(JSON.stringify(change));
                   res.write('],\n"last_seq":' + change.seq + "}\n");
                 }
-                //res.end();
-                //cleanUp();
+                // A CouchDB longpoll round is exactly one change, then the
+                // client reconnects for the next - this response was never
+                // actually finalised (both lines below were commented out),
+                // so a client whose HTTP layer waits for the response to
+                // complete before resolving (ActiveRequest/axios does, by
+                // default) hangs forever the moment a real change occurs,
+                // even though the bytes above were already written to the
+                // socket. Live-confirmed: this is why a nano-gateway
+                // subscriber connects fine (heartbeats keep flowing) but
+                // never actually receives a push for a real, committed
+                // change - ActiveDSChanges.listen() (packages/options/src/dsconnect.ts)
+                // never gets a resolved response to react to.
+                res.end();
+                cleanUp();
+                cancelChanges();
               };
 
               // Stop listening for changes


### PR DESCRIPTION
## Summary

Follow-up to #52. User pointed out SSE has a standard reconnection mechanism (Last-Event-ID) - correct, and better than what was there: `@activeledger/httpd` actually forwards `Last-Event-ID` to route handlers (confirmed reading its source), unlike the custom auth headers that had to go through the request body instead.

Each SSE frame is now numbered by the DB change sequence it came from, matching Activecore's own convention. A reconnecting client sends `Last-Event-ID` and resumes the changes feed from exactly that point instead of missing whatever changed during the gap.

Paired with a client-side change in `activeledger/nano` (separate repo): `NanoLedgerEvents` now reconnects automatically with backoff on any drop and tracks/resends `Last-Event-ID` across reconnects (not across explicit fresh subscribes, which reset intentionally).

## Test plan

- [x] `npm run build` - clean
- [x] 12 existing unit tests still pass (no regression)
- [ ] Not live-tested - same devnet blocker as #52