### PR TITLE
The SPI skipped branch threw instead of answering the client

### DIFF
--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -397,24 +397,11 @@ export class Endpoints {
                                     if (!response.dontRelease) {
                                       host.release(tx.$umid);
                                     }
-                                    // Resolve thiscopy paste, We are within a timeout so not ideal
-                                    const output: ActiveDefinitions.LedgerResponse =
-                                    {
-                                      $umid: tx.$umid,
-                                      $summary: summary,
-                                      $streams: tx.$streams,
-                                    };
-                                    // Optional Responses to add
-                                    if (responses.length) {
-                                      output.$responses = responses;
-                                    }
-
-                                    // Append Debug View
-                                    if (
-                                      ActiveOptions.get<boolean>("debugToClient", false)
-                                    ) {
-                                      output.$debug = tx;
-                                    }
+                                    const output = Endpoints.buildClientResponse(
+                                      tx,
+                                      summary,
+                                      responses
+                                    );
 
                                     ActiveLogger.warn(
                                       output,
@@ -431,9 +418,25 @@ export class Endpoints {
                                     `SPI Skipped not enough returned for consensus yet (${networkStreams.length}/${consensusReached})`
                                   );
                                   // Maybe retry  somehow? They could be spi lock failures
+                                  //
+                                  // Releasing as well as responding. The
+                                  // sibling branch above does both; this one
+                                  // did neither, because it threw before it
+                                  // got here - so the transaction's streams
+                                  // stayed locked until Locker's three minute
+                                  // sweep, on a network already short of
+                                  // responding nodes.
+                                  if (!response.dontRelease) {
+                                    host.release(tx.$umid);
+                                  }
+
                                   return resolve({
                                     statusCode: 200,
-                                    content: output,
+                                    content: Endpoints.buildClientResponse(
+                                      tx,
+                                      summary,
+                                      responses
+                                    ),
                                   });
 
                                 }
@@ -487,29 +490,14 @@ export class Endpoints {
                       host.release(tx.$umid);
                     }
 
-                    // doubt it as not trying to catch here
                     // We have the entire network $tx object. This isn't something we want to return
-                    const output: ActiveDefinitions.LedgerResponse = {
-                      $umid: tx.$umid,
-                      $summary: summary,
-                      $streams: tx.$streams,
-                    };
-                    // Optional Responses to add
-                    if (responses.length) {
-                      // Just pick one for now (should be same?)
-                      // I imagine its because commit is called early now so less filter chance
-                      //output.$responses = [responses[0]];
-                      output.$responses = responses;
-                    }
-
-                    // Append Debug View
-                    if (ActiveOptions.get<boolean>("debugToClient", false)) {
-                      output.$debug = tx;
-                    }
-
                     return resolve({
                       statusCode: 200,
-                      content: output,
+                      content: Endpoints.buildClientResponse(
+                        tx,
+                        summary,
+                        responses
+                      ),
                     });
                   } else {
                     // Release here?
@@ -863,6 +851,41 @@ export class Endpoints {
   public static revPosition(rev: string): number {
     const position = parseInt((rev || "").split("-")[0], 10);
     return isNaN(position) ? 0 : position;
+  }
+
+  /**
+   * The response a client gets back for a finished transaction.
+   *
+   * Built in one place because it was built in three, and one of them
+   * referred to a `const output` belonging to a sibling block. The name
+   * still resolved - to another `output` declared later in an enclosing
+   * scope - so TypeScript said nothing and the branch threw
+   * "Cannot access 'output' before initialization" at runtime, from inside
+   * a setTimeout callback where the rejection is unhandled: the client's
+   * promise never settles and the transaction's locks are never released.
+   *
+   * @static
+   */
+  public static buildClientResponse(
+    tx: ActiveDefinitions.LedgerEntry,
+    summary: ActiveDefinitions.ISummary,
+    responses: unknown[]
+  ): ActiveDefinitions.LedgerResponse {
+    const output: ActiveDefinitions.LedgerResponse = {
+      $umid: tx.$umid,
+      $summary: summary,
+      $streams: tx.$streams,
+    };
+
+    if (responses.length) {
+      output.$responses = responses;
+    }
+
+    if (ActiveOptions.get<boolean>("debugToClient", false)) {
+      output.$debug = tx;
+    }
+
+    return output;
   }
 
   public static shouldSelfRepairPosition(

--- a/tests/endpoints.test.ts
+++ b/tests/endpoints.test.ts
@@ -475,3 +475,48 @@ describe("Endpoints.spiConsensus - lag versus fork (Activenetwork)", () => {
     expect(winners["eb10c7"].rev).to.equal("104-aaaaaaaa");
   });
 });
+
+// Built in three places, and one of them referred to a `const output`
+// belonging to a sibling block. The name still resolved - to another
+// `output` declared later in an enclosing scope - so the compiler said
+// nothing and the branch threw "Cannot access 'output' before
+// initialization" at runtime, from inside a setTimeout callback where the
+// rejection is unhandled. The client's promise never settled and the
+// transaction's locks were never released.
+//
+// Reachable exactly when the network is already degraded: it is the branch
+// for "fewer nodes answered than consensus needs".
+describe("Endpoints.buildClientResponse (Activenetwork)", () => {
+  const tx: any = {
+    $umid: "umid-1",
+    $streams: { new: [], updated: ["stream-a"] },
+  };
+  const summary: any = { total: 4, vote: 3, commit: 3 };
+
+  it("carries the umid, summary and streams", () => {
+    const out = Endpoints.buildClientResponse(tx, summary, []);
+
+    expect(out.$umid).to.equal("umid-1");
+    expect(out.$summary).to.deep.equal(summary);
+    expect(out.$streams).to.deep.equal(tx.$streams);
+  });
+
+  it("omits $responses when a contract returned nothing", () => {
+    const out = Endpoints.buildClientResponse(tx, summary, []);
+
+    expect(out).to.not.have.property("$responses");
+  });
+
+  it("includes $responses when a contract returned something", () => {
+    const out = Endpoints.buildClientResponse(tx, summary, [{ a: 1 }]);
+
+    expect(out.$responses).to.deep.equal([{ a: 1 }]);
+  });
+
+  it("does not leak the whole transaction unless debugToClient is on", () => {
+    // $debug is the entire network $tx, node responses included
+    const out = Endpoints.buildClientResponse(tx, summary, []);
+
+    expect(out).to.not.have.property("$debug");
+  });
+});


### PR DESCRIPTION
A runtime `ReferenceError` on a reachable path, found in the review sweep and verified against the source rather than taken on report.

## What happens

When fewer nodes answer than consensus needs, the origin's SPI path logs `SPI Skipped not enough returned` and returns a response. It referred to a `const output` declared in the **sibling block above it**.

The name still resolved — to *another* `output` declared later in an enclosing scope — so the compiler said nothing, and at runtime the branch throws:

```
ReferenceError: Cannot access 'output' before initialization
```

That is why `tsc` is clean on it: this is a temporal dead zone violation across branches, not an unresolved name.

## Why it matters more than a thrown error

The throw is inside the `setTimeout` callback the SPI check runs in, so it becomes an **unhandled rejection** rather than an error anyone sees:

- the submitting client's promise never settles — the request hangs until the client's own timeout
- `host.release()` is never reached, so every stream the transaction named stays locked until `Locker`'s three-minute sweep

And it is reachable exactly when things are already bad: the branch exists for "fewer nodes responded than consensus needs".

The branch also never released those locks *even had it worked* — its sibling does both, this one did neither. Both are fixed.

## The fix

Build the response in one tested place instead of three. **The duplication is what hid it** — two of the three copies were byte-similar enough that a third reading a neighbour's variable looked ordinary.

## Verified

The scope error is now structurally impossible rather than merely corrected. A scan of the file finds one declaration and one use of that variable, and the use is inside the block that declares it:

```
declarations: [(400, depth 18), (874, depth 3)]
uses        : [(413, depth 19)]
  use at 413 has a preceding declaration at or above its scope: True
```

Four tests on the builder. 181 passing, clean build.