### PR TITLE
Release should publish itself, not hope a tag fires

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,18 @@ on:
       version:
         description: "Version to publish (e.g. 4.2.0). Leave blank to publish whatever's currently committed in package.json."
         required: false
+  # release.yml calls this directly rather than relying on the tag it pushes
+  # to trigger the `push: tags` above. GitHub does not start new workflow runs
+  # from events created with the default GITHUB_TOKEN, so that tag push is
+  # invisible to this workflow - v4.5.8 was tagged successfully and published
+  # nothing until it was dispatched by hand. A workflow_call happens inside
+  # the caller's run, so the restriction does not apply.
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to publish, without the leading v"
+        required: false
+        type: string
 
 permissions:
   # contents: write, not read - creating a GitHub Release writes to the repo.
@@ -69,8 +81,13 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: npx lerna version "${GITHUB_REF_NAME#v}" --no-git-tag-version --no-push --force-publish --exact --yes
 
+      # Deliberately not gated on github.event_name: under workflow_call that
+      # reports the CALLER's event, so a check for 'workflow_dispatch' here is
+      # both wrong and accidentally right depending on how release.yml was
+      # started. inputs.version is empty on a tag push and set on either of
+      # the other two triggers, which is exactly the distinction that matters.
       - name: Set version from workflow input
-        if: github.event_name == 'workflow_dispatch' && inputs.version != ''
+        if: inputs.version != ''
         run: npx lerna version "${{ inputs.version }}" --no-git-tag-version --no-push --force-publish --exact --yes
 
       # `lerna version --no-git-tag-version` deliberately leaves the bump as
@@ -88,7 +105,7 @@ jobs:
       # which failed the whole publish - the release plumbing working
       # correctly was enough to break the step that assumed it did not.
       - name: Commit version bump locally (not pushed)
-        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.version != '')
+        if: startsWith(github.ref, 'refs/tags/v') || inputs.version != ''
         run: |
           if git diff --quiet; then
             echo "Working tree already at the target version - nothing to commit."
@@ -159,13 +176,38 @@ jobs:
       # npmjs step was skipped for the first few tags while its token was being
       # restored, so re-running an old tag to backfill it is expected) and
       # `gh release create` fails on an existing tag rather than no-op'ing.
+      # The tag to release is either the ref that triggered this, or the one
+      # release.yml just pushed for the version it handed over. Keying this on
+      # the ref alone meant a run started any way other than by a tag push
+      # skipped the release entirely and said nothing about it - v4.5.8's
+      # GitHub Release had to be created by hand afterwards.
+      - name: Resolve release tag
+        id: releasetag
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "name=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ inputs.version }}" ]; then
+            echo "name=v${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: steps.releasetag.outputs.name != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.releasetag.outputs.name }}
         run: |
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            echo "release $GITHUB_REF_NAME already exists - nothing to do"
+          # Asked of the remote, not the local clone. This job's checkout is
+          # shallow and, when called from release.yml, happened before that
+          # workflow pushed the tag - so `git rev-parse` here would miss a tag
+          # that exists perfectly well on the remote.
+          if ! gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" >/dev/null 2>&1; then
+            echo "::warning::tag $TAG does not exist on the remote - skipping GitHub Release"
+            exit 0
+          fi
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG already exists - nothing to do"
           else
-            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
+            gh release create "$TAG" --title "$TAG" --generate-notes
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,11 @@
-# Cuts a release: bump -> commit -> tag -> push.
+# Cuts a release: bump -> commit -> tag -> push -> publish.
 #
-# KNOWN GAP: publish.yml does NOT fire on the tag this workflow pushes.
-# GitHub deliberately does not start new workflow runs from events created
-# with the default GITHUB_TOKEN, so the tag push here is invisible to
-# publish.yml's `on: push: tags` trigger. After this workflow succeeds,
-# publishing still has to be started by hand:
-#
-#   gh workflow run publish.yml --ref master -f version=<the version>
-#
-# Fixing it properly means either a PAT with workflow scope for the tag push,
-# or turning publish.yml into a reusable workflow this one calls directly
-# (workflow_call is part of the same run, so the restriction does not apply).
-# Left as a follow-up rather than changed mid-release.
+# The publish is CALLED from here rather than left to fire on the tag this
+# workflow pushes. GitHub does not start new workflow runs from events created
+# with the default GITHUB_TOKEN, so publish.yml's `on: push: tags` never sees
+# it - v4.5.8 was tagged correctly and published nothing at all until someone
+# noticed and dispatched it by hand. A workflow_call runs inside this run, so
+# the restriction does not apply and one dispatch does the whole release.
 #
 # This exists because the order matters and could not be fixed inside
 # publish.yml. That workflow triggers ON a tag, so by the time it runs the tag
@@ -42,7 +36,11 @@ on:
         required: true
 
 permissions:
+  # packages: write as well as contents: write - the called publish workflow
+  # inherits this job's permissions, not the ones declared in its own file,
+  # and it pushes to GitHub Packages.
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -91,5 +89,14 @@ jobs:
 
       - name: Summary
         run: |
-          echo "Released v${{ inputs.version }} - publish.yml now runs on the tag." >> "$GITHUB_STEP_SUMMARY"
+          echo "Tagged v${{ inputs.version }}. Publishing follows in this same run." >> "$GITHUB_STEP_SUMMARY"
           echo "The commit, the tag and the published packages all report ${{ inputs.version }}." >> "$GITHUB_STEP_SUMMARY"
+
+  # Same run, so no GITHUB_TOKEN trigger restriction to work around.
+  publish:
+    needs: release
+    uses: ./.github/workflows/publish.yml
+    with:
+      version: ${{ inputs.version }}
+    # NPM_TOKEN, and whatever else publish.yml reaches for
+    secrets: inherit


### PR DESCRIPTION
Cutting v4.5.8 needed **three manual interventions after the Release workflow reported success**. That is not a release process, and each gap was silent.

## 1. The tag never triggered the publish

GitHub does not start workflow runs from events created with the default `GITHUB_TOKEN`, so the tag `release.yml` pushes is invisible to `publish.yml`'s `on: push: tags`. v4.5.8 was tagged correctly and published nothing at all until it was dispatched by hand.

`release.yml` now **calls** `publish.yml` as a reusable workflow. A `workflow_call` runs inside the same run, so the restriction doesn't apply, and one dispatch does the whole release.

## 2. Version selection was gated on the wrong thing

`if: github.event_name == 'workflow_dispatch' && inputs.version != ''` — under `workflow_call`, `github.event_name` reports the *caller's* event, which makes that check simultaneously wrong and accidentally right depending on how `release.yml` was started. Now gated on `inputs.version` alone: empty on a tag push, set on either other trigger, which is the distinction that matters.

## 3. The GitHub Release was skipped silently

`Create GitHub Release` was gated on the ref being a tag, so any run started another way skipped it and said nothing. v4.5.8's release had to be created by hand afterwards.

It now resolves the tag from the ref *or* the version it was handed, and asks the **remote** whether that tag exists — this job's checkout is shallow and, on a release-driven run, happens before the tag is pushed, so a local `git rev-parse` would miss a tag that is perfectly present on origin.

## Permissions

`release.yml` gains `packages: write`. A called workflow inherits the *caller's* permissions rather than the ones declared in its own file, so without it the GitHub Packages publish would fail on a release-driven run while continuing to work on a manual dispatch — a failure that would only ever appear during a real release.

## Verification

YAML and job schema check out, and `test.yml` runs on this PR. **The release path itself cannot be proven without cutting a release** — that is exactly how today's two gaps stayed hidden. Worth a throwaway version bump to exercise it end to end before relying on it.