### PR TITLE
Publish never created a GitHub Release, so the releases page went stale

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,10 @@ on:
         required: false
 
 permissions:
-  contents: read
+  # contents: write, not read - creating a GitHub Release writes to the repo.
+  # This was `read`, which is why adding a release step would have failed even
+  # if one had existed.
+  contents: write
   packages: write
 
 jobs:
@@ -117,3 +120,31 @@ jobs:
         run: npx lerna publish from-package --yes --no-git-tag-version --no-push --registry https://registry.npmjs.org/
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Publishing to a registry and announcing a release are two different
+      # things, and only the first was ever automated here. No version of this
+      # workflow has ever created a GitHub Release - releases up to v4.4.0 were
+      # made by hand alongside the tag, and when tagging became frequent during
+      # the v4.5.x series that step simply stopped happening. The result was
+      # six versions (v4.5.0 through v4.5.6) published to npm and GitHub
+      # Packages with no release entry, so the releases page read as six
+      # versions behind reality while every CI run reported success.
+      #
+      # Last, deliberately: a release should announce something that actually
+      # shipped. If either publish above fails the job stops before here, so
+      # there is never a release pointing at a version nobody can install.
+      #
+      # Idempotent, because a re-run of a tag build is an ordinary thing (the
+      # npmjs step was skipped for the first few tags while its token was being
+      # restored, so re-running an old tag to backfill it is expected) and
+      # `gh release create` fails on an existing tag rather than no-op'ing.
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "release $GITHUB_REF_NAME already exists - nothing to do"
+          else
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
+          fi


### PR DESCRIPTION
npm and GitHub Packages have v4.5.6; the releases page showed v4.4.0 as
"Latest". That looks like a broken CI step, and it isn't.

**No version of `publish.yml` has ever created a GitHub Release**, and there
has never been another workflow file — confirmed by grepping every revision of
it for a release step (zero hits across all eight) and checking for deleted
workflow files (none). So every run legitimately reported success: the thing
that wasn't happening was never part of the run.

Releases up to v4.4.0 were being created by hand alongside the tag. When
tagging became frequent during the v4.5.x `_changes` work on 2026-09-02, that
manual step stopped. The result was seven versions — v4.5.0 through v4.5.6 —
published and installable with no release entry.

## Why it matters beyond tidiness

The releases page is what someone checks to know what shipped, and it was seven
versions behind while looking authoritative. It cost real confusion: the repo
appeared to be running behind its own published packages when it is exactly
current (`v4.5.6` is an ancestor of `master`, zero commits between them).

Worth separating two things that look alike here:

- The **code** is current. Not a problem.
- The **version fields** are stale — `lerna.json` and every `package.json` read
  `4.2.0` even at the `v4.5.6` tag itself. That is deliberate and already
  handled: the "Set version from tag" step derives the published version from
  the tag and ignores the files, with a comment explaining that the committed
  versions "have drifted from every tag since v4.0.0". Nothing to fix, but it
  reads alarmingly if you find it cold.

## The change

- Adds a `gh release create --generate-notes` step.
- Changes `permissions: contents: read` to `write`. A release writes to the
  repo, so a release step added under the old permissions would have failed
  anyway — worth knowing if anyone tried before and concluded it was
  impossible.

Placed **last** in the job deliberately: a release should announce something
that actually shipped, and if either publish step fails the job stops before
reaching it. So there is never a release pointing at a version nobody can
install.

Idempotent via `gh release view` first, because re-running an old tag build is
ordinary here — the npmjs.org step was skipped for the first few tags while its
token was being restored, so re-running those to backfill is expected — and
`gh release create` errors on an existing tag rather than no-op'ing.

## Already done separately

v4.5.0–v4.5.6 have been backfilled by hand at Adam's request, so the releases
page now matches npm. Two caveats on those: their creation dates read as today
rather than the original tag dates (unavoidable when backfilling), and the
generated notes are just a `Full Changelog` compare link, because
`--generate-notes` builds from merged PRs and those tags were cut from direct
commits.

Not backfilled: `v4.0.0`, and 156 historical `v2.x` tags. Creating those would
fire ~157 notifications at every watcher for releases nobody is looking for.
`v4.0.0` is the only one I would consider adding if you want the 4.x line
complete.