### PR TITLE
The data store listened on every interface and ignored its own host setting

### DIFF
--- a/packages/httpd/src/httpd.ts
+++ b/packages/httpd/src/httpd.ts
@@ -146,7 +146,13 @@ export class ActiveHttpd {
    * @param {number} port
    * @param {boolean} [log=false]
    */
-  public listen(port: number, log: boolean = false) {
+  /**
+   * @param host optional interface to bind to. Omitted, uWebSockets binds
+   *             every interface, which is the right default for a node's
+   *             public transaction port and the wrong one for anything
+   *             that expects to be local.
+   */
+  public listen(port: number, log: boolean = false, host?: string) {
     this.compile();
     // Get Local Reference
     let httpd: ActiveHttpd = this;
@@ -251,9 +257,13 @@ export class ActiveHttpd {
 
     // Note: uWebSockets.js uses SO_REUSEPORT by default, which allows multiple instances
     // to bind to the same port. Instance locking is handled externally.
-    this.server.listen(port, (token: us_listen_socket) => {
+    const bound = (token: us_listen_socket) => {
       this.listenSocket = token;
-    });
+    };
+
+    host
+      ? this.server.listen(host, port, bound)
+      : this.server.listen(port, bound);
 
   }
 

--- a/packages/storage/src/datastore.ts
+++ b/packages/storage/src/datastore.ts
@@ -112,6 +112,10 @@ export class ActiveDataStore {
         this.dsLocation,
         `${dbInfo.selfhost.port}`,
         `${dbInfo.selfhost.engine || "level"}`,
+        // db.selfhost.host has always existed and was only ever used as a
+        // client connection string; the server ignored it and bound every
+        // interface. Now it does what it looks like it does.
+        `${dbInfo.selfhost.host || "127.0.0.1"}`,
       ],
       {
         stdio: "inherit",

--- a/packages/storage/src/selfhost.ts
+++ b/packages/storage/src/selfhost.ts
@@ -45,6 +45,16 @@ import { IActiveHttpResponse } from "@activeledger/httpd/lib/httpd";
   // Data Storage Engine Provider, level provides backwards compatiblility
   const DS_PROVIDER = process.argv[4] || "level";
 
+  // Which interface to listen on. This store has no authentication of any
+  // kind - _bulk_docs will set any document to any revision, DELETE removes
+  // a stream or the whole database - so it should be reachable only by the
+  // node that owns it unless someone has deliberately decided otherwise.
+  //
+  // Local by default. An SSH tunnel still works (it connects from on the
+  // host), and so does a container sharing the node's network namespace,
+  // which is how the gateways reach it. Set db.selfhost.host to widen it.
+  const BIND_HOST = process.argv[5] || "127.0.0.1";
+
   // Database Connection Cache
   let dbCache: { [index: string]: LevelMe } = {};
 
@@ -1074,5 +1084,5 @@ import { IActiveHttpResponse } from "@activeledger/httpd/lib/httpd";
   http.use("_utils/**", "GET", fauxton);
 
   // Start Server
-  http.listen(parseInt(PORT));
+  http.listen(parseInt(PORT), false, BIND_HOST);
 })();


### PR DESCRIPTION
`db.selfhost.host` has existed all along and was only ever used to build a *client* connection string. The server never saw it — `selfhost.js` called `http.listen(port)` with no host, so uWebSockets bound every interface.

That store has **no authentication of any kind**. `_bulk_docs` sets any document to any revision — which is the repair primitive and has to stay — `DELETE` removes a stream or the whole database, and `_utils` serves files. None of that matters while only the node that owns it can connect. All of it matters otherwise.

## The change

Binds `127.0.0.1` by default, honours `db.selfhost.host` when set. `ActiveHttpd.listen` gains an optional host and passes it to uWebSockets' three-argument overload; the node's own public transaction port passes nothing and is unchanged.

**Local by default does not break how this is actually reached.** An SSH tunnel connects from on the host. A container sharing the node's network namespace reaches it on loopback — which is how the gateways talk to it.

## Verified against a running store, not by reading

```
no host argument   ->  LISTEN 127.0.0.1:5621
host 0.0.0.0       ->  LISTEN 0.0.0.0:5623
```

and the API still answers on loopback in the default case:

```
$ curl -s http://127.0.0.1:5619/
{"activeledger":"Welcome to Activeledger data!","adapters":["levelme"],"engine":...
```

## Deployment note

If any deployment currently reaches a node's store from a **different host**, it needs `db.selfhost.host` set explicitly before taking this. Worth a check on the Varnir nodes before rolling — the gateways share a namespace so they should be fine, but that is worth confirming rather than assuming.