### PR TITLE
Dependabot did not know the repository became a workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Without this file dependabot discovers each packages/*/package.json as its
+# own manifest and opens a PR that edits only that file. That worked while
+# every package carried its own package-lock.json. It does not now: the
+# workspace has ONE lockfile at the root, so a PR touching a package manifest
+# alone leaves the lock stale and `npm ci` refuses to install:
+#
+#   npm error `npm ci` can only install packages when your package.json and
+#   package-lock.json are in sync
+#   npm error Invalid: lock file's undici@6.18.2 does not satisfy undici@6.28.0
+#
+# Every dependency PR would fail CI in eight seconds, for a reason that has
+# nothing to do with the dependency. Pointing dependabot at the root instead
+# makes it treat the workspace as the single unit it now is, and update the
+# root lock alongside whichever package manifest changed.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      # These move together and are pointless to review one at a time
+      types:
+        patterns:
+          - "@types/*"
+
+  # The workflows pin actions by major version, and a deprecation only
+  # surfaces as a runner warning until the day it becomes an error - Node 20
+  # is already warning on actions/checkout@v4 and actions/setup-node@v4.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activeledger-monorepo",
-  "version": "4.5.10",
+  "version": "4.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activeledger-monorepo",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "workspaces": [
         "packages/*"
       ],
@@ -3898,9 +3898,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.18.2.tgz",
-      "integrity": "sha512-o/MQLTwRm9IVhOqhZ0NQ9oXax1ygPjw6Vs+Vq/4QRjbOAC3B1GCHy7TYxxbExKlb7bzDRzt9vBWU6BDz0RFfYg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -4179,16 +4179,16 @@
     },
     "packages/activeledger": {
       "name": "@activeledger/activeledger",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecontracts": "4.5.10",
-        "@activeledger/activecrypto": "4.5.10",
-        "@activeledger/activelogger": "4.5.10",
-        "@activeledger/activenetwork": "4.5.10",
-        "@activeledger/activeoptions": "4.5.10",
-        "@activeledger/activestorage": "4.5.10",
-        "@activeledger/activetoolkits": "4.5.10"
+        "@activeledger/activecontracts": "4.5.12",
+        "@activeledger/activecrypto": "4.5.12",
+        "@activeledger/activelogger": "4.5.12",
+        "@activeledger/activenetwork": "4.5.12",
+        "@activeledger/activeoptions": "4.5.12",
+        "@activeledger/activestorage": "4.5.12",
+        "@activeledger/activetoolkits": "4.5.12"
       },
       "bin": {
         "activeledger": "lib/index.js"
@@ -4201,14 +4201,14 @@
     },
     "packages/contracts": {
       "name": "@activeledger/activecontracts",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecrypto": "4.5.10",
-        "@activeledger/activedefinitions": "4.5.10",
-        "@activeledger/activelogger": "4.5.10",
-        "@activeledger/activequery": "4.5.10",
-        "@activeledger/activeutilities": "4.5.10"
+        "@activeledger/activecrypto": "4.5.12",
+        "@activeledger/activedefinitions": "4.5.12",
+        "@activeledger/activelogger": "4.5.12",
+        "@activeledger/activequery": "4.5.12",
+        "@activeledger/activeutilities": "4.5.12"
       },
       "devDependencies": {
         "@types/node": "18.0.0",
@@ -4217,17 +4217,17 @@
     },
     "packages/core": {
       "name": "@activeledger/activecore",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecrypto": "4.5.10",
-        "@activeledger/activelogger": "4.5.10",
-        "@activeledger/activenetwork": "4.5.10",
-        "@activeledger/activeoptions": "4.5.10",
-        "@activeledger/activequery": "4.5.10",
-        "@activeledger/activestorage": "4.5.10",
-        "@activeledger/activeutilities": "4.5.10",
-        "@activeledger/httpd": "4.5.10"
+        "@activeledger/activecrypto": "4.5.12",
+        "@activeledger/activelogger": "4.5.12",
+        "@activeledger/activenetwork": "4.5.12",
+        "@activeledger/activeoptions": "4.5.12",
+        "@activeledger/activequery": "4.5.12",
+        "@activeledger/activestorage": "4.5.12",
+        "@activeledger/activeutilities": "4.5.12",
+        "@activeledger/httpd": "4.5.12"
       },
       "bin": {
         "activecore": "lib/index.js"
@@ -4239,21 +4239,21 @@
     },
     "packages/crypto": {
       "name": "@activeledger/activecrypto",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activelogger": "4.5.10",
+        "@activeledger/activelogger": "4.5.12",
         "asn1.js": "5.4.1"
       },
       "devDependencies": {
-        "@activeledger/activedefinitions": "4.5.10",
+        "@activeledger/activedefinitions": "4.5.12",
         "@types/node": "18.0.0",
         "typescript": "4.7.3"
       }
     },
     "packages/definitions": {
       "name": "@activeledger/activedefinitions",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
         "@types/events": "^3.0.0"
@@ -4265,11 +4265,11 @@
     },
     "packages/httpd": {
       "name": "@activeledger/httpd",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activelogger": "4.5.10",
-        "@activeledger/activeutilities": "4.5.10",
+        "@activeledger/activelogger": "4.5.12",
+        "@activeledger/activeutilities": "4.5.12",
         "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.67.0"
       },
       "devDependencies": {
@@ -4279,19 +4279,19 @@
     },
     "packages/hybrid": {
       "name": "@activeledger/activehybrid",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecontracts": "4.5.10",
-        "@activeledger/activecrypto": "4.5.10",
-        "@activeledger/activedefinitions": "4.5.10",
-        "@activeledger/activelogger": "4.5.10",
-        "@activeledger/activeoptions": "4.5.10",
-        "@activeledger/activeprotocol": "4.5.10",
-        "@activeledger/activestorage": "4.5.10",
-        "@activeledger/activetoolkits": "4.5.10",
-        "@activeledger/activeutilities": "4.5.10",
-        "@activeledger/httpd": "4.5.10",
+        "@activeledger/activecontracts": "4.5.12",
+        "@activeledger/activecrypto": "4.5.12",
+        "@activeledger/activedefinitions": "4.5.12",
+        "@activeledger/activelogger": "4.5.12",
+        "@activeledger/activeoptions": "4.5.12",
+        "@activeledger/activeprotocol": "4.5.12",
+        "@activeledger/activestorage": "4.5.12",
+        "@activeledger/activetoolkits": "4.5.12",
+        "@activeledger/activeutilities": "4.5.12",
+        "@activeledger/httpd": "4.5.12",
         "typescript": "4.7.3"
       },
       "bin": {
@@ -4304,7 +4304,7 @@
     },
     "packages/logger": {
       "name": "@activeledger/activelogger",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
         "winston": "^3.15.0",
@@ -4317,14 +4317,14 @@
     },
     "packages/nano-gateway": {
       "name": "@activeledger/nano-gateway",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecrypto": "4.5.10",
-        "@activeledger/activedefinitions": "4.5.10",
-        "@activeledger/activelogger": "4.5.10",
-        "@activeledger/activeoptions": "4.5.10",
-        "@activeledger/httpd": "4.5.10",
+        "@activeledger/activecrypto": "4.5.12",
+        "@activeledger/activedefinitions": "4.5.12",
+        "@activeledger/activelogger": "4.5.12",
+        "@activeledger/activeoptions": "4.5.12",
+        "@activeledger/httpd": "4.5.12",
         "typescript": "5.5.4"
       },
       "bin": {
@@ -4350,16 +4350,16 @@
     },
     "packages/network": {
       "name": "@activeledger/activenetwork",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecrypto": "4.5.10",
-        "@activeledger/activedefinitions": "4.5.10",
-        "@activeledger/activelogger": "4.5.10",
-        "@activeledger/activeoptions": "4.5.10",
-        "@activeledger/activeprotocol": "4.5.10",
-        "@activeledger/activequery": "4.5.10",
-        "@activeledger/activeutilities": "4.5.10",
+        "@activeledger/activecrypto": "4.5.12",
+        "@activeledger/activedefinitions": "4.5.12",
+        "@activeledger/activelogger": "4.5.12",
+        "@activeledger/activeoptions": "4.5.12",
+        "@activeledger/activeprotocol": "4.5.12",
+        "@activeledger/activequery": "4.5.12",
+        "@activeledger/activeutilities": "4.5.12",
         "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.67.0"
       },
       "devDependencies": {
@@ -4369,15 +4369,15 @@
     },
     "packages/options": {
       "name": "@activeledger/activeoptions",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activelogger": "4.5.10",
-        "@activeledger/activeutilities": "4.5.10",
+        "@activeledger/activelogger": "4.5.12",
+        "@activeledger/activeutilities": "4.5.12",
         "minimist": "1.2.6"
       },
       "devDependencies": {
-        "@activeledger/activedefinitions": "4.5.10",
+        "@activeledger/activedefinitions": "4.5.12",
         "@types/minimist": "1.2.2",
         "@types/node": "18.0.0",
         "typescript": "4.7.3"
@@ -4398,16 +4398,16 @@
     },
     "packages/protocol": {
       "name": "@activeledger/activeprotocol",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecontracts": "4.5.10",
-        "@activeledger/activecrypto": "4.5.10",
-        "@activeledger/activedefinitions": "4.5.10",
-        "@activeledger/activelogger": "4.5.10",
-        "@activeledger/activeoptions": "4.5.10",
-        "@activeledger/activequery": "4.5.10",
-        "@activeledger/activetoolkits": "4.5.10",
+        "@activeledger/activecontracts": "4.5.12",
+        "@activeledger/activecrypto": "4.5.12",
+        "@activeledger/activedefinitions": "4.5.12",
+        "@activeledger/activelogger": "4.5.12",
+        "@activeledger/activeoptions": "4.5.12",
+        "@activeledger/activequery": "4.5.12",
+        "@activeledger/activetoolkits": "4.5.12",
         "@activeledger/vm2": "^3.9.20",
         "@types/node": "18.0.0",
         "typescript": "4.7.3"
@@ -4415,12 +4415,12 @@
     },
     "packages/query": {
       "name": "@activeledger/activequery",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecrypto": "4.5.10",
-        "@activeledger/activedefinitions": "4.5.10",
-        "@activeledger/activelogger": "4.5.10"
+        "@activeledger/activecrypto": "4.5.12",
+        "@activeledger/activedefinitions": "4.5.12",
+        "@activeledger/activelogger": "4.5.12"
       },
       "devDependencies": {
         "typescript": "^4.7.3"
@@ -4428,13 +4428,13 @@
     },
     "packages/restore": {
       "name": "@activeledger/activerestore",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecrypto": "4.5.10",
-        "@activeledger/activelogger": "4.5.10",
-        "@activeledger/activenetwork": "4.5.10",
-        "@activeledger/activeoptions": "4.5.10",
+        "@activeledger/activecrypto": "4.5.12",
+        "@activeledger/activelogger": "4.5.12",
+        "@activeledger/activenetwork": "4.5.12",
+        "@activeledger/activeoptions": "4.5.12",
         "typescript": "4.7.3"
       },
       "bin": {
@@ -4446,13 +4446,13 @@
     },
     "packages/storage": {
       "name": "@activeledger/activestorage",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activelogger": "4.5.10",
-        "@activeledger/activeoptions": "4.5.10",
-        "@activeledger/activeutilities": "4.5.10",
-        "@activeledger/httpd": "4.5.10",
+        "@activeledger/activelogger": "4.5.12",
+        "@activeledger/activeoptions": "4.5.12",
+        "@activeledger/activeutilities": "4.5.12",
+        "@activeledger/httpd": "4.5.12",
         "classic-level": "^3.0.0"
       },
       "devDependencies": {
@@ -4465,24 +4465,24 @@
     },
     "packages/toolkits": {
       "name": "@activeledger/activetoolkits",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activeutilities": "4.5.10"
+        "@activeledger/activeutilities": "4.5.12"
       },
       "devDependencies": {
-        "@activeledger/activedefinitions": "4.5.10",
+        "@activeledger/activedefinitions": "4.5.12",
         "@types/node": "18.0.0",
         "typescript": "4.7.3"
       }
     },
     "packages/utilities": {
       "name": "@activeledger/activeutilities",
-      "version": "4.5.10",
+      "version": "4.5.12",
       "license": "MIT",
       "dependencies": {
         "msgpackr": "^2.0.1",
-        "undici": "6.18.2"
+        "undici": "^6.28.0"
       },
       "devDependencies": {
         "@types/node": "18.0.0",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -47,6 +47,6 @@
   "module": "./es/index.js",
   "dependencies": {
     "msgpackr": "^2.0.1",
-    "undici": "6.18.2"
+    "undici": "^6.28.0"
   }
 }


### PR DESCRIPTION
#70 fails CI in eight seconds, and so would every dependency PR after it.

## The problem

With per-package lockfiles gone, dependabot's default discovery opens a PR that edits one `packages/*/package.json` and nothing else. The workspace has a **single lockfile at the root**, so the lock is left stale and `npm ci` refuses before any test runs:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json are in sync
npm error Invalid: lock file's undici@6.18.2 does not satisfy undici@6.28.0
```

A dependency PR failing for a reason unrelated to the dependency is the fastest way to teach everyone to ignore a signal.

## The fix

A `.github/dependabot.yml` pointing at the root, so the workspace is treated as the single unit it now is and the root lock moves with whichever manifest changes. `@types/*` grouped, since reviewing those one at a time is noise.

Also adds the **github-actions** ecosystem — the workflows pin actions by major version, and Node 20 deprecation is already warning on `actions/checkout@v4` and `actions/setup-node@v4`. That stays a warning right up until the day it is an error.

## Carries #70

The undici 6.18.2 → 6.28.0 bump, with the root lock updated, so **#70 can close**.

I checked what we actually depend on rather than assuming a minor is safe — this is the package carrying the keep-alive fix:

| | 6.18.2 | 6.28.0 |
|---|---|---|
| global dispatcher key | `Symbol.for("undici.globalDispatcher.1")` | unchanged — the three copies still share one |
| `keepAliveTimeout` default | `4e3` | unchanged |
| `keepAliveMaxTimeout` default | `600e3` | unchanged |
| both options accepted | yes | yes |

`npm test`: 177 passing, including the four keep-alive invariant tests — which are the ones that would have caught a change here.