### PR TITLE
The changes feed died on any quiet round, killing all push delivery

### DIFF
--- a/packages/options/src/dsconnect.ts
+++ b/packages/options/src/dsconnect.ts
@@ -507,6 +507,24 @@ export class ActiveDSChanges
   private stop = false;
 
   /**
+   * Pending retry from a failed round, so cancel()/restart() can clear it
+   * and two listen() loops can never run at once.
+   *
+   * @private
+   */
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Delay before re-arming after a failed round. Long enough that a
+   * datastore which is down doesn't get hammered, short enough that a
+   * transient blip costs a consumer a second rather than every subsequent
+   * change.
+   *
+   * @private
+   */
+  private static readonly RETRY_DELAY_MS = 1000;
+
+  /**
    *Creates an instance of ActiveDSChanges.
    * @param {{ live?: boolean; [opt: string]: any }} opts
    * @param {string} location
@@ -559,12 +577,37 @@ export class ActiveDSChanges
           // broke every round after the first.
           this.opts.since = response.data?.last_seq ?? this.opts.since;
 
+          // `data` can legitimately be null/empty - a longpoll round that
+          // times out with nothing to report is an ordinary outcome, not an
+          // error. The `?.` on last_seq above already allowed for that, but
+          // the reads below did not: `response.data.results` threw
+          // "Cannot read properties of null (reading 'results')" from inside
+          // this .then(), which landed in the .catch() below, which never
+          // called listen() again - so one empty body permanently killed the
+          // changes feed. Live-confirmed downstream: a nano-gateway subscriber
+          // took that error at 21:11 and never received another change, while
+          // its SSE socket stayed open and heartbeating, so nothing anywhere
+          // reported a fault.
+          const data = response.data;
+
+          if (!data) {
+            // Nothing to process, and re-arming immediately would spin: a
+            // body-less response returns straight away rather than blocking
+            // like a healthy longpoll, so an immediate this.listen() here
+            // busy-loops the event loop and starves every timer in the
+            // process. Back off instead - this is the same "no useful round"
+            // case as an outright failure. (An ordinary longpoll timeout is
+            // NOT this case: it returns {results: [], last_seq}, so it still
+            // continues immediately below.)
+            this.scheduleRetry();
+            return;
+          }
+
           if (this.bulk) {
-            // Emit all changed data
-            this.emit("change", response.data);
+            this.emit("change", data);
           } else {
-            // Emit each change
-            response.data.results.forEach((elm: any) => {
+            const results = Array.isArray(data.results) ? data.results : [];
+            results.forEach((elm: any) => {
               this.emit("change", {
                 doc: elm.doc,
                 seq: elm.seq,
@@ -576,7 +619,30 @@ export class ActiveDSChanges
           this.listen();
         }
       })
-      .catch((error) => this.emit("error", error));
+      .catch((error) => {
+        this.emit("error", error);
+
+        // Keep the feed alive. Previously any rejection - a dropped
+        // connection, a restarting datastore, a transient 500 - ended the
+        // changes feed for the lifetime of the process, silently, because
+        // nothing here scheduled another round. Consumers had no way to tell
+        // that apart from "no changes are happening".
+        this.scheduleRetry();
+      });
+  }
+
+  /**
+   * Re-arms listen() after a failed round, without stacking timers or
+   * racing a concurrent restart()/cancel().
+   */
+  private scheduleRetry(): void {
+    if (this.stop || this.retryTimer) return;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      if (!this.stop) {
+        this.listen();
+      }
+    }, ActiveDSChanges.RETRY_DELAY_MS);
   }
 
   /**
@@ -585,10 +651,25 @@ export class ActiveDSChanges
    */
   public cancel(): void {
     this.stop = true;
+    this.clearRetry();
   }
 
   public restart(): void {
     this.stop = false;
+    // Without this a restart() landing while a retry is pending would leave
+    // two listen() loops running against the same feed, duplicating every
+    // change event from then on.
+    this.clearRetry();
     this.listen();
+  }
+
+  /**
+   * @private
+   */
+  private clearRetry(): void {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
   }
 }

--- a/packages/storage/src/selfhost.ts
+++ b/packages/storage/src/selfhost.ts
@@ -746,15 +746,15 @@ import { IActiveHttpResponse } from "@activeledger/httpd/lib/httpd";
         if (incoming.query.feed === "continuous") {
           // Currently we do not do continuous
         } else {
-          //Long polling heartbeat
-          let hBInterval = setInterval(() => {
-            //res.write("\n");
-          }, incoming.query.heartbeat || 60000);
+          // Long polling heartbeat - armed only once the body is actually
+          // open for writing, further down.
+          let hBInterval: ReturnType<typeof setInterval> | null = null;
 
           // Clean up
           let cleanUp = () => {
             if (hBInterval) {
               clearInterval(hBInterval);
+              hBInterval = null;
             }
           };
 
@@ -807,6 +807,47 @@ import { IActiveHttpResponse } from "@activeledger/httpd/lib/httpd";
                 });
               }
               incoming.query.live = incoming.query.continuous = true;
+
+              // Keep bytes flowing while nothing is changing.
+              //
+              // This write was commented out, and that is what made a quiet
+              // feed fatal rather than merely quiet. The response holds open
+              // with nothing on the wire, so the client's undici bodyTimeout
+              // (300s - ActiveRequest's default, packages/utilities) fires and
+              // the round comes back with no body. Downstream,
+              // ActiveDSChanges.listen() dereferenced response.data.results on
+              // that null and threw, and nothing re-armed the loop - so the
+              // changes feed died for the lifetime of the process. Every five
+              // idle minutes was enough. Live-confirmed: nano-gateway kept its
+              // SSE socket open and heartbeating to its own subscribers the
+              // whole time, so every health signal said the link was fine
+              // while no change could ever arrive again. Background push on a
+              // real device stopped and nothing anywhere reported a fault.
+              //
+              // A newline is insignificant whitespace between JSON array
+              // elements, so it cannot corrupt the body being streamed - this
+              // is exactly what CouchDB sends. It has to be corked: uWS
+              // requires it for any write from a later tick, and an uncorked
+              // one is silently dropped or corrupts the stream, which is the
+              // likeliest reason this was disabled rather than fixed.
+              //
+              // Default is well under the client's timeout so an ordinary
+              // quiet period never reaches it. The client-side guard in
+              // dsconnect.ts is still required: this reduces how often a bad
+              // round happens, it does not make one survivable.
+              hBInterval = setInterval(() => {
+                if (!res.writable) {
+                  // The client went away mid-longpoll. Without this the
+                  // interval and the change listener both leak for the
+                  // lifetime of the process, one per abandoned request.
+                  cleanUp();
+                  cancelChanges();
+                  return;
+                }
+                res.cork(() => {
+                  res.write("\n");
+                });
+              }, Number(incoming.query.heartbeat) || 30000);
 
               // Listener Process event (to turn off)
               const listener = (change: any) => {

--- a/tests/dsconnect-changes.test.ts
+++ b/tests/dsconnect-changes.test.ts
@@ -1,0 +1,118 @@
+import { expect } from "chai";
+import "mocha";
+
+// The class captures ActiveRequest at module scope, and TypeScript's commonjs
+// emit resolves it per call (activeutilities_1.ActiveRequest.send), so
+// replacing send() on the required module object is enough - as long as it
+// happens before any round runs.
+// Resolved relative to packages/options rather than the repo root: this is a
+// lerna monorepo, so @activeledger/* are linked per-package and are not
+// resolvable from tests/ itself. dsconnect.ts resolves it from its own
+// location, which is the same module instance this replaces send() on.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const activeutilities = require(require.resolve("@activeledger/activeutilities", {
+  paths: [__dirname + "/../packages/options"],
+}));
+const realSend = activeutilities.ActiveRequest.send;
+
+import { ActiveDSChanges } from "../packages/options/src/dsconnect";
+
+const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Regression coverage for a changes feed that could stop forever without
+ * reporting anything.
+ *
+ * `response.data.results` was read unguarded while the `last_seq` read one
+ * line above already allowed for a null body. A body-less longpoll round
+ * therefore threw inside the .then(), landed in the .catch(), and nothing
+ * re-armed listen() - so a single empty response permanently ended the feed.
+ *
+ * Live-confirmed downstream before this fix: a nano-gateway subscriber took
+ * "Cannot read properties of null (reading 'results')" and never received
+ * another change, while its own SSE socket stayed open and heartbeating, so
+ * no component anywhere reported a fault.
+ */
+describe("ActiveDSChanges - the changes feed must survive a bad round", () => {
+  let calls = 0;
+  let sendImpl: () => Promise<unknown> = async () => ({ data: { results: [], last_seq: 1 } });
+
+  beforeEach(() => {
+    calls = 0;
+    activeutilities.ActiveRequest.send = async () => {
+      calls++;
+      return sendImpl();
+    };
+  });
+
+  after(() => {
+    activeutilities.ActiveRequest.send = realSend;
+  });
+
+  it("a null body neither throws nor ends the feed", async () => {
+    sendImpl = async () => ({ data: null });
+    const changes = new ActiveDSChanges({ since: 0 }, "http://store/db/_changes");
+    const errors: unknown[] = [];
+    changes.on("error", (e: unknown) => errors.push(e));
+    try {
+      await settle(1600);
+      expect(errors.map(String).join(","), "a null body is an ordinary empty round").to.equal("");
+      expect(calls, "feed must keep polling").to.be.greaterThan(1);
+      // Backs off rather than re-arming instantly - an immediate retry here
+      // busy-loops, because a body-less response returns straight away
+      // instead of blocking like a healthy longpoll.
+      expect(calls, "feed must back off, not spin").to.be.lessThan(20);
+    } finally {
+      changes.cancel();
+    }
+  });
+
+  it("a rejected round is reported and then retried, not fatal", async () => {
+    sendImpl = async () => {
+      throw new Error("datastore restarting");
+    };
+    const changes = new ActiveDSChanges({ since: 0 }, "http://store/db/_changes");
+    const errors: unknown[] = [];
+    changes.on("error", (e: unknown) => errors.push(e));
+    try {
+      await settle(1600);
+      expect(errors.length, "the failure should still surface").to.be.greaterThan(0);
+      expect(calls, "feed must retry after a failure").to.be.greaterThan(1);
+    } finally {
+      changes.cancel();
+    }
+  });
+
+  it("still emits ordinary changes one at a time", async () => {
+    // Delayed deliberately: a healthy round continues immediately (unchanged
+    // behaviour), which assumes the server is genuinely long-polling.
+    sendImpl = async () => {
+      await settle(50);
+      return { data: { results: [{ doc: { _id: "a" }, seq: 7 }], last_seq: 7 } };
+    };
+    const changes = new ActiveDSChanges({ since: 0 }, "http://store/db/_changes");
+    const seen: Array<{ doc: { _id: string }; seq: number }> = [];
+    changes.on("change", (c: { doc: { _id: string }; seq: number }) => seen.push(c));
+    try {
+      await settle(500);
+      expect(seen.length).to.be.greaterThan(0);
+      expect(seen[0].doc._id).to.equal("a");
+      expect(seen[0].seq).to.equal(7);
+    } finally {
+      changes.cancel();
+    }
+  });
+
+  it("cancel() stops the feed and clears a pending retry", async () => {
+    sendImpl = async () => {
+      throw new Error("down");
+    };
+    const changes = new ActiveDSChanges({ since: 0 }, "http://store/db/_changes");
+    changes.on("error", () => undefined);
+    await settle(400);
+    changes.cancel();
+    const after = calls;
+    await settle(1400);
+    expect(calls, "no further requests after cancel()").to.equal(after);
+  });
+});


### PR DESCRIPTION
Two commits, the two ends of one fault. Together they are what stops
nano-gateway's changes feed dying silently — which is currently blocking all
background push notifications on the devnet.

## What happens today

1. `selfhost.ts`'s `_changes` longpoll writes `{"results":[` and then holds the
   response open until a change arrives. Its heartbeat interval exists but the
   write inside it is **commented out**, so nothing goes down the wire during a
   quiet period.
2. The client's undici `bodyTimeout` is **300s** (`ActiveRequest`'s default),
   and it measures the gap *between body chunks*. Five idle minutes reaches it.
3. The round comes back with no body.
4. `dsconnect.ts` then does `response.data.results.forEach(...)` **unguarded**,
   one line below `response.data?.last_seq`, which optional-chains the very
   same object.
5. It throws inside the `.then()`, lands in the `.catch()`, and **nothing
   re-arms `listen()`**. The changes feed is dead for the lifetime of the
   process.

The failure is invisible. nano-gateway keeps its own SSE socket open to its
subscribers and keeps heartbeating to them, so every health signal says the
link is fine while no change can ever arrive again.

## Confirmed on the live devnet, not reasoned about

- Curling the node's longpoll directly returns the change immediately, with a
  real `last_seq` — so the datastore's live delivery is fine.
- Meanwhile the gateway held two ESTABLISHED connections to that same
  datastore on 5259 and forwarded nothing.
- Transactions committed throughout (documents read back at the expected new
  revisions); only the announcement was lost.
- Timeline fits exactly: push delivery worked for ~35 minutes, then stopped at
  the first quiet gap ≥5 minutes, and never recovered.

Note `_changes` returning `{"results":[],"last_seq":0}` is a **red herring** —
no sequence counter is ever written (documented in `prepareForWrite`), so an
empty backfill is that endpoint's permanent, expected state. It is not
evidence of this fault, and I wasted time treating it as such.

## The commits

**`101eaf8` — client.** Guards `results`; backs off on a null body rather than
re-arming immediately (an immediate retry busy-loops, because a body-less
response returns straight away instead of blocking — the first version of this
fix traded "feed dies" for "feed spins", which is worse, and the test caught it
by hanging); and retries a rejected round instead of ending the feed.

**`f57c4ff` — server.** Re-enables the heartbeat, corked (uWS requires it for
any write from a later tick), default 30s so an ordinary quiet period never
reaches the client's timeout. A newline is insignificant whitespace between
JSON array elements, so it cannot corrupt the streamed body — it is what
CouchDB itself sends. Also tears down the interval and the change listener when
a client vanishes mid-longpoll, which previously leaked a pair per abandoned
request.

The two are independent. The client fix is what makes a bad round survivable;
the server fix is what stops one being provoked every five idle minutes.
Neither depends on the other landing.

## Tests

The client change has 4 tests; 2 fail against the previous implementation with
the exact production error string.

The server change is **not** covered by a test and has not been run — I could
only typecheck it against an un-bootstrapped checkout, so the compiler
confirmed no syntax or local type errors but could not resolve the `httpd`
types. It uses exactly the `res.cork(() => res.write(...))` and `res.writable`
patterns already compiling elsewhere in that same handler. Worth a real build
before it goes near a node.

## Release note

`nano-gateway` resolves `@activeledger/activeoptions@^4.4.0` from npm, and both
the deployed 4.5.0 and the latest published 4.5.6 still contain the unguarded
line. So this needs publishing at **4.5.7 or higher** to reach a running
gateway — anything in the 4.2.x range the working tree reports would be
ignored by that range.