### PR TITLE
master does not build — undici 6.28's types need DOM globals we do not have

### DIFF
--- a/packages/tsconfig.settings.json
+++ b/packages/tsconfig.settings.json
@@ -4,13 +4,28 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "lib": ["es2022"],
-    "target":"es2022",
+    "lib": [
+      "es2022"
+    ],
+    // Do not type check third party .d.ts files. "lib" is es2022 with no
+    // "dom" on purpose - this is server code - but undici's published types
+    // reference DOM globals (Event, EventTarget) for its EventSource,
+    // FileReader and WebSocket surfaces, which we never touch. Without this
+    // the build fails with a dozen TS2304 "Cannot find name 'Event'"
+    // errors originating entirely inside node_modules.
+    //
+    // Adding "dom" to lib would fix the symptom by letting browser globals
+    // leak into every file in the repository, which is worse.
+    "skipLibCheck": true,
+    "target": "es2022",
     "alwaysStrict": true,
     "strictNullChecks": true,
     "noImplicitAny": true,
     "moduleResolution": "node",
     "removeComments": true
   },
-  "exclude": ["**/lib/", "**/es/"]
+  "exclude": [
+    "**/lib/",
+    "**/es/"
+  ]
 }


### PR DESCRIPTION
**master is currently broken.** #72 merged with a red check, and I did not stop it.

```
../../node_modules/undici/types/eventsource.d.ts(13,9): error TS2304: Cannot find name 'Event'.
../../node_modules/undici/types/filereader.d.ts(7,14): error TS2304: Cannot find name 'EventTarget'.
… twelve of these, all inside node_modules
```

`lib` is `es2022` with no `dom`, deliberately — this is server code. undici publishes types referencing DOM globals for its EventSource, FileReader and WebSocket surfaces, none of which this codebase touches.

## The fix

`skipLibCheck: true`. Our own code is type-checked exactly as before; only third-party `.d.ts` files are skipped. Adding `"dom"` to `lib` would fix the symptom by making browser globals visible in every file in the repo, which is worse.

## Why my local check missed it

tsc is incremental here (`composite: true`), and `packages/*/lib` plus the `.tsbuildinfo` files were left over from the previous undici version. tsc skipped the work and reported success — so I saw a green build over a stale one.

Verified this time on a genuinely clean tree (`rm -rf packages/*/lib packages/*/es packages/*/*.tsbuildinfo` first): build exits 0, no type errors, 177 passing. That is the check I should have run before merging #72.