### PR TITLE
Run the test suite in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # 22, not the 18 publish.yml uses. uWebSockets.js v20.67.0 ships
+      # prebuilt binaries only for Node 22, 24 and 26 (ABI 127/137/147), so
+      # anything older dies at require() with "Cannot find module
+      # './uws_linux_x64_108.node'" the moment a test touches httpd.
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Install root dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+# Runs the test suite. Nothing did before this: publish.yml was the only
+# workflow, so `npm test` only ever ran when someone remembered to run it
+# locally - on code that decides consensus and repairs divergent ledger
+# state.
+#
+# The bootstrap and build steps are not optional. The tests import from
+# packages/*/src directly, but those sources import each other through the
+# published @activeledger/* names, which only resolve once lerna has
+# symlinked the workspace and each package has a lib/ to resolve types
+# against. Without them every single test fails on "Cannot find module
+# '@activeledger/activelogger'", which reads like a broken test suite
+# rather than a missing setup step.
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Bootstrap workspace
+        run: npx lerna bootstrap
+
+      # Deliberately not `npm run build` - that script ends in `npm run link`,
+      # which npm-links the CLI packages globally. That is for a developer
+      # machine and is pointless on a throwaway runner.
+      - name: Build packages
+        run: |
+          for target in definitions logger utilities httpd options storage \
+                        crypto query contracts protocol network toolkits \
+                        ledger restore; do
+            echo "::group::build:$target"
+            npm run "build:$target"
+            echo "::endgroup::"
+          done
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,14 +26,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # 22, not the 18 publish.yml uses. uWebSockets.js v20.67.0 ships
+      # 24 (current LTS), not the 18 publish.yml used. uWebSockets.js v20.67.0 ships
       # prebuilt binaries only for Node 22, 24 and 26 (ABI 127/137/147), so
       # anything older dies at require() with "Cannot find module
       # './uws_linux_x64_108.node'" the moment a test touches httpd.
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install root dependencies
         run: npm ci


### PR DESCRIPTION
`publish.yml` was the only workflow in this repository, so `npm test` only ever ran when someone remembered to run it locally — on code that decides consensus and repairs divergent ledger state.

Adds a `Tests` workflow on `push: master`, `pull_request` and `workflow_dispatch`.

The bootstrap and build steps are load-bearing, not incidental: the tests import `packages/*/src` directly, but those sources import each other through the published `@activeledger/*` names, which only resolve once lerna has symlinked the workspace and each package has a `lib/`. Without them all 125 tests on master fail with `Cannot find module '@activeledger/activelogger'` — which reads like a broken suite rather than a missing setup step, so the reasoning is recorded in the workflow file.

Builds the packages individually rather than through `npm run build`, whose final `npm run link` step npm-links the CLI packages globally — useful on a developer machine, pointless on a throwaway runner.