### PR TITLE
The client outlived the server's connection, and writes died on dead sockets

### DIFF
--- a/packages/utilities/src/request.ts
+++ b/packages/utilities/src/request.ts
@@ -36,18 +36,68 @@ interface IHTTPResponse {
 // Below this many bytes, gzip's CPU cost outweighs the bandwidth it saves.
 const GZIP_MIN_BYTES = 1024;
 
-setGlobalDispatcher(
-  new Agent({
-    connect: {
-      rejectUnauthorized: false,
-    },
-    // Nodes repeatedly talk to the same small, fixed set of neighbours.
-    // undici's 4s default tears the socket down between consensus rounds
-    // more often than needed, forcing a fresh TCP+TLS handshake. 30s keeps
-    // connections warm across typical gaps without holding them open forever.
-    keepAliveTimeout: 30_000,
-  })
-);
+/**
+ * How long the SERVER we talk to keeps an idle connection.
+ *
+ * The self hosted store is @activeledger/httpd, which calls uWebSockets'
+ * App() with no options - and uWS's AppOptions has no timeout field at
+ * all, only TLS settings. Its HTTP idle timeout is compiled in: 10s
+ * upstream, swept by a ~4s timer, so an idle socket is closed somewhere in
+ * the 10-14s band. Measured at 11.8s against a live node.
+ *
+ * Not configurable, so it is a ceiling to design under rather than a
+ * number to change.
+ */
+export const SERVER_IDLE_TIMEOUT_MS = 10_000;
+
+/**
+ * How long WE keep an idle connection. Must be comfortably below
+ * SERVER_IDLE_TIMEOUT_MS - see the invariant asserted in the tests.
+ *
+ * This is undici's own default. It was raised to 30s in 16d3a9f to avoid
+ * a fresh handshake between consensus rounds, without the server's idle
+ * timeout in view, and that opened a ~20 second window in which this
+ * client would hand a request to a socket the server had already closed.
+ *
+ * undici does not retry non-idempotent requests, and a stream write is a
+ * POST to _bulk_docs. So the failure landed exactly there:
+ *
+ *   idle connection -> server closes at ~10s -> we reuse it inside our 30s
+ *   window -> POST dies on a dead socket -> ActiveRequest.send() returns
+ *   { data: null } -> bulkDocs resolves null -> streamUpdater raises 1510
+ *   "Failed to save streams" -> that node drops out of the round.
+ *
+ * Which is intermittent, hits writes but not reads (GETs are idempotent
+ * and undici retries them silently), leaves nothing in the server's log
+ * because the close was deliberate, and gets WORSE on quiet nodes, whose
+ * connections sit idle long enough to cross the server's timeout more
+ * often. On a four node network, losing two nodes to this is enough to
+ * put a round below consensus and commit nothing anywhere.
+ *
+ * The handshake this was avoiding costs a millisecond or two on a LAN. A
+ * lost commit costs a transaction.
+ */
+const CLIENT_IDLE_TIMEOUT_MS = 4_000;
+
+export const DISPATCHER_OPTIONS = {
+  connect: {
+    rejectUnauthorized: false,
+  },
+  keepAliveTimeout: CLIENT_IDLE_TIMEOUT_MS,
+  // Pinned as well as the default above. Left at undici's 600s default, a
+  // server advertising a long "Keep-Alive: timeout=N" would be honoured
+  // for up to ten minutes, which is the same bug against a different peer.
+  keepAliveMaxTimeout: CLIENT_IDLE_TIMEOUT_MS,
+};
+
+// One dispatcher governs every undici copy in the process: it is stored on
+// globalThis under Symbol.for("undici.globalDispatcher.1"), a registered
+// symbol, so the three copies in this workspace (utilities, options,
+// nano-gateway - all 6.18.2, all the same symbol version) share it. This
+// is the only setGlobalDispatcher call in the codebase. Anything that
+// somehow bypasses it falls back to undici's own 4s default, which is
+// safe by the same margin.
+setGlobalDispatcher(new Agent(DISPATCHER_OPTIONS));
 
 /**
  * Simple HTTP Request Object

--- a/tests/request-keepalive.test.ts
+++ b/tests/request-keepalive.test.ts
@@ -1,0 +1,46 @@
+import {
+  DISPATCHER_OPTIONS,
+  SERVER_IDLE_TIMEOUT_MS,
+} from "../packages/utilities/src/request";
+import { expect } from "chai";
+import "mocha";
+
+// These assert a RELATIONSHIP, not a number. The bug was never that 30s
+// was wrong in isolation - it was that nobody wrote down what it had to be
+// smaller than, so raising it looked like a free performance win.
+//
+// A client keep-alive longer than the server's idle timeout means the
+// client hands requests to sockets the server has already closed. undici
+// does not retry non-idempotent requests, so writes fail and reads do not:
+// a stream write is a POST to _bulk_docs, and it surfaced as intermittent
+// 1510 "Failed to save streams" with nothing in the server's log, taking
+// nodes out of consensus rounds.
+describe("ActiveRequest dispatcher keep-alive (Activeutilities)", () => {
+  it("expires an idle connection before the server does", () => {
+    expect(DISPATCHER_OPTIONS.keepAliveTimeout).to.be.lessThan(
+      SERVER_IDLE_TIMEOUT_MS
+    );
+  });
+
+  it("leaves real margin, not a boundary", () => {
+    // The server sweeps its timeout on a timer rather than to the
+    // millisecond, so "just under" is not under
+    expect(SERVER_IDLE_TIMEOUT_MS - DISPATCHER_OPTIONS.keepAliveTimeout).to.be.at.least(
+      2_000
+    );
+  });
+
+  it("caps the ceiling too, so a server hint cannot re-raise it", () => {
+    // undici honours a server's "Keep-Alive: timeout=N" up to
+    // keepAliveMaxTimeout, which defaults to 600s
+    expect(DISPATCHER_OPTIONS.keepAliveMaxTimeout).to.be.lessThan(
+      SERVER_IDLE_TIMEOUT_MS
+    );
+  });
+
+  it("still reuses connections rather than disabling keep-alive", () => {
+    // The point is a safe window, not no window - tearing down every
+    // socket would reintroduce the handshake cost 16d3a9f was avoiding
+    expect(DISPATCHER_OPTIONS.keepAliveTimeout).to.be.greaterThan(0);
+  });
+});


### PR DESCRIPTION
The intermittent `1510 "Failed to save streams"` that has been taking nodes out of consensus rounds. Separate from #63, which does not touch it.

## The mismatch

`keepAliveTimeout` was raised from undici's 4s default to **30s** in `16d3a9f` to avoid a fresh handshake between consensus rounds. The server closes idle connections at **~10s**.

That leaves roughly twenty seconds in which this client hands requests to sockets the server has already closed. **undici does not retry non-idempotent requests**, and a stream write is a POST to `_bulk_docs`:

```
idle connection → server closes at ~10s → client reuses it inside its 30s window
→ POST dies on a dead socket → ActiveRequest.send() returns { data: null }
→ bulkDocs resolves null → streamUpdater raises 1510 → node drops out of the round
```

**Measured on a live node:** the store closed an idle keep-alive socket at **11.8s** while the client held it for 30s.

## Why it looked like everything except what it was

| Observation | Explained by |
|---|---|
| Intermittent | Only when that connection has been idle 10–30s |
| Writes fail, reads don't | GETs are idempotent — undici retries them silently. POSTs are not. |
| Nothing in the server's log | The close was deliberate |
| Worse on *quiet* nodes | Their connections idle long enough to cross the server's timeout more often — traffic pattern, not hardware |
| Whole rounds committing nowhere | On four nodes, losing two this way puts the round below consensus |

## The server end cannot move

`httpd` calls uWebSockets' `App()` with no options, and `AppOptions` has no timeout field at all — only TLS settings. Its HTTP idle timeout is compiled in (10s upstream, swept on a ~4s timer, hence 11.8s observed). The client is the only end that can be fixed.

## The fix

Back to 4s, with `keepAliveMaxTimeout` pinned to match — left at undici's 600s default, a server advertising a long `Keep-Alive: timeout=N` would be honoured for **up to ten minutes**, which is the same bug against a different peer.

**The tests assert the relationship, not the number.** The original change wasn't wrong to want a warm connection; the problem was that nothing recorded what the value had to stay *under*, so raising it read as a free performance win. `SERVER_IDLE_TIMEOUT_MS` now sits next to the value that has to stay below it, and the suite fails if that ordering is ever broken again.

Mutation-checked: restoring 30s fails 3 of the 4 new tests.

## Scope

One dispatcher covers everything — it lives on `globalThis` under `Symbol.for("undici.globalDispatcher.1")`, a registered symbol, so all three undici copies in the workspace (utilities, options, nano-gateway — all 6.18.2, same symbol version) share it. This is the only `setGlobalDispatcher` call in the codebase, and anything that somehow bypasses it falls back to undici's own 4s default, which is safe by the same margin.

Optional follow-up, not included: have `httpd` send `Keep-Alive: timeout=10` so the server states its own policy rather than every client having to be told.

`npm test`: 182 passing, 0 failing.