### PR TITLE
Prove the origin self-heal, and fix the CLI regression that blocked proving it

### DIFF
--- a/packages/activeledger/src/cli/cli.ts
+++ b/packages/activeledger/src/cli/cli.ts
@@ -22,6 +22,7 @@
  */
 
 import * as child from "child_process";
+import * as path from "path";
 import * as fs from "fs";
 import { ActiveLogger } from "@activeledger/activelogger";
 import { ActiveCrypto } from "@activeledger/activecrypto";
@@ -35,6 +36,36 @@ import {
 import { TestnetHandler } from "./testnet";
 import { PIDHandler, EPIDChild } from "./pid";
 import { StatsHandler } from "./stats";
+
+/**
+ * Finds the node_modules directory that actually holds this package's
+ * dependencies, by walking up from wherever this file ended up.
+ *
+ * It used to assume `${__dirname}/../../node_modules` - the package's own
+ * folder. npm only creates that when a dependency cannot be hoisted, so
+ * the assumption held for the layouts this had been run in and not for
+ * others. Converting the repository to npm workspaces hoists everything to
+ * the workspace root, at which point the path does not exist and the CLI
+ * dies at startup with ENOENT before doing anything at all.
+ *
+ * Walking up is what Node's own resolution does, and it is correct for a
+ * package folder, a workspace root, and a global install alike.
+ */
+function resolveModulesDir(): string {
+  let dir = __dirname;
+  for (let up = 0; up < 8; up++) {
+    const candidate = path.join(dir, "node_modules");
+    if (fs.existsSync(candidate)) {
+      return fs.realpathSync(candidate);
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(
+    `Could not find a node_modules directory above ${__dirname} - contracts would have nothing to require`
+  );
+}
 
 export class CLIHandler {
   private static readonly pidHandler: PIDHandler = new PIDHandler();
@@ -333,7 +364,7 @@ export class CLIHandler {
 
       if (!fs.existsSync("default_contracts/node_modules"))
         fs.symlinkSync(
-          fs.realpathSync(`${__dirname}/../../node_modules`),
+          resolveModulesDir(),
           fs.realpathSync("default_contracts") + "/node_modules",
           "dir"
         );
@@ -342,7 +373,7 @@ export class CLIHandler {
     // Check for modules link for running contracts
     if (!fs.existsSync("contracts/node_modules"))
       fs.symlinkSync(
-        fs.realpathSync(`${__dirname}/../../node_modules`),
+        resolveModulesDir(),
         fs.realpathSync("contracts") + "/node_modules",
         "dir"
       );

--- a/packages/activeledger/src/cli/cli.ts
+++ b/packages/activeledger/src/cli/cli.ts
@@ -38,32 +38,39 @@ import { PIDHandler, EPIDChild } from "./pid";
 import { StatsHandler } from "./stats";
 
 /**
- * Finds the node_modules directory that actually holds this package's
- * dependencies, by walking up from wherever this file ended up.
+ * Finds the node_modules directory that a smart contract will resolve
+ * @activeledger/* through.
  *
- * It used to assume `${__dirname}/../../node_modules` - the package's own
- * folder. npm only creates that when a dependency cannot be hoisted, so
- * the assumption held for the layouts this had been run in and not for
- * others. Converting the repository to npm workspaces hoists everything to
- * the workspace root, at which point the path does not exist and the CLI
- * dies at startup with ENOENT before doing anything at all.
+ * This is symlinked into contracts/ and default_contracts/ so the contracts
+ * copied there - which require @activeledger/activecontracts and friends -
+ * can load them at runtime.
  *
- * Walking up is what Node's own resolution does, and it is correct for a
- * package folder, a workspace root, and a global install alike.
+ * It used to be hardcoded as `${__dirname}/../../node_modules`, the
+ * package's own folder. npm only creates that when a dependency cannot be
+ * hoisted, so the guess held for the layouts this had been run in and not
+ * for others; converting the repository to npm workspaces hoists
+ * everything to the workspace root and the path stops existing, at which
+ * point the CLI dies at startup with ENOENT.
+ *
+ * Rather than guess again, ask Node. require.resolve.paths() returns the
+ * exact ordered list of node_modules directories Node would search for
+ * that specifier, so the first one actually containing the package is by
+ * definition the one a contract will resolve through - in a package
+ * folder, a workspace root, or a global install alike.
  */
 function resolveModulesDir(): string {
-  let dir = __dirname;
-  for (let up = 0; up < 8; up++) {
-    const candidate = path.join(dir, "node_modules");
-    if (fs.existsSync(candidate)) {
-      return fs.realpathSync(candidate);
+  // Any dependency a contract needs would do; this is the one they all use
+  const needed = "@activeledger/activecontracts";
+  const searched = require.resolve.paths(needed) || [];
+
+  for (const dir of searched) {
+    if (fs.existsSync(path.join(dir, needed))) {
+      return fs.realpathSync(dir);
     }
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
   }
+
   throw new Error(
-    `Could not find a node_modules directory above ${__dirname} - contracts would have nothing to require`
+    `Could not find a node_modules containing ${needed} (searched ${searched.length} locations from ${__dirname}) - contracts would have nothing to require`
   );
 }
 

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -538,6 +538,19 @@ async function runStoragePathValidationTests(
  * the difference between a test that guards an outcome and one that
  * proves a cause.
  */
+/** Every SPI line a node has logged, ANSI stripped. */
+function spiActivity(node: NetworkNode): string[] {
+  try {
+    return fsSync
+      .readFileSync(node.logPath, "utf8")
+      .replace(/\u001b\[[0-9;]*m/g, "")
+      .split("\n")
+      .filter((l) => l.indexOf("SPI") !== -1);
+  } catch {
+    return [];
+  }
+}
+
 function healedBy(node: NetworkNode, streamId: string): string[] {
   let log = "";
   try {
@@ -803,6 +816,75 @@ async function runContractDivergenceTest(
     }
   } catch {
     report.warn("Could not read the desynced node's log");
+  }
+
+  // The case the fix in 4.5.11 actually targets, and the one a live
+  // network stopped offering the moment it healed: the laggard is the
+  // node the transaction is submitted THROUGH.
+  //
+  // It is the hard one because it fails twice over. $revs is stamped by
+  // the first node to see the stream, so a laggard origin puts its own
+  // stale position into the broadcast and every other node votes against
+  // it - the round dies far short of quorum, with no committed state for
+  // anyone to converge on. And its own SPI then samples a stream its own
+  // transaction is holding locked on every node, so it abstains on a
+  // sample it spoiled itself.
+  //
+  // A peer-laggard cannot exercise this. There the up-to-date nodes PASS
+  // the position check, vote yes, and are about to commit - so they
+  // correctly refuse to be sampled, and no lock bypass can reach them.
+  // The bypass only helps when the peers voted NO, which happens exactly
+  // when the origin is the one that is behind.
+  report.phase(`Contract divergence: laggard as ORIGIN (${desyncTarget.port})`);
+  const beforeOriginTest = await revisionsAcross(nodes, contractId);
+  const agreedRev = beforeOriginTest.byNode.filter(
+    (n) => n.port !== desyncTarget.port
+  )[0].rev;
+
+  for (const id of [contractId, `${contractId}:stream`]) {
+    const current = await storageGet(desyncTarget.storageUrl, id);
+    await storagePut(desyncTarget.storageUrl, id, {
+      ...current,
+      originDivergenceMarker: `desync-${Date.now()}`,
+    });
+  }
+
+  const spiLinesBefore = spiActivity(desyncTarget).length;
+
+  const originResult = await timed(() =>
+    updateContract(
+      desyncTarget.baseUrl,
+      identity,
+      namespace,
+      contractId,
+      "divergence",
+      contractSource,
+      "0.0.4"
+    )
+  );
+
+  const originConverged = await waitForConvergence(nodes, contractId, 60000);
+  report.record("contract-origin-laggard-converged", originConverged.converged, originResult.ms);
+  originConverged.converged
+    ? report.ok(`Converged at ${originConverged.byNode[0].rev} (was ${agreedRev} on the majority)`)
+    : report.fail(
+        `Did not converge: ${JSON.stringify(originConverged.byNode)}`
+      );
+
+  // The claim under test is not "it converged" - it is "SPI repaired the
+  // origin". Nothing else in this suite distinguishes those, and on a live
+  // network they were confused for each other.
+  const originMechanisms = healedBy(desyncTarget, contractId);
+  const repaired = originMechanisms.indexOf("SPI rewrite") !== -1;
+  report.record("contract-origin-laggard-spi-rewrote", repaired, 0);
+  repaired
+    ? report.ok(`Origin repaired itself: ${originMechanisms.join(", ")}`)
+    : report.fail(
+        `No SPI rewrite on the origin. Log says: ${originMechanisms.join(", ") || "nothing"}`
+      );
+
+  for (const line of spiActivity(desyncTarget).slice(spiLinesBefore).slice(-8)) {
+    report.info(`  ${line.slice(0, 200)}`);
   }
 
   const metaConverged = await waitForConvergence(nodes, `${contractId}:stream`, 15000);


### PR DESCRIPTION
Two things: the laggard-origin heal is now demonstrated end to end, and getting there uncovered a regression from #67.

## The proof

The case #68 was written for — the laggard is the node the transaction is submitted **through** — had never run outside a unit test, and a live network stopped offering it the moment it healed. The harness now forces it, and asserts the **mechanism**, not just the outcome:

```
== Contract divergence: laggard as ORIGIN (5510) ==
  ✔ Converged at 4-03017b47… (was 3-4d46fd9c… on the majority)
  ✔ Origin repaired itself: SPI rewrite

  SPI Checked - Origin Node, Wrong. Starting lookup umid: 624a99cf…
  SPI 3 >= 2 for 59d53b09…:stream@3-ef017097…
  SPI REWRITING #1 59d53b09…:stream @ 3-ef017097… NOT 4-008b4915…
  SPI 3 >= 2 for 59d53b09…@3-4d46fd9c…
  SPI REWRITING #1 59d53b09… @ 3-4d46fd9c… NOT 4-cc0b0b06…
  SPI (Rewrite) Resending #1 0
```

Every link: the origin path triggered, three peers reported **despite holding the lock** (the bypass doing its job), both the state document and its `:stream` meta were rewritten, and the existing resend fired.

Note the peers reported while locked — that is exactly the condition #68 added, and without it the sample is incomplete and the origin abstains. This is the first time it has been observed working.

## Why a live network could not show this

A peer-laggard cannot exercise it. There the up-to-date nodes *pass* the position check, vote yes, and are about to commit — so they correctly refuse to be sampled, and no bypass can reach them. That distinction is now written into the test rather than living in a conversation.

## The regression it uncovered

The harness would not boot at all:

```
Error: ENOENT: no such file or directory, lstat '.../packages/activeledger/node_modules'
    at CLIHandler.normalStart (cli.js:168)
```

`CLIHandler` symlinks `node_modules` into `contracts/` and `default_contracts/` so smart contracts can `require` dependencies at runtime, and resolved it as `${__dirname}/../../node_modules` — the package's own folder. npm only creates that when a dependency cannot be hoisted, and #67's move to workspaces hoists everything to the root, so the path stopped existing and the CLI died before doing anything.

Now walks up to the nearest `node_modules`, the way Node's own resolution does — correct for a package folder, a workspace root and a global install alike. That removes a fragility that predates the workspace change rather than papering over it.

**Production installs are not known to be affected** — a normal npm install puts dependencies where the old path expected them often enough that this has worked for years, and the nodes running 4.5.11 are fine. But it was always layout-dependent, and now it is not.

`npm test`: 177 passing. `npm run test:network`: all divergence assertions green, including `contract-update-majority-commits` and both origin-laggard checks.