### PR TITLE
Publishing failed because the version was already correct

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,9 +80,20 @@ jobs:
       # in lerna's own source has no bypass flag). Commit it locally so the
       # tree is clean for the publish step below; this commit is never
       # pushed anywhere and only exists in this runner's throwaway checkout.
+      #
+      # There may be nothing to commit, and that is the healthy case now.
+      # release.yml bumps the versions BEFORE creating the tag, so a tag cut
+      # that way already has the right numbers committed and lerna version
+      # above changes nothing. `git commit` with no staged changes exits 1,
+      # which failed the whole publish - the release plumbing working
+      # correctly was enough to break the step that assumed it did not.
       - name: Commit version bump locally (not pushed)
         if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.version != '')
         run: |
+          if git diff --quiet; then
+            echo "Working tree already at the target version - nothing to commit."
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "chore: set version for publish (not pushed)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,17 @@
-# Cuts a release: bump -> commit -> tag -> push. publish.yml then fires on the
-# tag and does the building and publishing.
+# Cuts a release: bump -> commit -> tag -> push.
+#
+# KNOWN GAP: publish.yml does NOT fire on the tag this workflow pushes.
+# GitHub deliberately does not start new workflow runs from events created
+# with the default GITHUB_TOKEN, so the tag push here is invisible to
+# publish.yml's `on: push: tags` trigger. After this workflow succeeds,
+# publishing still has to be started by hand:
+#
+#   gh workflow run publish.yml --ref master -f version=<the version>
+#
+# Fixing it properly means either a PAT with workflow scope for the tag push,
+# or turning publish.yml into a reusable workflow this one calls directly
+# (workflow_call is part of the same run, so the restriction does not apply).
+# Left as a follow-up rather than changed mid-release.
 #
 # This exists because the order matters and could not be fixed inside
 # publish.yml. That workflow triggers ON a tag, so by the time it runs the tag


### PR DESCRIPTION
Cutting v4.5.8 surfaced two gaps in the release plumbing. This fixes the blocking one and documents the other.

## Fixed: publish fails on a clean tree

`release.yml` bumps versions **before** creating the tag — that ordering is the entire point of it (PR #56). So at a tag cut that way, `publish.yml`'s own `lerna version` step finds nothing to change, and the next step runs `git commit -am` against a clean tree:

```
HEAD detached at v4.5.8
nothing to commit, working tree clean
##[error]Process completed with exit code 1.
```

The release plumbing working correctly was enough to break the step that assumed it wouldn't. Now skips the commit when the tree is already clean.

## Documented, not fixed: the tag does not trigger publish

The `v4.5.8` tag was pushed successfully and `publish.yml` never ran. GitHub does not start workflow runs from events created with the default `GITHUB_TOKEN`, so `on: push: tags` never sees a tag that `release.yml` pushed.

Publishing therefore has to be dispatched by hand after a release:

```
gh workflow run publish.yml --ref master -f version=<version>
```

Fixing it properly means either a PAT with workflow scope for the tag push, or converting `publish.yml` into a reusable workflow that `release.yml` calls (`workflow_call` runs inside the same run, so the restriction doesn't apply). Both are deliberate changes to release plumbing and shouldn't be made mid-release, so this PR only records the gap and the workaround in the workflow file.