### PR TITLE
Cover the write semantics every repair path depends on

### DIFF
--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -107,6 +107,135 @@ describe("LevelMe write path (Activestorage) - hpe-14 regressions", () => {
     });
   });
 
+  // The revision rules every repair path in the codebase depends on, and
+  // which nothing asserted until now. SPI's rewrite, quick-restore's
+  // adoptDocument and the ordinary commit path each pick a different
+  // combination of these flags, and picking the wrong one does not fail -
+  // it silently writes the wrong revision, which is how a node ends up
+  // claiming a position the network does not agree with.
+  //
+  // _rev here is content addressed: `<position>-md5(JSON.stringify({...doc,
+  // _rev: null}))`. There is no revision tree; a document is one key.
+  describe("prepareForWrite() revision semantics", () => {
+    it("refuses a new_edits:false write when the local revision differs, and leaves the document alone", async () => {
+      // The gate quick-restore relies on to avoid overwriting a stream a
+      // live commit may be part-way through. Nothing else in the write path
+      // checks it.
+      await db.bulkDocs([{ _id: "streamX", value: "original" }], {
+        new_edits: true,
+      });
+      const stored: any = await db.get("streamX");
+
+      let threw: Error | null = null;
+      try {
+        await db.bulkDocs(
+          [{ _id: "streamX", _rev: "39-notthelocalrevision", value: "incoming" }],
+          { new_edits: false }
+        );
+      } catch (error) {
+        threw = error as Error;
+      }
+
+      expect(threw, "a divergent new_edits:false write must throw").to.not.equal(null);
+      expect(threw!.message).to.contain("Revision Mismatch");
+
+      // And the refusal has to be total - a partial write here is worse
+      // than the write it was protecting against
+      const after: any = await db.get("streamX");
+      expect(after._rev).to.equal(stored._rev);
+      expect(after.value).to.equal("original");
+    });
+
+    it("overwrites a divergent document when force_rev is given", async () => {
+      // The only combination that can repair a stream, used by both SPI
+      // rewrite sites and quick-restore's divergent branch
+      await db.bulkDocs([{ _id: "streamY", value: "stale" }], {
+        new_edits: true,
+      });
+
+      const written = await db.bulkDocs(
+        [{ _id: "streamY", _rev: "42-networkagreed", value: "repaired" }],
+        { new_edits: true, force_rev: "42-networkagreed" }
+      );
+      expect(written).to.equal(true);
+
+      // Read it back rather than trusting the return - the whole reason
+      // this suite exists
+      const after: any = await db.get("streamY");
+      expect(after._rev).to.equal("42-networkagreed");
+      expect(after.value).to.equal("repaired");
+    });
+
+    it("creates a missing document at the revision it was given, with new_edits:false", async () => {
+      // A restore fetching a stream this node never had must keep the
+      // network's position. Minting a fresh one instead would leave the
+      // node claiming position 1 for a stream everyone else holds at 39,
+      // which re-diverges the thing restore was fixing.
+      await db.bulkDocs([{ _id: "streamZ", _rev: "39-fromthenetwork", value: "adopted" }], {
+        new_edits: false,
+      });
+
+      const after: any = await db.get("streamZ");
+      expect(after._rev).to.equal("39-fromthenetwork");
+    });
+
+    it("mints a fresh 1- revision for a missing document when new_edits is true", async () => {
+      // The same call with the other flag, so the distinction is pinned
+      // rather than implied by the test above
+      await db.bulkDocs([{ _id: "streamW", _rev: "39-fromthenetwork", value: "adopted" }], {
+        new_edits: true,
+      });
+
+      const after: any = await db.get("streamW");
+      expect(after._rev).to.match(/^1-/);
+      expect(after._rev).to.not.equal("39-fromthenetwork");
+    });
+
+    it("does not advance the revision when a document is rewritten unchanged", async () => {
+      // A no-op write must not move the position, or every redundant write
+      // would desync a node from its peers. Note the round trip through
+      // get() - see the test below for why re-serialising by hand does not
+      // count as "unchanged".
+      await db.bulkDocs([{ _id: "streamV", value: "same" }], { new_edits: true });
+      const first: any = await db.get("streamV");
+
+      await db.bulkDocs([first], { new_edits: true });
+      const second: any = await db.get("streamV");
+
+      expect(second._rev).to.equal(first._rev);
+    });
+
+    it("derives the revision from the serialisation, and must keep doing so", async () => {
+      // A guard against a future tidy-up, not a warning about key order.
+      //
+      // _rev is md5(JSON.stringify({...doc, _rev: null})), and
+      // JSON.stringify follows insertion order - so this hash is a function
+      // of the serialisation rather than of the content. That is fine here:
+      // nothing outside this codebase ever computes a _rev, and every node
+      // builds a given document through the same contract and the same
+      // streamUpdater, so the order is identical everywhere and the hashes
+      // agree. Divergence makes revisions differ; differing key order does
+      // not arise.
+      //
+      // What this test exists to catch is someone canonicalising the hash
+      // later - sorting keys before stringify, say - which reads as a
+      // harmless tidy-up and is not. It changes every revision computation,
+      // so a patched and an unpatched node would compute different
+      // revisions for the same write and diverge for the length of a
+      // rolling upgrade. If that change is ever wanted it needs to be
+      // deliberate and coordinated, and this test failing is how it gets
+      // noticed.
+      await db.bulkDocs([{ _id: "orderA", x: 1, y: 2 }], { new_edits: true });
+      await db.bulkDocs([{ _id: "orderB", y: 2, x: 1 }], { new_edits: true });
+
+      const a: any = await db.get("orderA");
+      const b: any = await db.get("orderB");
+
+      const hashOf = (rev: string) => rev.split("-")[1];
+      expect(hashOf(a._rev)).to.not.equal(hashOf(b._rev));
+    });
+  });
+
   describe("post() error signalling (e81cd7c)", () => {
     it("resolves { ok: true } on success", async () => {
       const result = await db.post({ _id: "streamE", name: "epsilon" });

--- a/tests/write-paths.test.ts
+++ b/tests/write-paths.test.ts
@@ -1,0 +1,165 @@
+import { StreamUpdater } from "../packages/protocol/src/protocol/streamUpdater";
+import { QuickRestore } from "../packages/restore/src/modules/quick-restore/quick-restore";
+import { Provider } from "../packages/restore/src/modules/provider/provider";
+import { expect } from "chai";
+import "mocha";
+
+// The two places that write to a store outside the ordinary commit, and the
+// commit's own guard that the write landed. All three were untested.
+//
+// They matter together because they are the same shape as the incidents
+// this codebase keeps producing: a function that reports success without
+// checking its effect. A failed write that reads as a commit leaves a node
+// silently behind the network, which is the state every SPI and restore
+// path exists to clean up afterwards.
+
+describe("StreamUpdater.append - a failed write must not read as a commit", () => {
+  let raised: { code: number; reason: any }[];
+  let eventsWritten: any[];
+
+  const build = (bulkDocsResult: any) => {
+    raised = [];
+    eventsWritten = [];
+
+    const updater = Object.create(StreamUpdater.prototype);
+    (updater as any).docs = [{ _id: "streamA", _rev: "1-abc" }];
+    (updater as any).entry = {
+      $umid: "umid-1",
+      $datetime: new Date(),
+      $territoriality: "",
+    };
+    (updater as any).nodeResponse = {};
+    (updater as any).db = { bulkDocs: async () => bulkDocsResult };
+    (updater as any).dbev = {
+      post: async (doc: any) => {
+        eventsWritten.push(doc);
+      },
+    };
+    (updater as any).shared = {
+      raiseLedgerError: (code: number, reason: any) => {
+        raised.push({ code, reason });
+      },
+    };
+    // Only reached once the write succeeds - append() carries on into the
+    // response-building tail, which is not what these assert
+    (updater as any).reference = "self";
+    (updater as any).contractId = "contract";
+    (updater as any).refStreams = { new: [], updated: [] };
+    (updater as any).virtualMachine = {
+      getReturnContractData: () => undefined,
+      getNewContractData: () => undefined,
+      postProcess: async () => undefined,
+    };
+    (updater as any).emitter = { emit: () => true };
+    return updater;
+  };
+
+  it("raises 1510 when the store answers { ok: false }", async () => {
+    // The self hosted store's shape for a failed batch write. It is a
+    // truthy object, so a plain falsy check lets it through - which is
+    // exactly what it used to do.
+    const updater = build({ ok: false });
+
+    await (updater as any).append();
+
+    expect(raised.map((r) => r.code)).to.deep.equal([1510]);
+  });
+
+  it("raises 1510 when LevelMe answers false", async () => {
+    // The other failure shape: LevelMe.bulkDocs catches its own batch
+    // write error and returns false rather than throwing
+    const updater = build(false);
+
+    await (updater as any).append();
+
+    expect(raised.map((r) => r.code)).to.deep.equal([1510]);
+  });
+
+  it("raises 1510 when a per document result carries an error", async () => {
+    // CouchDB's shape
+    const updater = build([{ id: "streamA", error: "conflict" }]);
+
+    await (updater as any).append();
+
+    expect(raised.map((r) => r.code)).to.deep.equal([1510]);
+  });
+
+  it("does not record the transaction in the event stream when the write failed", async () => {
+    // The part that makes a silent failure durable: an event written for a
+    // transaction whose streams never landed tells every subscriber the
+    // change happened
+    const updater = build({ ok: false });
+
+    await (updater as any).append();
+
+    expect(eventsWritten).to.have.length(0);
+  });
+
+  it("records the transaction when the write really succeeded", async () => {
+    const updater = build({ ok: true });
+
+    await (updater as any).append();
+
+    expect(raised).to.have.length(0);
+    expect(eventsWritten).to.have.length(1);
+    expect(eventsWritten[0]._id).to.contain("umid-1");
+  });
+});
+
+// The only place besides SPI that repairs a divergent stream. Each branch
+// picks a different write mode, and picking the wrong one does not fail -
+// it writes the wrong revision.
+describe("QuickRestore.adoptDocument - restoring a stream", () => {
+  let writes: { docs: any[]; options: any }[];
+  let local: { [id: string]: any };
+
+  const adopt = (doc: any) => (QuickRestore as any).adoptDocument(doc);
+
+  beforeEach(() => {
+    writes = [];
+    local = {};
+    (Provider as any).database = {
+      get: async (id: string) => {
+        if (!local[id]) throw { notFound: true };
+        return local[id];
+      },
+      bulkDocs: async (docs: any[], options: any) => {
+        writes.push({ docs, options });
+        return { ok: true };
+      },
+    };
+  });
+
+  it("creates a missing document with new_edits:false, keeping the network's revision", async () => {
+    // new_edits:true here would mint a fresh 1-<md5> and leave this node
+    // claiming position 1 for a stream the network holds at 39 - silently
+    // re-diverging the thing the restore was fixing
+    await adopt({ _id: "streamA", _rev: "39-network" });
+
+    expect(writes).to.have.length(1);
+    expect(writes[0].options).to.deep.equal({ new_edits: false });
+    expect(writes[0].docs[0]._rev).to.equal("39-network");
+  });
+
+  it("overwrites a stale document with new_edits + force_rev", async () => {
+    // new_edits:false against a differing local revision throws Revision
+    // Mismatch, so this is the only combination that can repair
+    local["streamA"] = { _id: "streamA", _rev: "38-stale" };
+
+    await adopt({ _id: "streamA", _rev: "39-network" });
+
+    expect(writes).to.have.length(1);
+    expect(writes[0].options).to.deep.equal({
+      new_edits: true,
+      force_rev: "39-network",
+    });
+  });
+
+  it("writes nothing when this node already agrees", async () => {
+    local["streamA"] = { _id: "streamA", _rev: "39-network" };
+
+    await adopt({ _id: "streamA", _rev: "39-network" });
+
+    expect(writes).to.have.length(0);
+  });
+});


### PR DESCRIPTION
Three write paths had no unit coverage, and they are the ones that decide whether a repair actually landed. All three are the shape this codebase keeps producing incidents from: a success reported by code that did not check its effect. Each was confirmed untested by grep before anything was written.

## `LevelMe.prepareForWrite` revision rules

Nothing asserted any of them, yet SPI's rewrite, `quick-restore`'s `adoptDocument` and the ordinary commit each pick a **different combination**, and picking wrong does not fail — it writes the wrong revision.

- `new_edits:false` must **refuse** a divergent write and leave the stored document untouched. This is the gate `quick-restore` relies on to avoid overwriting a stream a live commit may be part-way through.
- `force_rev` must overwrite one — verified by reading the store back, not by trusting the return value. This is the repair primitive: the only thing that can put a stream back to the network's revision.
- a missing document must be created at the revision it was **given** under `new_edits:false`, and mint a fresh `1-<md5>` under `new_edits:true`. Both directions are pinned, because a restore that mints fresh revisions leaves a node claiming position 1 for a stream the network holds at 39.

## `StreamUpdater.append`'s bulk-write check

Three distinct failure shapes — LevelMe's `false`, the self-hosted store's truthy `{ok:false}`, and CouchDB's per-document `error`. The tests also assert the transaction is **not** written to the event stream when the write failed, which is what makes a silent failure durable for every subscriber.

## `QuickRestore.adoptDocument`

The only place besides SPI that repairs a divergent stream, and it had no test at all.

## One test that is a guard, not a warning

One test pins that the revision hash is a function of the serialisation. **Not because that is a problem** — nothing outside this codebase computes a `_rev`, and every node builds a document through the same contract and the same `streamUpdater`, so the order is identical everywhere and the hashes agree.

It is there to catch a later tidy-up that canonicalises the hash by sorting keys. That reads as harmless and is not: it changes every revision computation, so patched and unpatched nodes would diverge for the length of a rolling upgrade.

Mutation-checked: reverting the `append` write guard fails 3 of the new tests.