### PR TITLE
A contract could reach the Function constructor through this

### DIFF
--- a/packages/activeledger/src/contracts/default/contract.ts
+++ b/packages/activeledger/src/contracts/default/contract.ts
@@ -564,6 +564,51 @@ export default class Contract extends Standard {
           return false;
       };
 
+      // Does a this-chain pass THROUGH a banned property on its way?
+      //
+      // isThisAccess() answers "does this chain start at this", which is not
+      // the same question as "is this chain still the contract". Once a hop
+      // lands on a banned name the object stops being the contract and
+      // becomes whatever that property is - this.constructor is the Function
+      // constructor, and anything reached from there is outside the scan's
+      // remit entirely.
+      //
+      // Only a demonstrably banned hop taints the chain: a dot name, or an
+      // element access with a literal key. A dynamic hop is deliberately
+      // left alone, because this.a[k].b is an ordinary way to walk
+      // transaction data and blocking it would reject working contracts.
+      // That is safe here because isThisAccess() does not recurse through
+      // element access at all, so this[k1][k2] is already refused by the
+      // dynamic rule below.
+      const chainTouchesBanned = (expr: ts.Expression): boolean => {
+        let current: ts.Node = unwrap(expr);
+        while (true) {
+          if (ts.isPropertyAccessExpression(current)) {
+            if (
+              ts.isIdentifier(current.name) &&
+              BANNED_PROPERTIES_SET.has(current.name.text)
+            ) {
+              return true;
+            }
+            current = unwrap(current.expression);
+            continue;
+          }
+          if (ts.isElementAccessExpression(current)) {
+            const arg = current.argumentExpression;
+            if (
+              (ts.isStringLiteral(arg) ||
+                ts.isNoSubstitutionTemplateLiteral(arg)) &&
+              BANNED_PROPERTIES_SET.has(arg.text)
+            ) {
+              return true;
+            }
+            current = unwrap(current.expression);
+            continue;
+          }
+          return false;
+        }
+      };
+
       // 1. Block Banned Identifiers or Protected Shadows
       if (ts.isIdentifier(node)) {
         if (node.text === "require") {
@@ -666,8 +711,15 @@ export default class Contract extends Standard {
           }
         }
 
-        // Always allow dynamic access on 'this' properties
-        if (isThisAccess(node.expression)) {
+        // Dynamic access on 'this' is allowed - a contract walking its own
+        // transaction data by key is the normal case - but NOT when the
+        // chain has already passed through a banned property. The comment
+        // above describes the second hop this closes: with an identifier
+        // key rather than a literal one, `this.constructor[k]` reached the
+        // Function constructor with the whole check skipped, because the
+        // literal-key branch above only fires for a resolvable key and this
+        // exemption trusted the entire chain.
+        if (isThisAccess(node.expression) && !chainTouchesBanned(node.expression)) {
             // Continue
         } else {
             // Check for trusted objects defined in configuration

--- a/tests/contract-security-scan.test.ts
+++ b/tests/contract-security-scan.test.ts
@@ -303,3 +303,64 @@ describe("Contract.securityScan() - destructuring via computed literal key bypas
     expect(result).to.include("constructor");
   });
 });
+
+// The scanner is the only barrier in front of contract code - there is no
+// runtime sandbox behind it - so a chain that walks off `this` and keeps
+// its exemption is a full escape, not a hardening gap.
+//
+// `this.constructor` is the Function constructor. Reaching it with a
+// literal key or with dot notation was already refused; reaching it with
+// an identifier key was not, because the literal-key check only fires for
+// a resolvable key and the dynamic-access exemption trusted the whole
+// this-chain. The file's own comment described this second hop as still
+// open. It is not now.
+describe("Contract.securityScan() - a this-chain that walks off this", () => {
+  // The one case that was actually open. Reverting the fix fails this test
+  // and only this test - the other spellings below were already refused.
+  it("blocks a dynamic key on a chain that passed through a banned property", () => {
+    const result = scan(
+      'export default class F { vote(){ const k = "constructor"; return (this.constructor as any)[k]; } }'
+    );
+    expect(result).to.not.be.null;
+  });
+
+  it("blocks it however the key is spelled", () => {
+    // Already covered before the fix - a no-substitution template resolves
+    // to a literal key, so the literal-key rule catches it. Here to pin
+    // that the resolvable spellings stay closed, not as a guard for the
+    // fix itself.
+    const result = scan(
+      'export default class F { vote(){ return (this.constructor as any)[`constructor`]; } }'
+    );
+    expect(result).to.not.be.null;
+  });
+
+  it("blocks the chain even when the banned hop is further back", () => {
+    // Also already covered: the dot-notation rule refuses `.prototype` once
+    // its object is `this.constructor` rather than bare `this`. Pinned
+    // because the fix touches the same chain-walking logic.
+    const result = scan(
+      'export default class F { vote(){ const k = "x"; return (this.constructor as any).prototype[k]; } }'
+    );
+    expect(result).to.not.be.null;
+  });
+
+  it("still blocks the literal-key and dot-notation forms", () => {
+    expect(scan('export default class F { vote(){ return (this.constructor as any)["constructor"]; } }')).to.not.be.null;
+    expect(scan('export default class F { vote(){ return (this.constructor as any).constructor; } }')).to.not.be.null;
+  });
+
+  it("still allows a contract to walk its own data by key", () => {
+    // The pattern this must not break: reading transaction inputs by a
+    // label the contract computed
+    expect(
+      scan('export default class F { vote(){ const l = "a"; return (this as any).transactions.$i[l]; } }')
+    ).to.be.null;
+  });
+
+  it("still allows dynamic access directly on this", () => {
+    expect(
+      scan('export default class F { vote(){ const k = "state"; return (this as any)[k]; } }')
+    ).to.be.null;
+  });
+});


### PR DESCRIPTION
`securityScan` is the only barrier in front of contract code — there is no runtime sandbox behind it — so a chain that walks off `this` while keeping its exemption is a full escape, not a hardening gap.

## The hole

The dynamic-element-access rule exempted any chain `isThisAccess()` approved. But that function answers *"does this chain start at `this`"*, which is not the same question as *"is this chain still the contract"*. Once a hop lands on a banned name the object stops being the contract — `this.constructor` is the Function constructor.

Reaching it with a **literal key** or with **dot notation** was already refused. Reaching it with an **identifier key** was not: the literal-key check only fires for a resolvable key, and the exemption then trusted the whole chain.

The file's own comment (line 659) described exactly this second hop as still open.

Verified against the real scanner, before:

```
literal key on a chain     -> blocked
dot chain                  -> blocked
identifier key on a chain  -> PASSES SCAN      <-- the hole
```

and after:

```
identifier key on a chain  -> blocked: Dynamic element access is forbidden
bare this dynamic          -> PASSES SCAN      (must keep working)
legit nested dynamic       -> PASSES SCAN      (must keep working)
```

## Why it is narrow on purpose

Only a **demonstrably** banned hop taints a chain — a dot name, or an element access with a literal key. A dynamic hop is deliberately left alone, because `this.a[k].b` is an ordinary way to read transaction data and blocking it would reject working contracts.

That is safe because `isThisAccess()` never recursed through element access in the first place, so `this[k1][k2]` was already refused by the dynamic rule.

## Tests

Six added, and I checked which of them actually guard the fix rather than assuming: **reverting the fix fails one test and only one** — the identifier-key case. The others pin the spellings that were already closed, and the two legitimate patterns that must not break. The comments say which is which.

43 passing in that file (was 37), 183 across the suite.