### PR TITLE
Three inputs that were trusted further than they are owned

### DIFF
--- a/packages/activeledger/src/index.ts
+++ b/packages/activeledger/src/index.ts
@@ -48,7 +48,16 @@ if (
 if (!fs.existsSync("./.identity")) {
   ActiveLogger.info("No Identity found. Generating Identity");
   let identity: ActiveCrypto.KeyPair = new ActiveCrypto.KeyPair();
-  fs.writeFileSync("./.identity", JSON.stringify(identity.generate()));
+  // 0600: this file contains the node's RSA PRIVATE key - KeyPair.pem is a
+  // public field, so JSON.stringify emits it. Without a mode it lands at
+  // 0644 under a default umask, readable by every user on the host.
+  //
+  // Only affects a newly generated identity; an existing .identity keeps
+  // whatever permissions it already has, so tightening one that is already
+  // on disk is a separate, deliberate step.
+  fs.writeFileSync("./.identity", JSON.stringify(identity.generate()), {
+    mode: 0o600,
+  });
   ActiveLogger.info("Identity Generated. Continue Boot Cycle");
 }
 

--- a/packages/options/src/dsconnect.ts
+++ b/packages/options/src/dsconnect.ts
@@ -36,6 +36,21 @@ const REMOVE_CACHE_TIMER = 5 * 60 * 1000;
  * @class ActiveDSConnect
  * @implements {ActiveDefinitions.IActiveDSConnect}
  */
+/**
+ * Document ids reach these methods from callers that do not own them -
+ * Endpoints.streams() passes whatever a peer asked about straight through -
+ * so they are encoded before becoming a URL path segment.
+ *
+ * Unencoded, a "../" inside an id stops being part of the document name the
+ * moment a URL parser sees it: it walks up out of the database path, and a
+ * request for one database becomes a request for another. The store's
+ * getDB() then throws for the unrecognised name from inside a Promise
+ * executor, which surfaces as an unhandled rejection rather than a 500.
+ *
+ * Safe for the ids this ledger actually uses: the ":" in "<id>:stream",
+ * "<id>:data" and "umid:..." becomes %3A on the wire, and the store decodes
+ * the path again before looking it up.
+ */
 export class ActiveDSConnect implements ActiveDefinitions.IActiveDSConnect {
   /**
    * Creates an instance of DBConnector.
@@ -204,13 +219,13 @@ export class ActiveDSConnect implements ActiveDefinitions.IActiveDSConnect {
    */
   public get(id: string, options: any = {}): Promise<any> {
     return new Promise((resolve, reject) => {
-      ActiveRequest.send(`${this.location}/${id}`, "GET", undefined, options)
+      ActiveRequest.send(`${this.location}/${encodeURIComponent(id)}`, "GET", undefined, options)
         .then((response: any) => resolve(response.data))
         .catch(reject);
     });
 
     // if (!this.secondaryCache[id]) {
-    //   const response = await ActiveRequest.send(`${this.location}/${id}`, "GET", undefined, options);
+    //   const response = await ActiveRequest.send(`${this.location}/${encodeURIComponent(id)}`, "GET", undefined, options);
     //   return response.data
     //   // DISABLED
     //   // this.secondaryCache[id] = {
@@ -230,7 +245,7 @@ export class ActiveDSConnect implements ActiveDefinitions.IActiveDSConnect {
    */
   public createget(id: string, options: any = {}): Promise<any> {
     return new Promise((resolve) => {
-      ActiveRequest.send(`${this.location}/${id}`, "GET", undefined, options)
+      ActiveRequest.send(`${this.location}/${encodeURIComponent(id)}`, "GET", undefined, options)
         .then((response: any) => resolve(response.data))
         .catch(() => {
           resolve({ _id: id });
@@ -246,7 +261,7 @@ export class ActiveDSConnect implements ActiveDefinitions.IActiveDSConnect {
    */
   public exists(id: string): Promise<Boolean> {
     return new Promise<Boolean>((resolve) => {
-      ActiveRequest.send(`${this.location}/${id}`, "GET", undefined, {})
+      ActiveRequest.send(`${this.location}/${encodeURIComponent(id)}`, "GET", undefined, {})
         .then((response: any) => resolve(response.data?._id ? true : false))
         .catch(() => {
           resolve(false);

--- a/packages/storage/src/selfhost.ts
+++ b/packages/storage/src/selfhost.ts
@@ -1050,7 +1050,23 @@ import { IActiveHttpResponse } from "@activeledger/httpd/lib/httpd";
 
     // If path is not default overwrite
     if (req.url !== "/_utils/") {
-      file = FAUXTON_PATH + (req.url as string).replace("/_utils", "");
+      // Resolved and contained, not concatenated. uWebSockets hands the
+      // path through as sent, so "../" segments arrive verbatim - and
+      // FAUXTON_PATH sits several levels inside the install, so a few of
+      // them reach the node's working directory, where config.json and the
+      // .identity private key live.
+      const requested = path.resolve(
+        FAUXTON_PATH,
+        "." + decodeURIComponent((req.url as string).replace("/_utils", ""))
+      );
+
+      if (!requested.startsWith(path.resolve(FAUXTON_PATH) + path.sep)) {
+        // Outside the asset directory. Serve the app shell rather than
+        // reporting whether the path existed.
+        return fauxtonCache[FAUXTON_PATH + "/index.html"] || null;
+      }
+
+      file = requested;
     }
 
     if (fauxtonCache[file]) {


### PR DESCRIPTION
Hardening from the review sweep. **No behaviour change for any legitimate caller** — each fix was verified against real inputs as well as hostile ones.

## 1. Document ids are encoded before becoming a URL path segment
`packages/options/src/dsconnect.ts`

Ids arrive from callers that do not own them — `Endpoints.streams()` passes whatever a peer asked about straight through, and that endpoint has no firewall check. Unencoded, a relative segment inside an id stops being part of the document name once a URL parser sees it, so a request for one database becomes a request for another. The store's `getDB()` then throws for the unrecognised name **from inside a Promise executor**, which surfaces as an unhandled rejection rather than a 500 — and the datastore has a restart cap.

Verified the ids this ledger actually uses still resolve end to end: the `:` in `<id>:stream` becomes `%3A` on the wire and the store decodes the path before lookup.

## 2. The Fauxton static handler resolves and contains its path
`packages/storage/src/selfhost.ts`

It concatenated `FAUXTON_PATH + req.url`. uWebSockets hands the path through as sent, so relative segments arrive verbatim — and the asset directory sits several levels inside the install, far enough in that a few of them reach the working directory where `config.json` and the `.identity` private key live.

Now resolves against the asset root and serves the app shell for anything outside it, rather than reporting whether the path existed. Checked against real asset paths as well as traversal, **including percent-encoded forms** — the decode happens before the containment test, not after:

```
serve  /_utils/index.html
serve  /_utils/dashboard.assets/img/a.png
block  /_utils/../../../../../../etc/passwd
block  /_utils/../../../.identity
block  /_utils/%2e%2e%2f%2e%2e%2fconfig.json
```

## 3. `.identity` is written 0600
`packages/activeledger/src/index.ts`

It holds the node's RSA **private** key — `KeyPair.pem` is a public field, so `JSON.stringify` emits it — and without a mode it lands at 0644 under a default umask, readable by every user on the host.

Only affects a newly generated identity. An existing `.identity` keeps the permissions it has, so tightening one already on disk is a separate, deliberate step.

## Not included

The larger items from the same review need a decision rather than a patch, and are noted for discussion: a firewall check on `/a/stream` (restore depends on that endpoint), authentication on the storage port, and the contract sandbox question.

Verified on a clean tree — `lib/` and `.tsbuildinfo` removed first: build exits 0, 177 passing.