### PR TITLE
chore: upgrade TypeScript to 5.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "mocha": "10.0.0",
         "nyc": "15.1.0",
         "ts-node": "10.8.1",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       }
     },
     "node_modules/@activeledger/activecontracts": {
@@ -3888,15 +3888,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici": {
@@ -4198,7 +4199,7 @@
       "devDependencies": {
         "@types/node": "18.0.0",
         "copyfiles": "2.4.1",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       }
     },
     "packages/contracts": {
@@ -4214,7 +4215,7 @@
       },
       "devDependencies": {
         "@types/node": "18.0.0",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       }
     },
     "packages/core": {
@@ -4250,7 +4251,7 @@
       "devDependencies": {
         "@activeledger/activedefinitions": "4.5.12",
         "@types/node": "18.0.0",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       }
     },
     "packages/definitions": {
@@ -4262,7 +4263,7 @@
       },
       "devDependencies": {
         "@types/node": "18.0.0",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       }
     },
     "packages/httpd": {
@@ -4276,7 +4277,7 @@
       },
       "devDependencies": {
         "@types/node": "18.0.0",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       }
     },
     "packages/hybrid": {
@@ -4294,7 +4295,7 @@
         "@activeledger/activetoolkits": "4.5.12",
         "@activeledger/activeutilities": "4.5.12",
         "@activeledger/httpd": "4.5.12",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       },
       "bin": {
         "activehybrid": "lib/index.js"
@@ -4314,7 +4315,7 @@
       },
       "devDependencies": {
         "@types/node": "18.0.0",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       }
     },
     "packages/nano-gateway": {
@@ -4327,7 +4328,7 @@
         "@activeledger/activelogger": "4.5.12",
         "@activeledger/activeoptions": "4.5.12",
         "@activeledger/httpd": "4.5.12",
-        "typescript": "5.5.4"
+        "typescript": "5.6.3"
       },
       "bin": {
         "nano-gateway": "lib/index.js"
@@ -4335,19 +4336,6 @@
       "devDependencies": {
         "@types/node": "18.0.0",
         "copyfiles": "2.4.1"
-      }
-    },
-    "packages/nano-gateway/node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/network": {
@@ -4366,7 +4354,7 @@
       },
       "devDependencies": {
         "@types/node": "18.0.0",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       }
     },
     "packages/options": {
@@ -4382,7 +4370,7 @@
         "@activeledger/activedefinitions": "4.5.12",
         "@types/minimist": "1.2.2",
         "@types/node": "18.0.0",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       }
     },
     "packages/options/node_modules/@types/minimist": {
@@ -4412,7 +4400,7 @@
         "@activeledger/activetoolkits": "4.5.12",
         "@activeledger/vm2": "^3.9.20",
         "@types/node": "18.0.0",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       }
     },
     "packages/query": {
@@ -4425,7 +4413,7 @@
         "@activeledger/activelogger": "4.5.12"
       },
       "devDependencies": {
-        "typescript": "^4.7.3"
+        "typescript": "5.6.3"
       }
     },
     "packages/restore": {
@@ -4437,7 +4425,7 @@
         "@activeledger/activelogger": "4.5.12",
         "@activeledger/activenetwork": "4.5.12",
         "@activeledger/activeoptions": "4.5.12",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       },
       "bin": {
         "activerestore": "lib/index.js"
@@ -4462,7 +4450,7 @@
         "@types/node": "18.0.0",
         "copyfiles": "2.4.1",
         "levelup": "5.1.1",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       }
     },
     "packages/toolkits": {
@@ -4475,7 +4463,7 @@
       "devDependencies": {
         "@activeledger/activedefinitions": "4.5.12",
         "@types/node": "18.0.0",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       }
     },
     "packages/utilities": {
@@ -4488,7 +4476,7 @@
       },
       "devDependencies": {
         "@types/node": "18.0.0",
-        "typescript": "4.7.3"
+        "typescript": "5.6.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "mocha": "10.0.0",
     "nyc": "15.1.0",
     "ts-node": "10.8.1",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   }
 }

--- a/packages/activeledger/package.json
+++ b/packages/activeledger/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/node": "18.0.0",
     "copyfiles": "2.4.1",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   },
   "files": [
     "es",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "18.0.0",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   },
   "files": [
     "es",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@activeledger/activedefinitions": "4.5.12",
     "@types/node": "18.0.0",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   },
   "files": [
     "es",

--- a/packages/definitions/package.json
+++ b/packages/definitions/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "18.0.0",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   },
   "files": [
     "es",

--- a/packages/httpd/package.json
+++ b/packages/httpd/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "18.0.0",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   },
   "files": [
     "es",

--- a/packages/hybrid/package.json
+++ b/packages/hybrid/package.json
@@ -58,7 +58,7 @@
     "@activeledger/activetoolkits": "4.5.12",
     "@activeledger/activeutilities": "4.5.12",
     "@activeledger/httpd": "4.5.12",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   },
   "gitHead": "0e3737c01cf21565ceee635a5b912af3020a5fd6"
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "18.0.0",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   },
   "files": [
     "es",

--- a/packages/nano-gateway/package.json
+++ b/packages/nano-gateway/package.json
@@ -53,6 +53,6 @@
     "@activeledger/activelogger": "4.5.12",
     "@activeledger/activeoptions": "4.5.12",
     "@activeledger/httpd": "4.5.12",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "18.0.0",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   },
   "files": [
     "es",

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -35,7 +35,7 @@
     "@activeledger/activedefinitions": "4.5.12",
     "@types/minimist": "1.2.2",
     "@types/node": "18.0.0",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   },
   "files": [
     "es",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -48,6 +48,6 @@
     "@activeledger/activetoolkits": "4.5.12",
     "@activeledger/vm2": "^3.9.20",
     "@types/node": "18.0.0",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   }
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -32,7 +32,7 @@
   "author": "Activeledger",
   "license": "MIT",
   "devDependencies": {
-    "typescript": "^4.7.3"
+    "typescript": "5.6.3"
   },
   "files": [
     "es",

--- a/packages/restore/package.json
+++ b/packages/restore/package.json
@@ -49,7 +49,7 @@
     "@activeledger/activelogger": "4.5.12",
     "@activeledger/activenetwork": "4.5.12",
     "@activeledger/activeoptions": "4.5.12",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   },
   "gitHead": "0e3737c01cf21565ceee635a5b912af3020a5fd6"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -39,7 +39,7 @@
     "@types/node": "18.0.0",
     "copyfiles": "2.4.1",
     "levelup": "5.1.1",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   },
   "dependencies": {
     "@activeledger/activelogger": "4.5.12",

--- a/packages/toolkits/package.json
+++ b/packages/toolkits/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@activeledger/activedefinitions": "4.5.12",
     "@types/node": "18.0.0",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   },
   "files": [
     "es",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "18.0.0",
-    "typescript": "4.7.3"
+    "typescript": "5.6.3"
   },
   "files": [
     "es",


### PR DESCRIPTION
The build was pinned to TypeScript 4.7.3, which cannot parse `const` type
parameters (TS 5.0 syntax). Any modern `@types/node` therefore fails at parse
time with `TS1139: Type parameter declaration expected` in `ffi.d.ts`, and
`skipLibCheck` does not help because parsing precedes checking. That is what
blocks #76.

## Why 5.6.3 and not latest

TypeScript 5.7 made the typed arrays generic (`Uint8Array<ArrayBufferLike>`).
Under 5.7+ every `Buffer.concat(...)`, and every Buffer passed as `BinaryLike`
or `ArrayBufferView`, becomes a variance error — roughly 30 sites across
crypto, utilities, httpd, toolkits and network, each needing an
`as unknown as` cast. Those casts buy nothing and cost real type safety.

5.6.3 is the last release before that change, so **this PR contains no source
changes whatsoever** — it is a version bump in 18 manifests and the lockfile.

Worth noting the tree already proved 5.x works: `nano-gateway` was on 5.5.4.

## Verification

Built from genuinely clean each time (`packages/*/lib`, `packages/*/es` and
`*.tsbuildinfo` removed first, so nothing was skipped as up to date):

| Combination | Build | Tests |
|---|---|---|
| TS 5.6.3 + `@types/node` 18.0.0 (current) | 0 errors | 201 passing |
| TS 5.6.3 + `@types/node` 26.4.1 (#76) | 0 errors | 201 passing |

So #76 merges cleanly on top of this with no further work.

Node 24 throughout, matching CI.