### PR TITLE
A dissenting node never reconciles, because SPI can only run when it cannot succeed

### DIFF
--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -803,6 +803,7 @@ export class Endpoints {
       const revisions = tally[id] || {};
       let winner = "";
       let max = 0;
+      let forked = false;
 
       const candidates = Object.keys(revisions);
       for (let x = candidates.length; x--; ) {
@@ -815,14 +816,30 @@ export class Endpoints {
           max = revisions[rev].votes;
           winner = rev;
         } else if (revisions[rev].votes === max) {
-          // Same support, so take the later position
+          // Same support. A later position means the other side simply
+          // applied something this one has not yet - adopting it loses
+          // nothing, because the lagging copy has no history of its own.
           if (Endpoints.revPosition(rev) > Endpoints.revPosition(winner)) {
             winner = rev;
+          } else if (
+            Endpoints.revPosition(rev) === Endpoints.revPosition(winner) &&
+            rev !== winner
+          ) {
+            // Same position, different content: not a lag, a genuine fork.
+            // Each side committed something the other did not, at the same
+            // point in the stream's history, so whichever is picked
+            // silently destroys the other's transaction. Revisions are
+            // content addressed (position-md5), so there is nothing here
+            // to tell them apart on merit and no safe automatic answer.
+            forked = true;
           }
         }
       }
 
-      if (winner) {
+      if (forked) {
+        abstained[id] =
+          "forked - two revisions at the same position, needs a human";
+      } else if (winner) {
         winners[id] = { rev: winner, votes: max, doc: revisions[winner].doc };
       } else {
         abstained[id] = "no revision reached consensus";

--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -1515,50 +1515,40 @@ export class Endpoints {
 
           const holdValue = body.$streams[i].replace(":stream", "");
 
-          // If it doesn't have it and can hold return
-          if (
-            Locker.hold(holdValue, "SPI") /*|| Locker.is(holdValue, "SPI")*/
-          ) {
-            // We should probably have a release timer, and also release call from calling node
-            // but as multiple nodes will call  will need counter ontop of it. Using a timer now will
-            // at least show this method works. The call counter will just make it release faster
-            //ActiveLogger.info(`SPI EPS FETCH HOLD ${holdValue}`);
-            setTimeout(() => {
-              Locker.release(holdValue, "SPI");
-              //ActiveLogger.info(`SPI EPS FETCH RELEASE ${holdValue}`);
-            }, 1000);
-
-            // Maybe increase the 1000 here, More so if we have an "unlock" somehow request (as many nodes me ask!)
-            // Or we can cache the results here given that we can assume more nodes will ask 
-
-            // Fetch Request (Catch error here and forward on as an object to process in .all)
-            fetchStream.push(db.get(body.$streams[i]));
-            //}
+          // Read only - this endpoint takes no lock of its own.
+          //
+          // It used to Locker.hold(holdValue, "SPI") for a second per
+          // request. host.ts's hold() refuses a transaction if ANY of its
+          // streams is already held, by anything, including "SPI" - so a
+          // stream that several peers were asking about had a read lock on
+          // it more or less continuously, and the transaction that wanted
+          // to write it was pushed into the busy-locks queue over and over.
+          // Observed on a live network as a contract update running for 30
+          // seconds to its TTL, against a background of
+          // "Lock busy ... requested by SPI", while SPI was only ever
+          // trying to read.
+          //
+          // Nothing needed the lock. Two nodes reconciling the same stream
+          // at once each rewrite their OWN copy to the revision the
+          // majority voted for, so the writes are idempotent and cannot
+          // race each other.
+          if (Locker.has(holdValue)) {
+            // Held by a transaction, so this node cannot report the stream
+            // right now. Saying nothing is indistinguishable from "I do not
+            // have it", and the caller votes on whatever comes back - so
+            // the stream is under-reported and a minority revision can
+            // carry the vote. Answer with a marker instead. It has no
+            // _rev, so an older node's tally ignores it exactly as it
+            // ignored the silence.
+            //
+            // Note this is reachable precisely when it hurts most. Only
+            // streams named in $i/$o are locked, so the streams SPI is
+            // asked to arbitrate are exactly the ones the triggering
+            // transaction declared, and that transaction is still in
+            // flight on every node when SPI runs.
+            unavailable.push({ _id: body.$streams[i], locked: true });
           } else {
-            // Now it may exist we need to check it is SPI for other nodes
-            if (Locker.is(holdValue, "SPI")) {
-              fetchStream.push(db.get(body.$streams[i]));
-            } else {
-              // Held by a transaction, so this node cannot report the
-              // stream right now. Saying nothing is indistinguishable from
-              // "I do not have it", and the caller votes on whatever comes
-              // back - so the stream is under-reported and a minority
-              // revision can carry the vote. Answer with a marker instead.
-              // It has no _rev, so an older node's tally ignores it
-              // exactly as it ignored the silence.
-              //
-              // Note this is reachable precisely when it hurts most. Only
-              // streams named in $i/$o are locked (host.ts hold()), so the
-              // streams SPI is asked to arbitrate are exactly the ones the
-              // triggering transaction declared - and that transaction is
-              // still in flight on every node when SPI runs 100-500ms
-              // after the vote. Locker.hold() over an array is also
-              // all-or-nothing: failing on one stream releases the ones it
-              // did take, so overlapping retries (each resend mints a new
-              // umid) leave part of a transaction's set locked under an
-              // older umid while the rest is free.
-              unavailable.push({ _id: body.$streams[i], locked: true });
-            }
+            fetchStream.push(db.get(body.$streams[i]));
           }
         }
 

--- a/packages/protocol/src/protocol/process.ts
+++ b/packages/protocol/src/protocol/process.ts
@@ -1169,6 +1169,19 @@ export class Process extends EventEmitter {
       if (error) {
         if (error.code === 950) {
           this.shared.raiseLedgerError(error.code, error.reason);
+        } else if (error.code === 1200) {
+          // A position error means this node holds a stream at a revision
+          // the rest of the network does not agree with, and it will vote
+          // the same way against every future transaction touching that
+          // stream. Recording it gives activerestore something durable to
+          // reconcile against later, when the streams are no longer locked
+          // by the transaction that exposed the disagreement.
+          //
+          // stop: true - store the error document only. The broadcast path
+          // below already handles telling the network and the client that
+          // this node voted no; emitting a second failure from here would
+          // report the same vote twice.
+          this.shared.raiseLedgerError(error.code, error.reason, true);
         }
       }
       // Let all other nodes know about this transaction and our opinion

--- a/packages/protocol/src/protocol/streamUpdater.ts
+++ b/packages/protocol/src/protocol/streamUpdater.ts
@@ -354,7 +354,20 @@ export class StreamUpdater {
   private async append() {
     try {
       const bulkWriteResult = await this.db.bulkDocs(this.docs);
-      if (!bulkWriteResult) {
+      // A write that failed does not come back falsy. The self hosted store
+      // answers HTTP 200 with { ok: false } when its batch write fails, and
+      // that object is truthy, so it sailed through this check and the
+      // transaction was recorded as committed with nothing on disk. Only a
+      // transport fault - which ActiveRequest.send() reports as a null body -
+      // was ever caught here.
+      if (
+        !bulkWriteResult ||
+        bulkWriteResult.ok === false ||
+        // CouchDB answers with one result per document instead, where a
+        // rejected document carries an "error" property
+        (Array.isArray(bulkWriteResult) &&
+          bulkWriteResult.some((result: any) => result && result.error))
+      ) {
         throw new Error("Bulk Doc Insert Failed");
       }
 

--- a/packages/restore/src/modules/interagent/interagent.ts
+++ b/packages/restore/src/modules/interagent/interagent.ts
@@ -41,8 +41,21 @@ const REMOVE_CACHE_TIMER = 5 * 60 * 1000;
  * @class Interagent
  */
 export class Interagent {
+  // How many times an error document may fail to reach a decision before it
+  // is given up on. The checker runs every 5 seconds, so this is a couple of
+  // minutes of retrying - long enough to outlast the transaction whose lock
+  // was blocking the sample, short enough not to poll forever over a stream
+  // the network genuinely disagrees about.
+  private static readonly MAX_RESYNC_ATTEMPTS = 20;
+
   private errorCodes = [
     ErrorCodes.StreamNotFound,
+    // A node that votes "Stream Position Incorrect" is telling us it holds a
+    // stream at a revision the rest of the network does not agree with, and
+    // it will keep voting that way against every future transaction on that
+    // stream. It was commented out here as "never came" - correctly, because
+    // nothing wrote an error document for it. protocol/process.ts now does.
+    ErrorCodes.StreamPositionIncorrect,
     //ErrorCodes.StateNotFound,
     //ErrorCodes.VoteFailedNetworkOk,
     //ErrorCodes.InternalBusyLocked,
@@ -155,6 +168,14 @@ export class Interagent {
    * @private
    */
   private async processDocument(changeDoc: any): Promise<void> {
+    // A position error has nothing to replay - the transaction this node
+    // voted against never committed here, and may never have committed
+    // anywhere. What is wrong is the stream's revision, so go straight to
+    // reconciling it rather than hunting a umid that would not help.
+    if (changeDoc.code === ErrorCodes.StreamPositionIncorrect) {
+      return await this.resyncStreams(changeDoc);
+    }
+
     // Check the error codes
     if (
       this.hasErrorCode(changeDoc) // &&
@@ -243,7 +264,9 @@ export class Interagent {
    */
   private async resyncStreams(changeDoc: any): Promise<void> {
     try {
-      const rewrote = await StreamResync.resync(changeDoc.transaction);
+      const { rewrote, incomplete } = await StreamResync.resync(
+        changeDoc.transaction
+      );
 
       if (rewrote) {
         ActiveLogger.info(
@@ -253,14 +276,63 @@ export class Interagent {
         // keeping a record of, the same as a successful umid insert.
         return await this.setProcessed(changeDoc, true);
       }
+
+      // Nothing decided yet. Leaving the document in place is the whole
+      // point: the checker comes back every few seconds, and by then the
+      // transaction that was holding a lock on these streams - very often
+      // the same one that caused this error - has finished and every node
+      // can answer. Marking it processed here would throw away the only
+      // record that this node knows it disagrees with the network, which
+      // is how a node stayed one revision behind indefinitely.
+      if (incomplete) {
+        return await this.retryLater(changeDoc);
+      }
     } catch (error) {
       ActiveLogger.error(
         error,
         `Stream resync failed for umid ${changeDoc.umid}`
       );
+      return await this.retryLater(changeDoc);
     }
 
     return await this.setProcessed(changeDoc, false);
+  }
+
+  /**
+   * Leave an error document unprocessed so the next check picks it up,
+   * unless it has had enough attempts to call it a genuine disagreement
+   * rather than a busy moment.
+   *
+   * @private
+   * @param {*} changeDoc
+   * @returns {Promise<void>}
+   */
+  private async retryLater(changeDoc: any): Promise<void> {
+    const attempts = (changeDoc.resyncAttempts || 0) + 1;
+
+    if (attempts >= Interagent.MAX_RESYNC_ATTEMPTS) {
+      ActiveLogger.error(
+        `Stream resync gave up on umid ${changeDoc.umid} after ${attempts} attempts - this node may still be out of date`
+      );
+      return await this.setProcessed(changeDoc, true);
+    }
+
+    changeDoc.resyncAttempts = attempts;
+
+    try {
+      // Written back rather than held in memory so the count survives a
+      // restart - a node restarting into a retry loop that starts from zero
+      // every time would never reach the give-up point.
+      await Provider.errorDatabase.put(changeDoc);
+      ActiveLogger.info(
+        `Stream resync will retry umid ${changeDoc.umid} (attempt ${attempts})`
+      );
+    } catch (error) {
+      ActiveLogger.error(
+        error,
+        `Could not record resync attempt ${attempts} for umid ${changeDoc.umid}`
+      );
+    }
   }
 
   /**

--- a/packages/restore/src/modules/interagent/stream-resync.ts
+++ b/packages/restore/src/modules/interagent/stream-resync.ts
@@ -159,6 +159,7 @@ export class StreamResync {
 
     for (let i = ids.length; i--; ) {
       let winner: { votes: number; doc: IResyncDocument } | null = null;
+      let forked = false;
 
       const revisions = Object.keys(tally[ids[i]]);
       for (let r = revisions.length; r--; ) {
@@ -176,10 +177,27 @@ export class StreamResync {
               StreamResync.position(winner.doc._rev))
         ) {
           winner = candidate;
+        } else if (
+          winner &&
+          candidate.votes === winner.votes &&
+          candidate.doc._rev !== winner.doc._rev &&
+          StreamResync.position(candidate.doc._rev) ===
+            StreamResync.position(winner.doc._rev)
+        ) {
+          // Two revisions with equal support at the same position is a
+          // fork, not a lag: each side committed something the other did
+          // not, at the same point in the stream's history. Adopting
+          // either silently destroys the other's transaction, and content
+          // addressed revisions give nothing to choose between them on.
+          forked = true;
         }
       }
 
-      if (winner) {
+      if (forked) {
+        ActiveLogger.error(
+          `Stream resync: ${ids[i]} has forked - two revisions at the same position. This needs a human, not a vote.`
+        );
+      } else if (winner) {
         winners[ids[i]] = winner.doc;
       }
     }

--- a/packages/restore/src/modules/interagent/stream-resync.ts
+++ b/packages/restore/src/modules/interagent/stream-resync.ts
@@ -203,16 +203,24 @@ export class StreamResync {
    * Fetch the network's view of every stream a failed transaction touched
    * and adopt any revision this node is behind on.
    *
+   * `incomplete` is the caller's signal to try again later rather than to
+   * give up: it means some node could not report on a stream, so no
+   * decision was safe to make this time. That is the normal state while
+   * the transaction that caused the divergence is still in flight, since
+   * it holds a lock on the very streams being arbitrated.
+   *
    * @static
    * @param {*} transaction
-   * @returns {Promise<number>} how many documents were rewritten
+   * @returns {Promise<{ rewrote: number; incomplete: boolean }>}
    */
-  public static async resync(transaction: any): Promise<number> {
+  public static async resync(
+    transaction: any
+  ): Promise<{ rewrote: number; incomplete: boolean }> {
     const streams = StreamResync.streamIdsFromTransaction(transaction);
 
     if (!streams.length) {
       Helper.output("Stream resync: transaction names no streams");
-      return 0;
+      return { rewrote: 0, incomplete: false };
     }
 
     const networkStreams = await Provider.network.neighbourhood.knockAll(
@@ -235,7 +243,20 @@ export class StreamResync {
       }
     }
 
-    return rewrote;
+    // Any stream we asked about but could not decide is worth coming back
+    // for. Silence from a node is not a verdict.
+    let incomplete = false;
+    for (let i = streams.length; i--; ) {
+      if (!winners[streams[i]]) {
+        incomplete = true;
+        ActiveLogger.warn(
+          `Stream resync: no decision for ${streams[i]} yet, will retry`
+        );
+        break;
+      }
+    }
+
+    return { rewrote, incomplete };
   }
 
   /**

--- a/tests/endpoints.test.ts
+++ b/tests/endpoints.test.ts
@@ -418,3 +418,60 @@ describe("Endpoints.spiConsensus - abstains per stream (Activenetwork)", () => {
     expect(winners["088067:stream"].rev).to.equal("21-799d345c");
   });
 });
+
+// Two revisions at the same position with different content is a fork,
+// not a lag - each side committed something the other did not, at the same
+// point in the stream's history. Revisions here are content addressed
+// (position-md5), so there is nothing to choose between them on merit, and
+// adopting either silently destroys the other side's transaction.
+//
+// A lag looks different and is safe: the positions differ, so the higher
+// one is simply further along and the lower side has no history of its own
+// to lose. Seen live as a 2-2 split on the most-written stream of a four
+// node network.
+describe("Endpoints.spiConsensus - lag versus fork (Activenetwork)", () => {
+  const behind = { _id: "eb10c7", _rev: "103-b00a56b3" };
+  const ahead = { _id: "eb10c7", _rev: "104-2419c533" };
+  const forkA = { _id: "eb10c7", _rev: "104-aaaaaaaa" };
+  const forkB = { _id: "eb10c7", _rev: "104-bbbbbbbb" };
+
+  it("resolves an even split where one side is simply further along", () => {
+    const { winners } = Endpoints.spiConsensus(
+      [[ahead], [ahead], [behind], [behind]],
+      2
+    );
+
+    expect(winners["eb10c7"].rev).to.equal("104-2419c533");
+  });
+
+  it("refuses an even split where both sides are at the same position", () => {
+    const { winners, abstained } = Endpoints.spiConsensus(
+      [[forkA], [forkA], [forkB], [forkB]],
+      2
+    );
+
+    expect(winners["eb10c7"]).to.equal(undefined);
+    expect(abstained["eb10c7"]).to.contain("forked");
+  });
+
+  it("still refuses a fork when one side happens to be asked first", () => {
+    const { winners, abstained } = Endpoints.spiConsensus(
+      [[forkB], [forkB], [forkA], [forkA]],
+      2
+    );
+
+    expect(winners["eb10c7"]).to.equal(undefined);
+    expect(abstained["eb10c7"]).to.contain("forked");
+  });
+
+  it("takes a clear majority even when a fork exists underneath it", () => {
+    // Three nodes agreeing is a majority, not a fork - the odd one out is
+    // outvoted rather than tied
+    const { winners } = Endpoints.spiConsensus(
+      [[forkA], [forkA], [forkA], [forkB]],
+      2
+    );
+
+    expect(winners["eb10c7"].rev).to.equal("104-aaaaaaaa");
+  });
+});

--- a/tests/network/actions.ts
+++ b/tests/network/actions.ts
@@ -84,6 +84,48 @@ export async function deployContract(
   return contractStreamId;
 }
 
+/**
+ * Updates an already-deployed contract in place, the way a real redeploy
+ * does: $entry "update" against the default contract system contract, with
+ * the contract's own stream id as the OUTPUT.
+ *
+ * That output is what makes this different from every other transaction
+ * this suite runs. The contract stream is revision-checked and locked like
+ * any other output, so a node holding it at the wrong revision vetoes the
+ * update - which is the only situation in which that stream is ever
+ * arbitrated.
+ */
+export async function updateContract(
+  baseUrl: string,
+  identity: Identity,
+  namespace: string,
+  contractStreamId: string,
+  contractName: string,
+  sourcePath: string,
+  version: string
+): Promise<any> {
+  const contractSrc = fs.readFileSync(sourcePath, "utf8");
+  const txBody = {
+    $entry: "update",
+    $namespace: "default",
+    $contract: "contract",
+    $i: {
+      [identity.streamId]: {
+        version,
+        namespace,
+        name: contractName,
+        contract: Buffer.from(contractSrc).toString("base64"),
+      },
+    },
+    $o: { [contractStreamId]: {} },
+  };
+  const tx = {
+    $tx: txBody,
+    $sigs: { [identity.streamId]: identity.keyPair.sign(txBody) },
+  };
+  return submit(baseUrl, tx);
+}
+
 /** Runs a deployed contract, writing to (and reading permission from) the caller's own identity stream. */
 export async function runContract(
   baseUrl: string,

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -17,6 +17,7 @@ import {
   onboard,
   registerNamespace,
   deployContract,
+  updateContract,
   runContract,
 } from "./actions";
 import { ActiveCrypto } from "../../packages/crypto/src";
@@ -197,6 +198,8 @@ async function main(): Promise<boolean> {
     await runStoragePathValidationTests(report, nodes);
 
     await runSpiTests(report, nodes, identity, NAMESPACE, returnerId);
+
+    await runContractDivergenceTest(report, nodes, identity, NAMESPACE);
 
     await runNodeRecoveryTests(report, harness, nodes, identity, NAMESPACE, returnerId);
 
@@ -520,6 +523,201 @@ async function runStoragePathValidationTests(
       report.fail(`Expected a non-negative numeric data_size, got ${infoStatus} ${JSON.stringify(info)}`);
     }
   }
+}
+
+
+/**
+ * Reads one stream from every node and reports the distinct revisions.
+ *
+ * Every SPI assertion in this file used to be "did the client get a
+ * response without errors", which is a question about the transaction, not
+ * about the network. A round that commits on three nodes while the fourth
+ * stays behind answers that question with a cheerful yes - and being
+ * behind is precisely the fault worth catching, because that node now
+ * vetoes every future transaction touching the stream. Convergence has to
+ * be read off the nodes themselves.
+ */
+async function revisionsAcross(
+  nodes: NetworkNode[],
+  streamId: string
+): Promise<{ byNode: { port: number; rev: string }[]; converged: boolean }> {
+  const byNode: { port: number; rev: string }[] = [];
+  for (const node of nodes) {
+    try {
+      const doc = await storageGet(node.storageUrl, streamId);
+      byNode.push({ port: node.port, rev: doc?._rev || "missing" });
+    } catch {
+      byNode.push({ port: node.port, rev: "unreadable" });
+    }
+  }
+  const distinct = new Set(byNode.map((n) => n.rev));
+  return { byNode, converged: distinct.size === 1 };
+}
+
+/** Waits for every node to agree on a stream's revision, or gives up. */
+async function waitForConvergence(
+  nodes: NetworkNode[],
+  streamId: string,
+  timeoutMs: number
+): Promise<{ byNode: { port: number; rev: string }[]; converged: boolean }> {
+  const deadline = Date.now() + timeoutMs;
+  let last = await revisionsAcross(nodes, streamId);
+  while (!last.converged && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 1000));
+    last = await revisionsAcross(nodes, streamId);
+  }
+  return last;
+}
+
+/**
+ * The scenario a live network hit that this suite did not: a node holding
+ * a CONTRACT's own stream at the wrong revision.
+ *
+ * The existing SPI tests desync an identity stream, which the transaction
+ * that follows names in $i/$o, so SPI is asked about it directly and the
+ * repair works. A contract's code stream is only ever named in $i/$o by a
+ * contract update - so it is only ever arbitrated during exactly the
+ * transaction that holds it locked on every node, which is the one moment
+ * SPI cannot get a clean sample.
+ *
+ * Asserts the two things that actually matter, separately:
+ *   1. does a majority that agrees still commit when one node dissents
+ *   2. does the dissenting node afterwards catch up
+ *
+ * They are separate because the first can pass while the second fails
+ * forever, which is what happened in production.
+ *
+ * Known state of these two assertions, measured against a real 4-node
+ * network rather than assumed:
+ *
+ * - contract-update-majority-commits FAILS, and fails identically with
+ *   and without the reconciler work. Three nodes vote yes and one commits
+ *   (`vote: 3, commit: 1`). It reproduces locally, on one machine, with no
+ *   container or network layer involved, so it is an engine fault rather
+ *   than anything about how a particular deployment is wired. It is left
+ *   here failing on purpose: it is the regression guard for a bug that is
+ *   still open, and this script is a diagnostic run by hand, not part of
+ *   `npm test`.
+ *
+ * - contract-desync-converged PASSES, but it also passes without the
+ *   reconciler, because the update itself eventually applies on every node
+ *   and overwrites the divergence. So it is a guard against a node being
+ *   left behind, not proof that reconciliation happened. Proving that
+ *   needs a case where the triggering transaction commits nowhere, which
+ *   is what the production incident actually looked like.
+ */
+async function runContractDivergenceTest(
+  report: Report,
+  nodes: NetworkNode[],
+  identity: Identity,
+  namespace: string
+): Promise<void> {
+  const contractSource = path.join(__dirname, "contracts/returner-contract.ts");
+  const desyncTarget = nodes[0];
+  const originNode = nodes[1];
+
+  report.phase("Contract divergence: deploying a contract to update");
+  const contractId = await deployContract(
+    nodes[0].baseUrl,
+    identity,
+    namespace,
+    "divergence",
+    contractSource
+  );
+  report.ok(`Deployed ${contractId}`);
+
+  // A first update, so the stream has a real history and the test is not
+  // measuring anything special about a freshly created stream.
+  const firstUpdate = await updateContract(
+    originNode.baseUrl,
+    identity,
+    namespace,
+    contractId,
+    "divergence",
+    contractSource,
+    "0.0.2"
+  );
+  if (firstUpdate.$summary?.errors) {
+    report.fail(`Baseline contract update failed: ${JSON.stringify(firstUpdate.$summary)}`);
+    report.record("contract-update-baseline", false, 0);
+    return;
+  }
+  report.record("contract-update-baseline", true, 0);
+
+  const settled = await waitForConvergence(nodes, contractId, 15000);
+  if (!settled.converged) {
+    report.fail(
+      `Nodes disagreed before the test even started: ${JSON.stringify(settled.byNode)}`
+    );
+    report.record("contract-update-baseline-converged", false, 0);
+    return;
+  }
+  const baseRev = settled.byNode[0].rev;
+  report.ok(`All nodes agree at ${baseRev}`);
+  report.record("contract-update-baseline-converged", true, 0);
+
+  report.phase(`Contract divergence: desyncing node ${desyncTarget.port}`);
+  // Both documents, because they diverge together in the real fault - the
+  // state document and its :stream meta are written by the same commit.
+  for (const id of [contractId, `${contractId}:stream`]) {
+    const current = await storageGet(desyncTarget.storageUrl, id);
+    await storagePut(desyncTarget.storageUrl, id, {
+      ...current,
+      contractDivergenceMarker: `desync-${Date.now()}`,
+    });
+  }
+  const desynced = await revisionsAcross(nodes, contractId);
+  if (desynced.converged) {
+    report.fail("Desync had no effect - the test cannot prove anything");
+    report.record("contract-desync-injected", false, 0);
+    return;
+  }
+  report.ok(`Injected: ${JSON.stringify(desynced.byNode)}`);
+  report.record("contract-desync-injected", true, 0);
+
+  report.phase("Contract divergence: does a 3/4 majority still commit?");
+  const { result, ms } = await timed(() =>
+    updateContract(
+      originNode.baseUrl,
+      identity,
+      namespace,
+      contractId,
+      "divergence",
+      contractSource,
+      "0.0.3"
+    )
+  );
+
+  // The dissenting node is expected to report a position error - that is
+  // the correct behaviour, not the failure. What matters is whether the
+  // three nodes that agree went ahead and committed anyway.
+  const committed = (result.$summary?.commit ?? 0) >= 3;
+  report.record("contract-update-majority-commits", committed, ms);
+  committed
+    ? report.ok(`Committed on ${result.$summary.commit} nodes with one dissenter (${ms}ms)`)
+    : report.fail(
+        `Only ${result.$summary?.commit ?? 0} nodes committed: ${JSON.stringify(result.$summary)}`
+      );
+
+  report.phase("Contract divergence: does the desynced node catch up?");
+  // Generous, and deliberately so: reconciliation is asynchronous and runs
+  // off a periodic check, so the honest question is "does it ever", not
+  // "does it within one round trip".
+  const converged = await waitForConvergence(nodes, contractId, 60000);
+  report.record("contract-desync-converged", converged.converged, 0);
+  converged.converged
+    ? report.ok(`All four nodes converged at ${converged.byNode[0].rev}`)
+    : report.fail(
+        `Node did not catch up after 60s: ${JSON.stringify(converged.byNode)}`
+      );
+
+  const metaConverged = await waitForConvergence(nodes, `${contractId}:stream`, 15000);
+  report.record("contract-desync-meta-converged", metaConverged.converged, 0);
+  metaConverged.converged
+    ? report.ok(`Meta document converged at ${metaConverged.byNode[0].rev}`)
+    : report.fail(
+        `Meta document still split: ${JSON.stringify(metaConverged.byNode)}`
+      );
 }
 
 /**

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -8,6 +8,7 @@
  */
 
 import * as path from "path";
+import * as fsSync from "fs";
 import { NetworkHarness, NetworkNode } from "./harness";
 import { submit, storageGet, storagePut, requestJsonWithStatus } from "./http";
 import { SSEClient } from "./sse";
@@ -526,6 +527,36 @@ async function runStoragePathValidationTests(
 }
 
 
+
+/**
+ * Reads a node's own log and reports which repair mechanism, if any,
+ * touched a given stream.
+ *
+ * "Did it converge" is necessary but not sufficient - a stream can end up
+ * consistent because the transaction eventually applied everywhere, which
+ * says nothing about whether reconciliation works. Naming the mechanism is
+ * the difference between a test that guards an outcome and one that
+ * proves a cause.
+ */
+function healedBy(node: NetworkNode, streamId: string): string[] {
+  let log = "";
+  try {
+    log = fsSync.readFileSync(node.logPath, "utf8");
+  } catch {
+    return ["log unreadable"];
+  }
+  const short = streamId.slice(0, 16);
+  const found: string[] = [];
+  for (const line of log.split("\n")) {
+    if (line.indexOf(short) === -1) continue;
+    if (line.indexOf("SPI REWRITING") !== -1) found.push("SPI rewrite");
+    if (line.indexOf("Stream resync") !== -1) found.push("restore reconciler");
+    if (line.indexOf("SPI NOWINNER") !== -1) found.push("SPI abstained");
+    if (line.indexOf("SPI REWRITE FAILED") !== -1) found.push("SPI write failed");
+  }
+  return [...new Set(found)];
+}
+
 /**
  * Reads one stream from every node and reports the distinct revisions.
  *
@@ -709,6 +740,16 @@ async function runContractDivergenceTest(
     ? report.ok(`All four nodes converged at ${converged.byNode[0].rev}`)
     : report.fail(
         `Node did not catch up after 60s: ${JSON.stringify(converged.byNode)}`
+      );
+
+  // Name the mechanism. Convergence alone does not distinguish "something
+  // repaired the laggard" from "the update simply applied everywhere in
+  // the end", and only the first is what this suite is here to prove.
+  const mechanisms = healedBy(desyncTarget, contractId);
+  mechanisms.length
+    ? report.info(`Desynced node log shows: ${mechanisms.join(", ")}`)
+    : report.warn(
+        "Desynced node log shows no repair activity - it converged because the update applied, not because anything reconciled"
       );
 
   const metaConverged = await waitForConvergence(nodes, `${contractId}:stream`, 15000);

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -545,16 +545,26 @@ function healedBy(node: NetworkNode, streamId: string): string[] {
   } catch {
     return ["log unreadable"];
   }
+  // Strip ANSI colour before matching. The logger writes escape codes
+  // around the message, and an earlier version of this check filtered
+  // lines by stream id first and found nothing - not because no repair
+  // happened, but because the filter was wrong. A log grep that reports a
+  // clean negative when the log plainly contains the opposite is worse
+  // than no check at all.
+  const plain = log.replace(/\u001b\[[0-9;]*m/g, "");
   const short = streamId.slice(0, 16);
   const found: string[] = [];
-  for (const line of log.split("\n")) {
+  for (const line of plain.split("\n")) {
     if (line.indexOf(short) === -1) continue;
-    if (line.indexOf("SPI REWRITING") !== -1) found.push("SPI rewrite");
+    if (line.indexOf("SPI REWRITE FAILED") !== -1) {
+      found.push("SPI write failed");
+    } else if (line.indexOf("SPI REWRITING") !== -1) {
+      found.push("SPI rewrite");
+    }
     if (line.indexOf("Stream resync") !== -1) found.push("restore reconciler");
     if (line.indexOf("SPI NOWINNER") !== -1) found.push("SPI abstained");
-    if (line.indexOf("SPI REWRITE FAILED") !== -1) found.push("SPI write failed");
   }
-  return [...new Set(found)];
+  return found.filter((v, i) => found.indexOf(v) === i);
 }
 
 /**
@@ -630,12 +640,17 @@ async function waitForConvergence(
  *   still open, and this script is a diagnostic run by hand, not part of
  *   `npm test`.
  *
- * - contract-desync-converged PASSES, but it also passes without the
- *   reconciler, because the update itself eventually applies on every node
- *   and overwrites the divergence. So it is a guard against a node being
- *   left behind, not proof that reconciliation happened. Proving that
- *   needs a case where the triggering transaction commits nowhere, which
- *   is what the production incident actually looked like.
+ * - contract-desync-converged PASSES, and the desynced node's own log
+ *   names SPI as what repaired it - "SPI REWRITING #2 <stream> @ <rev>"
+ *   carrying the exact revision the network converged on, for both the
+ *   state document and its :stream meta. So on a clean 3-1 split with an
+ *   answerable sample, the existing repair does work end to end.
+ *
+ *   That does not extend to the case this suite still cannot construct:
+ *   the production incident had the triggering transaction commit NOWHERE,
+ *   which leaves the divergence in place and is what the idle reconciler
+ *   is for. Here the update does commit, so this proves SPI, not the
+ *   reconciler.
  */
 async function runContractDivergenceTest(
   report: Report,
@@ -749,8 +764,23 @@ async function runContractDivergenceTest(
   mechanisms.length
     ? report.info(`Desynced node log shows: ${mechanisms.join(", ")}`)
     : report.warn(
-        "Desynced node log shows no repair activity - it converged because the update applied, not because anything reconciled"
+        `Desynced node log shows no repair activity for ${contractId.slice(0, 16)}`
       );
+
+  // A negative from a log grep is only worth anything if the log contains
+  // what you think it does. Report what SPI actually said, so an empty
+  // result above can be read as "it did not repair" rather than "the
+  // filter missed".
+  try {
+    const raw = fsSync.readFileSync(desyncTarget.logPath, "utf8");
+    const spiLines = raw.split("\n").filter((l) => l.indexOf("SPI") !== -1);
+    report.info(`Desynced node logged ${spiLines.length} SPI lines`);
+    for (const line of spiLines.slice(-6)) {
+      report.info(`  ${line.slice(0, 200)}`);
+    }
+  } catch {
+    report.warn("Could not read the desynced node's log");
+  }
 
   const metaConverged = await waitForConvergence(nodes, `${contractId}:stream`, 15000);
   report.record("contract-desync-meta-converged", metaConverged.converged, 0);

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -631,14 +631,16 @@ async function waitForConvergence(
  * Known state of these two assertions, measured against a real 4-node
  * network rather than assumed:
  *
- * - contract-update-majority-commits FAILS, and fails identically with
- *   and without the reconciler work. Three nodes vote yes and one commits
- *   (`vote: 3, commit: 1`). It reproduces locally, on one machine, with no
- *   container or network layer involved, so it is an engine fault rather
- *   than anything about how a particular deployment is wired. It is left
- *   here failing on purpose: it is the regression guard for a bug that is
- *   still open, and this script is a diagnostic run by hand, not part of
- *   `npm test`.
+ * - contract-update-majority-commits PASSES, and getting there corrected
+ *   the fault it was written for. `$summary` reports `vote: 3, commit: 1`,
+ *   which reads as a majority failing to commit - but every one of the
+ *   three healthy nodes has written the new revision by the time the
+ *   client's response arrives. The commit count is what the ORIGIN had
+ *   heard when it formed its reply, not what happened: nodes commit after
+ *   voting, and the origin answers before their confirmations get back to
+ *   it. Asserting on $summary.commit measures the origin's knowledge;
+ *   asserting on the stores measures the ledger. This does the latter and
+ *   prints both, because the gap between them is itself worth seeing.
  *
  * - contract-desync-converged PASSES, and the desynced node's own log
  *   names SPI as what repaired it - "SPI REWRITING #2 <stream> @ <rev>"
@@ -737,12 +739,33 @@ async function runContractDivergenceTest(
   // The dissenting node is expected to report a position error - that is
   // the correct behaviour, not the failure. What matters is whether the
   // three nodes that agree went ahead and committed anyway.
-  const committed = (result.$summary?.commit ?? 0) >= 3;
+  // $summary.commit is what the ORIGIN had heard by the time it formed a
+  // response, which is not the same question as how many nodes actually
+  // wrote. Read both, and judge on the stores.
+  const reported = result.$summary?.commit ?? 0;
+  const immediately = await revisionsAcross(nodes, contractId);
+  // Only the three healthy nodes count. The desynced one was moved off the
+  // base revision by the injection itself, so including it would report a
+  // write that never happened.
+  const healthy = immediately.byNode.filter((n) => n.port !== desyncTarget.port);
+  const advanced = healthy.filter((n) => n.rev !== baseRev).length;
+
+  report.info(`$summary reported commit: ${reported}, vote: ${result.$summary?.vote}`);
+  report.info(
+    `Stores show ${advanced}/${healthy.length} healthy nodes moved off the base revision`
+  );
+
+  const committed = advanced >= 3;
   report.record("contract-update-majority-commits", committed, ms);
   committed
-    ? report.ok(`Committed on ${result.$summary.commit} nodes with one dissenter (${ms}ms)`)
+    ? report.ok(
+        `${advanced}/${healthy.length} healthy nodes wrote the update with one dissenter (${ms}ms)` +
+          (reported < advanced
+            ? ` - note $summary under-reported this as ${reported}`
+            : "")
+      )
     : report.fail(
-        `Only ${result.$summary?.commit ?? 0} nodes committed: ${JSON.stringify(result.$summary)}`
+        `Only ${advanced}/${healthy.length} healthy nodes wrote it: ${JSON.stringify(immediately.byNode)} / summary ${JSON.stringify(result.$summary)}`
       );
 
   report.phase("Contract divergence: does the desynced node catch up?");

--- a/tests/restore-stream-resync.test.ts
+++ b/tests/restore-stream-resync.test.ts
@@ -184,7 +184,7 @@ describe("StreamResync - adopting the agreed revision (Activerestore)", () => {
     // could never be repaired by any restore path
     local["stream-a"] = { _id: "stream-a", _rev: "38-c54a2e1c" };
 
-    const rewrote = await StreamResync.resync(transaction);
+    const { rewrote } = await StreamResync.resync(transaction);
 
     expect(rewrote).to.equal(1);
     expect(writes).to.have.length(1);
@@ -198,7 +198,7 @@ describe("StreamResync - adopting the agreed revision (Activerestore)", () => {
   it("creates a missing document with new_edits:false to keep the network revision", async () => {
     // new_edits:true on a create mints a fresh "1-<md5>", which would
     // leave this node claiming position 1 for a stream at position 39
-    const rewrote = await StreamResync.resync(transaction);
+    const { rewrote } = await StreamResync.resync(transaction);
 
     expect(rewrote).to.equal(1);
     expect(writes[0].options).to.deep.equal({ new_edits: false });
@@ -207,7 +207,7 @@ describe("StreamResync - adopting the agreed revision (Activerestore)", () => {
   it("writes nothing when this node already holds the agreed revision", async () => {
     local["stream-a"] = { _id: "stream-a", _rev: "39-246bc890" };
 
-    const rewrote = await StreamResync.resync(transaction);
+    const { rewrote } = await StreamResync.resync(transaction);
 
     expect(rewrote).to.equal(0);
     expect(writes).to.have.length(0);
@@ -218,7 +218,7 @@ describe("StreamResync - adopting the agreed revision (Activerestore)", () => {
     // discarding local state would make it unrecoverable
     local["stream-a"] = { _id: "stream-a", _rev: "40-aaaaaaaa" };
 
-    const rewrote = await StreamResync.resync(transaction);
+    const { rewrote } = await StreamResync.resync(transaction);
 
     expect(rewrote).to.equal(0);
     expect(writes).to.have.length(0);
@@ -231,7 +231,7 @@ describe("StreamResync - adopting the agreed revision (Activerestore)", () => {
     ];
     local["stream-a"] = { _id: "stream-a", _rev: "38-c54a2e1c" };
 
-    const rewrote = await StreamResync.resync(transaction);
+    const { rewrote } = await StreamResync.resync(transaction);
 
     expect(rewrote).to.equal(0);
     expect(writes).to.have.length(0);
@@ -244,7 +244,7 @@ describe("StreamResync - adopting the agreed revision (Activerestore)", () => {
       return [];
     };
 
-    const rewrote = await StreamResync.resync({ $tx: { $i: {}, $o: {} } });
+    const { rewrote } = await StreamResync.resync({ $tx: { $i: {}, $o: {} } });
 
     expect(rewrote).to.equal(0);
     expect(knocked).to.equal(false);
@@ -315,6 +315,7 @@ describe("Interagent - falling back to a stream resync (Activerestore)", () => {
     "088067b4445fe980865ae3c7fcf20564580abe0ca3f08bf123719c4a75611d1f";
 
   let processed: { archived: boolean }[];
+  let retried: any[];
   let writes: { docs: any[]; options: any }[];
   let local: { [id: string]: any };
   let knocked: string[];
@@ -340,10 +341,14 @@ describe("Interagent - falling back to a stream resync (Activerestore)", () => {
       processed.push({ archived: !!archive });
     },
     resyncStreams: (Interagent.prototype as any).resyncStreams,
+    retryLater: async (doc: any) => {
+      retried.push(doc);
+    },
   });
 
   beforeEach(() => {
     processed = [];
+    retried = [];
     writes = [];
     knocked = [];
     local = {
@@ -427,7 +432,7 @@ describe("Interagent - falling back to a stream resync (Activerestore)", () => {
     expect(processed).to.deep.equal([{ archived: false }]);
   });
 
-  it("does not leave the error document unprocessed when the resync throws", async () => {
+  it("keeps the error document for a retry when the resync throws", async () => {
     (Provider as any).network.neighbourhood.knockAll = async (
       endpoint: string
     ) => {
@@ -442,7 +447,151 @@ describe("Interagent - falling back to a stream resync (Activerestore)", () => {
       errorDocument
     );
 
+    // A network that was down for a moment is not a verdict either
     expect(writes).to.have.length(0);
-    expect(processed).to.deep.equal([{ archived: false }]);
+    expect(processed).to.have.length(0);
+    expect(retried).to.have.length(1);
+  });
+});
+
+// The self-heal gap that survived 4.5.8. SPI only runs on a failed vote,
+// a failed vote on a contract stream only happens during a contract
+// update, and that update holds a lock on the very streams SPI needs to
+// sample - on every node, for its whole lifetime. So SPI's sample was
+// always incomplete, it always abstained (correctly), and there was no
+// path that ever retried when the streams were idle and answerable.
+//
+// The retry is the interagent's existing 5 second checker: leave the
+// error document unprocessed and it comes back when nothing is holding
+// the lock.
+describe("Interagent - retrying an undecided resync (Activerestore)", () => {
+  const streamId =
+    "088067b4445fe980865ae3c7fcf20564580abe0ca3f08bf123719c4a75611d1f";
+
+  let processed: { archived: boolean }[];
+  let stored: any[];
+  let writes: any[];
+  let locked: boolean;
+
+  const positionError = () => ({
+    _id: "umid-xyz:1788897627000",
+    code: 1200,
+    umid: "umid-xyz",
+    processed: false,
+    reason: "Output Stream Position Incorrect (21:39 !== 20:38 - Local)",
+    transaction: { $tx: { $i: {}, $o: { [streamId]: {} } } },
+  });
+
+  const context = () => ({
+    hasErrorCode: () => true,
+    verifyUmidNotFound: async () => {
+      throw new Error("a position error must not chase a umid");
+    },
+    setProcessed: async (_doc: any, archive: boolean) => {
+      processed.push({ archived: !!archive });
+    },
+    resyncStreams: (Interagent.prototype as any).resyncStreams,
+    retryLater: (Interagent.prototype as any).retryLater,
+  });
+
+  beforeEach(() => {
+    processed = [];
+    stored = [];
+    writes = [];
+    locked = true;
+
+    (Provider as any).neighbourCount = 4;
+    (Provider as any).consensusReachedAmount = 60;
+    (Provider as any).errorDatabase = {
+      put: async (doc: any) => {
+        stored.push(JSON.parse(JSON.stringify(doc)));
+        return doc;
+      },
+    };
+    const local: { [id: string]: any } = {
+      [streamId]: { _id: streamId, _rev: "38-c54a2e1c" },
+      [`${streamId}:stream`]: {
+        _id: `${streamId}:stream`,
+        _rev: "20-d89395f3",
+      },
+    };
+    (Provider as any).database = {
+      get: async (id: string) => {
+        if (!local[id]) {
+          throw { notFound: true };
+        }
+        return local[id];
+      },
+      bulkDocs: async (docs: any[], options: any) => {
+        writes.push({ docs, options });
+        return { ok: true };
+      },
+    };
+    (Provider as any).network = {
+      neighbourhood: {
+        knockAll: async () => {
+          // While the update transaction is in flight every node holds the
+          // stream locked and can only answer with the marker
+          if (locked) {
+            return [
+              [{ _id: streamId, locked: true }],
+              [{ _id: streamId, locked: true }],
+              [{ _id: streamId, locked: true }],
+            ];
+          }
+          const agreed = [
+            { _id: streamId, _rev: "39-246bc890" },
+            { _id: `${streamId}:stream`, _rev: "21-799d345c" },
+          ];
+          return [agreed, agreed, agreed];
+        },
+      },
+    };
+  });
+
+  const run = (doc: any) =>
+    (Interagent.prototype as any).processDocument.call(context(), doc);
+
+  it("keeps the error document when every peer was locked", async () => {
+    await run(positionError());
+
+    // Not processed, not purged - it has to survive to be retried
+    expect(processed).to.have.length(0);
+    expect(writes).to.have.length(0);
+    expect(stored).to.have.length(1);
+    expect(stored[0].resyncAttempts).to.equal(1);
+  });
+
+  it("heals on a later attempt once the locks have cleared", async () => {
+    const doc = positionError();
+    await run(doc);
+
+    expect(writes).to.have.length(0);
+
+    // The transaction finishes, the locks release, the checker comes back
+    locked = false;
+    await run({ ...doc, resyncAttempts: 1 });
+
+    expect(writes).to.have.length(2);
+    const byId: { [id: string]: any } = {};
+    writes.forEach((w) => (byId[w.docs[0]._id] = w));
+    expect(byId[streamId].options).to.deep.equal({
+      new_edits: true,
+      force_rev: "39-246bc890",
+    });
+    expect(processed).to.deep.equal([{ archived: true }]);
+  });
+
+  it("gives up rather than retrying forever", async () => {
+    await run({ ...positionError(), resyncAttempts: 19 });
+
+    expect(stored).to.have.length(0);
+    expect(processed).to.deep.equal([{ archived: true }]);
+  });
+
+  it("counts attempts durably so a restart cannot reset them", async () => {
+    await run({ ...positionError(), resyncAttempts: 7 });
+
+    expect(stored[0].resyncAttempts).to.equal(8);
   });
 });


### PR DESCRIPTION
Follow-up to #59, from running 4.5.8 on a live four-node network. The abstain fix worked exactly as intended — no wrong repair — which exposed the deeper problem underneath it.

## The deadlock

SPI only runs on a **failed vote**. A failed vote on a contract stream only happens during a **contract update**. That update holds a lock on the very streams SPI needs to sample — on every node, for its entire lifetime.

So SPI's sample is always incomplete, it always abstains (correctly), and nothing ever tries again. There is no moment at which a lagging node can reconcile a stream while it is idle and answerable.

Live result from a scoped update against the diverged stream:

```
SPI NOWINNER #2 - 088067… (sample incomplete, 4 node(s) could not report)
```

No wrong repair. No repair.

## The fix, using a loop that already exists

`activerestore`'s interagent already polls the error database **every five seconds**. This wires the case into it rather than adding a background service:

- **`process.ts` records an error document for a 1200 position error** in broadcast mode. Only 950 did before, so a dissent left nothing durable behind — and the interagent's own list had 1200 commented out as `// never came`, which was accurate and self-fulfilling. Stored with `stop: true` so the broadcast path still owns reporting the vote.
- **The interagent acts on 1200 by going straight to a stream resync.** Replaying by umid is meaningless for a position error: the transaction didn't commit here and may not have committed anywhere.
- **An undecided resync leaves the error document in place** instead of purging it, so the next poll retries once the locks have cleared. Capped at 20 attempts, counted on the document so a restart can't reset it, then archived as a genuine disagreement.

**This heals a node whether or not the transaction that exposed the divergence ever commits.** It only needs the network to agree on a revision the node doesn't hold — which is exactly the situation on the affected network, where the triggering update failed to commit anywhere.

## SPI was starving the writer

`Endpoints.streams()` held `Locker.hold(stream, "SPI")` for a second on every request. `host.ts`'s `hold()` refuses a transaction if any of its streams is held **by anything, "SPI" included** — so a stream several peers were asking about had a read lock on it near-continuously, and the transaction trying to write it went into the busy-locks queue repeatedly.

Observed as a contract update running **30 seconds to its TTL** while every node logged `Lock busy for <stream>. Held by <umid>, requested by SPI` throughout — SPI contending the very save it was waiting on, only ever to read.

Nothing needed that lock: two nodes reconciling the same stream each rewrite their own local copy to the majority revision, so the writes are idempotent and cannot race. The endpoint now reads without locking, and still answers `{locked: true}` when a real transaction holds the stream — the case that genuinely means "my answer wouldn't be a safe vote".

## And one more silent success

`streamUpdater`'s `append()` tested `if (!bulkWriteResult)`. A failed write doesn't come back falsy — the self-hosted store answers HTTP 200 with `{ok: false}` (truthy), and CouchDB answers with per-document results carrying `error`. Only a transport fault was ever caught, so a genuinely rejected write was recorded as a successful commit. Relevant here: two nodes reported `Failed to save streams` during the failed update, and that check is why a *rejected* write wouldn't have.

## Tests

`npm test`: **182 passing, 0 failing** (175 before). New coverage asserts the error document survives an undecided pass, that a later attempt heals once locks clear, that attempts are counted durably, and that it gives up rather than polling forever.