### PR TITLE
A node that originates a transaction on a stream it lags could never heal

### DIFF
--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -293,6 +293,10 @@ export class Endpoints {
                                 const networkStreams =
                                   await host.neighbourhood.knockAll("stream", {
                                     $streams: streams,
+                                    // So a peer holding these under THIS
+                                    // transaction can answer properly if it
+                                    // has already voted against it
+                                    $umid: tx.$umid,
                                   });
 
                                 // Optimise this loop once we know we have 50+% (or config) (TODO - Make static calc)
@@ -1157,6 +1161,7 @@ export class Endpoints {
                         const networkStreams =
                           await host.neighbourhood.knockAll("stream", {
                             $streams: streams,
+                            $umid: tx.$umid,
                           });
 
                         // Optimise this loop once we know we have 50+% (or config) (TODO - Make static calc)
@@ -1511,7 +1516,11 @@ export class Endpoints {
    * @param {*} body
    * @returns {Promise<any>}
    */
-  public static streams(db: ActiveDSConnect, body: any): Promise<any> {
+  public static streams(
+    db: ActiveDSConnect,
+    body: any,
+    host?: Host
+  ): Promise<any> {
     return new Promise((resolve, reject) => {
       if (body.$streams) {
         // Restrict Access to any volatile requests
@@ -1549,7 +1558,33 @@ export class Endpoints {
           // at once each rewrite their OWN copy to the revision the
           // majority voted for, so the writes are idempotent and cannot
           // race each other.
-          if (Locker.has(holdValue)) {
+          // A stream this node is writing cannot be sampled safely, with
+          // one exception: the transaction holding it is the SAME one the
+          // asking node is running SPI for, AND this node has already voted
+          // against it. A node that voted no never reaches commit(), so its
+          // copy is not going to move and reading it is safe.
+          //
+          // That exception is the whole point. A broadcast contract update
+          // locks its output stream on every node, so when the origin's own
+          // vote fails and it runs SPI, every peer is holding the very
+          // stream it needs to ask about - and answers "locked". The origin
+          // abstains on a sample its own transaction spoiled, and a node
+          // that is the origin of the transaction it is behind on can never
+          // heal. With this, the three peers that rejected it answer with
+          // their real revision, the origin gets a clean majority, and it
+          // corrects itself inside the same failed round.
+          //
+          // The vote check is not optional. Without it this reads a stream
+          // a peer may be committing, and a commit writes the state
+          // document and its :stream meta in one batch while SPI fetches
+          // them as two requests - so a mid-commit sample can pair
+          // state@43 with meta@21. Writing that pair locally makes
+          // meta._rev:state._rev permanently wrong, which is a worse fault
+          // than the one being fixed and is not repairable by SPI.
+          const heldByAsker =
+            body.$umid && Locker.is(holdValue, body.$umid);
+
+          if (Locker.has(holdValue) && !(heldByAsker && host?.willNotCommit(body.$umid))) {
             // Held by a transaction, so this node cannot report the stream
             // right now. Saying nothing is indistinguishable from "I do not
             // have it", and the caller votes on whatever comes back - so

--- a/packages/network/src/network/host.ts
+++ b/packages/network/src/network/host.ts
@@ -187,6 +187,56 @@ export class Host extends Home {
   private dbEventConnection: ActiveDSConnect;
 
   /**
+   * Has this node already decided it will NOT commit a transaction?
+   *
+   * Used to answer a peer asking about a stream this node currently holds
+   * locked. Normally that is refused - a stream being written cannot be
+   * sampled safely - but a node that has voted NO will never write it, so
+   * its documents are stable and the read is safe by construction.
+   *
+   * The three states are deliberately distinct:
+   *
+   *   early     - voting has not concluded. postVote() deletes this flag
+   *               when the node's opinion becomes real, so while it is set
+   *               nothing is known and the answer must be no.
+   *   vote true - it may still commit, and a commit writes the state and
+   *               meta documents together. Reading between those two is
+   *               how a node ends up with a mismatched
+   *               meta._rev:state._rev pair, which produces position
+   *               errors on that stream forever.
+   *   vote false- voting concluded against. commit() gates on
+   *               nodeResponse.vote, so this node cannot write for this
+   *               transaction. Safe.
+   *
+   * @static
+   * @param {ActiveDefinitions.LedgerEntry} [entry]
+   * @param {string} reference this node's own reference
+   * @returns {boolean}
+   */
+  public static hasVotedAgainst(
+    entry: ActiveDefinitions.LedgerEntry | undefined,
+    reference: string
+  ): boolean {
+    const response = entry?.$nodes?.[reference];
+    if (!response || response.early) {
+      return false;
+    }
+    return response.vote === false;
+  }
+
+  /**
+   * Whether this node has voted against the transaction holding a lock,
+   * and so cannot be part-way through writing its streams.
+   *
+   * @param {string} umid
+   * @returns {boolean}
+   */
+  public willNotCommit(umid: string): boolean {
+    const pending = this.processPending[umid];
+    return Host.hasVotedAgainst(pending?.entry, Home.reference);
+  }
+
+  /**
    * Holds the processPending requests before processing
    *
    * @private
@@ -2193,7 +2243,7 @@ export class Host extends Home {
             }
             break;
           case "/a/stream": // Stream Data Management (Activerestore)
-            response = Endpoints.streams(this.dbConnection, body);
+            response = Endpoints.streams(this.dbConnection, body, this);
             break;
           default:
             return this.writeResponse(res, 404, "Not Found", gzipAccepted);

--- a/tests/spi-origin-heal.test.ts
+++ b/tests/spi-origin-heal.test.ts
@@ -1,0 +1,125 @@
+import { Host } from "../packages/network/src/network/host";
+import { Endpoints } from "../packages/network/src/network/endpoints";
+import { Locker } from "../packages/network/src/network/locker";
+import { expect } from "chai";
+import "mocha";
+
+const STREAM =
+  "5d1750a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d";
+
+// A broadcast contract update locks its output stream on every node. So
+// when the origin's own vote fails on that stream and it runs SPI, every
+// peer is holding the exact stream it needs to ask about, answers
+// "locked", and the origin abstains on a sample its own transaction
+// spoiled. A node that is the origin of the transaction it is behind on
+// could therefore never heal - which is why one production laggard healed
+// (its update was sent through an up-to-date node) and two did not.
+//
+// The exception that fixes it: a peer that has already voted AGAINST that
+// transaction will never write those streams, so its copy is stable and
+// can be read. Everything here is about keeping that exception exactly
+// that narrow.
+describe("Host.hasVotedAgainst (Activenetwork)", () => {
+  const entry = (self: any): any => ({ $nodes: { me: self, other: {} } });
+
+  it("is true once this node has voted no", () => {
+    expect(Host.hasVotedAgainst(entry({ vote: false, commit: false }), "me")).to.equal(true);
+  });
+
+  it("is false while voting is still open", () => {
+    // postVote() deletes `early` when the opinion becomes real. Until then
+    // nothing is known, and a maybe must read as no.
+    expect(
+      Host.hasVotedAgainst(entry({ vote: false, commit: false, early: true }), "me")
+    ).to.equal(false);
+  });
+
+  it("is false when this node voted yes, even before it commits", () => {
+    // It may still write, and a write is what makes a read unsafe
+    expect(Host.hasVotedAgainst(entry({ vote: true, commit: false }), "me")).to.equal(false);
+  });
+
+  it("is false when this node has already committed", () => {
+    expect(Host.hasVotedAgainst(entry({ vote: true, commit: true }), "me")).to.equal(false);
+  });
+
+  it("is false for an unknown transaction or an absent record", () => {
+    expect(Host.hasVotedAgainst(undefined, "me")).to.equal(false);
+    expect(Host.hasVotedAgainst({ $nodes: {} } as any, "me")).to.equal(false);
+  });
+});
+
+describe("Endpoints.streams - answering about a locked stream (Activenetwork)", () => {
+  const doc = { _id: STREAM, _rev: "42-746224aa" };
+  const db: any = {
+    get: async (id: string) => (id === STREAM ? doc : { error: "not found" }),
+  };
+  const hostThatVotedAgainst: any = { willNotCommit: () => true };
+  const hostThatMayCommit: any = { willNotCommit: () => false };
+
+  const ask = async (body: any, host?: any) =>
+    ((await Endpoints.streams(db, body, host)) as any).content;
+
+  afterEach(() => Locker.release(STREAM, "tx-under-way"));
+
+  it("reports the real revision to the transaction that holds the lock, once it has been voted down", async () => {
+    Locker.hold(STREAM, "tx-under-way");
+
+    const content = await ask(
+      { $streams: [STREAM], $umid: "tx-under-way" },
+      hostThatVotedAgainst
+    );
+
+    expect(content).to.deep.equal([doc]);
+  });
+
+  it("still refuses while that node might yet commit", async () => {
+    Locker.hold(STREAM, "tx-under-way");
+
+    const content = await ask(
+      { $streams: [STREAM], $umid: "tx-under-way" },
+      hostThatMayCommit
+    );
+
+    expect(content).to.deep.equal([{ _id: STREAM, locked: true }]);
+  });
+
+  it("refuses a DIFFERENT transaction, however this node voted", async () => {
+    // The exception is only ever about the asker's own round. Another
+    // transaction's write is still in flight as far as this one knows.
+    Locker.hold(STREAM, "tx-under-way");
+
+    const content = await ask(
+      { $streams: [STREAM], $umid: "some-other-tx" },
+      hostThatVotedAgainst
+    );
+
+    expect(content).to.deep.equal([{ _id: STREAM, locked: true }]);
+  });
+
+  it("refuses when no umid is offered at all", async () => {
+    // An older node, or any caller that does not identify its round
+    Locker.hold(STREAM, "tx-under-way");
+
+    const content = await ask({ $streams: [STREAM] }, hostThatVotedAgainst);
+
+    expect(content).to.deep.equal([{ _id: STREAM, locked: true }]);
+  });
+
+  it("refuses when there is no host to ask", async () => {
+    Locker.hold(STREAM, "tx-under-way");
+
+    const content = await ask({ $streams: [STREAM], $umid: "tx-under-way" });
+
+    expect(content).to.deep.equal([{ _id: STREAM, locked: true }]);
+  });
+
+  it("answers normally when nothing holds the stream", async () => {
+    const content = await ask(
+      { $streams: [STREAM], $umid: "tx-under-way" },
+      hostThatMayCommit
+    );
+
+    expect(content).to.deep.equal([doc]);
+  });
+});


### PR DESCRIPTION
SPI runs on a failed vote. A broadcast contract update locks its output stream on **every** node for the life of that round. So when the origin's own vote fails on that stream and it runs SPI, every peer is holding the exact stream it needs to ask about and answers `locked` — the origin abstains on a sample **its own transaction spoiled**, and nothing else ever fires.

It is stuck twice over: `$revs` is stamped by the first node to see the stream (`permissionsChecker.ts:317`), so a laggard origin stamps its own stale position into the broadcast, every other node votes against it, and the round dies with one yes vote. No committed state to converge on, and no clean sample to converge from.

Observed live: of three streams a node lagged on, the one whose update was submitted through an **up-to-date** node healed itself via SPI; the two submitted through the laggard did not.

## The rule

A peer answers with the real revision instead of the locked marker when **both** hold:

1. the lock is held by the **same transaction** the asker is running SPI for — matched on umid, which works cleanly because `Locker` already keys holders by umid and `dc960d6` removed SPI's own lock, so a holder can only be a transaction;
2. **and that peer has already voted against that transaction.**

## Why (2) is not optional

`commit()` gates on `nodeResponse.vote`, so a node that voted no cannot write those streams — its copy is stable by construction.

Without it, this reads a stream a peer may be committing. A commit writes the state document and its `:stream` meta **in one batch**, while SPI fetches them as **two requests** — so a mid-commit sample can pair `state@43` with `meta@21`. Writing that pair locally makes `meta._rev:state._rev` permanently wrong, producing position errors on that stream forever, unrepairable by the very mechanism being extended. That is a worse fault than the one being fixed.

Mutation-checked: dropping the vote condition fails 2 of the 11 new tests.

## What stays refused

A different transaction's lock. A caller that does not identify its round. A node with no host to ask. Any node that might still commit — including one that voted yes but has not committed, and one that already has.

## The resubmit already exists — this makes it reachable

Correcting my earlier note on this PR: the origin path **already** re-submits transparently. `endpoints.ts:375`, gated on `rewroteSomething`:

```js
if (rewroteSomething) {
  delete initTx.$nodes;  delete initTx.$revs;  delete initTx.$streams;
  host.release(initTx.$umid);
  initTx.$umid = ActiveCrypto.Hash.getHash(JSON.stringify(initTx) + counter);
  setTimeout(() => resendable(initTx, ++counter), 50);
  return;                     // client's promise stays open
}
```

New umid, up to `MAX_COUNTERS = 10`, and the bare `return` leaves the caller's promise unresolved so it sees the final outcome rather than the failed round.

That branch was simply unreachable for a laggard origin: `rewroteSomething` is only set when SPI actually rewrites, and SPI could never rewrite because every peer answered `locked` to a sample its own transaction had spoiled. **This PR makes it reachable** — the client now sees success where it previously saw a position error.

Expect `SPI (Rewrite) Resending #1` in the origin's log when it fires, and one umid per attempt in the transaction history for a single logical transaction.

The non-origin resend is a separate thing and stays dormant: it is gated on `canRetry && tx.$unanimous`, and `$unanimous` is never set anywhere in the codebase.

`npm test`: **177 passing**, 0 failing.
