### PR TITLE
chore: update dependencies (supersedes #76-#80)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
       "devDependencies": {
         "@types/chai": "4.3.1",
         "@types/mocha": "9.1.1",
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "chai": "4.3.6",
-        "mocha": "10.0.0",
+        "mocha": "10.8.2",
         "nyc": "15.1.0",
-        "ts-node": "10.8.1",
+        "ts-node": "10.9.2",
         "typescript": "5.6.3"
       }
     },
@@ -842,9 +842,9 @@
       "license": "MIT"
     },
     "node_modules/@types/levelup": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-5.1.1.tgz",
-      "integrity": "sha512-VITfjLp6apbz6IHxBb+8px455J+7KKWxY4mgbXlSWtiXJKiiYwnl0c6ViKrBp02SHadPxvTb5BUe44TzQmBpiQ==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-5.1.5.tgz",
+      "integrity": "sha512-Sm0jSj+LoncQ8BuZZJBjYitY5r9/V/Xd//vRjfgbQLWcQg2/iCm0HQqIOZ1KBE7QdNyAqMIG97mE3+t1GR0TIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -860,21 +860,19 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "license": "MIT"
-    },
-    "node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
     },
     "node_modules/abstract-level": {
       "version": "3.1.1",
@@ -1004,10 +1002,11 @@
       }
     },
     "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1130,6 +1129,19 @@
         }
       ]
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1178,9 +1190,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -1196,11 +1208,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1246,9 +1260,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001612",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
-      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -1263,7 +1277,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/catering": {
       "version": "2.1.1",
@@ -1633,12 +1648,13 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1648,12 +1664,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
@@ -1717,19 +1727,21 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.745",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.745.tgz",
-      "integrity": "sha512-tRbzkaRI5gbUn5DEvF0dV4TQbMZ5CLkWeTAXmpC9IrYT+GE+x76i9p+o3RJ5l9XmdQlI1pPhVtE9uNcJJ0G0EA==",
-      "dev": true
+      "version": "1.5.426",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.426.tgz",
+      "integrity": "sha512-2Gcq6inCQs/AqfHP3f5ftCzk+pqeW2VlA1LgmPqEj2hfBO8HiZRspNYkD4HzFBe4u6lGqca4BspFr6Ix4Q400g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1750,10 +1762,11 @@
       "dev": true
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1929,6 +1942,27 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -2636,6 +2670,29 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "license": "ISC"
     },
+    "node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -2649,33 +2706,32 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.4",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "5.0.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.3",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "workerpool": "6.2.1",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",
@@ -2683,10 +2739,6 @@
       },
       "engines": {
         "node": ">= 14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mochajs"
       }
     },
     "node_modules/mocha/node_modules/escape-string-regexp": {
@@ -2699,60 +2751,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mocha/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
-      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/mocha/node_modules/supports-color": {
@@ -2824,18 +2822,6 @@
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
       }
     },
-    "node_modules/nanoid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-      "dev": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/napi-macros": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
@@ -2880,10 +2866,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-      "dev": true
+      "version": "2.0.55",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.55.tgz",
+      "integrity": "sha512-mIrE/Cw9y+9Au6dS5vDKDhQza9YvG6w+ZrS6X+ZzA7yFW/soAeaups4Qzn1bL6g5FVy8WtP79+0j82oPIbqRjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/noms": {
       "version": "0.0.0",
@@ -3267,10 +3257,11 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -3391,6 +3382,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -3517,10 +3509,11 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -3818,10 +3811,11 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
-      "integrity": "sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -3909,6 +3903,12 @@
         "node": ">=18.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
     "node_modules/untildify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
@@ -3920,9 +3920,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {
@@ -3938,9 +3938,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -4035,10 +4036,11 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
-      "dev": true
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
@@ -4103,10 +4105,11 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
@@ -4197,7 +4200,7 @@
         "activeledger": "lib/index.js"
       },
       "devDependencies": {
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "copyfiles": "2.4.1",
         "typescript": "5.6.3"
       }
@@ -4214,7 +4217,7 @@
         "@activeledger/activeutilities": "4.5.12"
       },
       "devDependencies": {
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "typescript": "5.6.3"
       }
     },
@@ -4236,7 +4239,7 @@
         "activecore": "lib/index.js"
       },
       "devDependencies": {
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "copyfiles": "2.4.1"
       }
     },
@@ -4250,7 +4253,7 @@
       },
       "devDependencies": {
         "@activeledger/activedefinitions": "4.5.12",
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "typescript": "5.6.3"
       }
     },
@@ -4262,7 +4265,7 @@
         "@types/events": "^3.0.0"
       },
       "devDependencies": {
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "typescript": "5.6.3"
       }
     },
@@ -4276,7 +4279,7 @@
         "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.67.0"
       },
       "devDependencies": {
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "typescript": "5.6.3"
       }
     },
@@ -4301,7 +4304,7 @@
         "activehybrid": "lib/index.js"
       },
       "devDependencies": {
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "copyfiles": "2.4.1"
       }
     },
@@ -4314,7 +4317,7 @@
         "winston-daily-rotate-file": "^5.0.0"
       },
       "devDependencies": {
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "typescript": "5.6.3"
       }
     },
@@ -4334,7 +4337,7 @@
         "nano-gateway": "lib/index.js"
       },
       "devDependencies": {
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "copyfiles": "2.4.1"
       }
     },
@@ -4353,7 +4356,7 @@
         "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.67.0"
       },
       "devDependencies": {
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "typescript": "5.6.3"
       }
     },
@@ -4369,7 +4372,7 @@
       "devDependencies": {
         "@activeledger/activedefinitions": "4.5.12",
         "@types/minimist": "1.2.2",
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "typescript": "5.6.3"
       }
     },
@@ -4399,7 +4402,7 @@
         "@activeledger/activequery": "4.5.12",
         "@activeledger/activetoolkits": "4.5.12",
         "@activeledger/vm2": "^3.9.20",
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "typescript": "5.6.3"
       }
     },
@@ -4431,7 +4434,7 @@
         "activerestore": "lib/index.js"
       },
       "devDependencies": {
-        "@types/node": "18.0.0"
+        "@types/node": "24.10.1"
       }
     },
     "packages/storage": {
@@ -4446,8 +4449,8 @@
         "classic-level": "^3.0.0"
       },
       "devDependencies": {
-        "@types/levelup": "5.1.1",
-        "@types/node": "18.0.0",
+        "@types/levelup": "^5.1.5",
+        "@types/node": "24.10.1",
         "copyfiles": "2.4.1",
         "levelup": "5.1.1",
         "typescript": "5.6.3"
@@ -4462,7 +4465,7 @@
       },
       "devDependencies": {
         "@activeledger/activedefinitions": "4.5.12",
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "typescript": "5.6.3"
       }
     },
@@ -4475,7 +4478,7 @@
         "undici": "^6.28.0"
       },
       "devDependencies": {
-        "@types/node": "18.0.0",
+        "@types/node": "24.10.1",
         "typescript": "5.6.3"
       }
     }

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   "devDependencies": {
     "@types/chai": "4.3.1",
     "@types/mocha": "9.1.1",
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "chai": "4.3.6",
-    "mocha": "10.0.0",
+    "mocha": "10.8.2",
     "nyc": "15.1.0",
-    "ts-node": "10.8.1",
+    "ts-node": "10.9.2",
     "typescript": "5.6.3"
   }
 }

--- a/packages/activeledger/package.json
+++ b/packages/activeledger/package.json
@@ -36,7 +36,7 @@
   "author": "Activeledger",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "copyfiles": "2.4.1",
     "typescript": "5.6.3"
   },

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -32,7 +32,7 @@
   "author": "Activeledger",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "typescript": "5.6.3"
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
     "@activeledger/httpd": "4.5.12"
   },
   "devDependencies": {
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "copyfiles": "2.4.1"
   },
   "gitHead": "0e3737c01cf21565ceee635a5b912af3020a5fd6"

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "devDependencies": {
     "@activeledger/activedefinitions": "4.5.12",
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "typescript": "5.6.3"
   },
   "files": [

--- a/packages/definitions/package.json
+++ b/packages/definitions/package.json
@@ -32,7 +32,7 @@
   "author": "Activeledger",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "typescript": "5.6.3"
   },
   "files": [

--- a/packages/httpd/package.json
+++ b/packages/httpd/package.json
@@ -31,7 +31,7 @@
   "author": "Activeledger",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "typescript": "5.6.3"
   },
   "files": [

--- a/packages/hybrid/package.json
+++ b/packages/hybrid/package.json
@@ -37,7 +37,7 @@
   "author": "Activeledger",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "copyfiles": "2.4.1"
   },
   "files": [

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -32,7 +32,7 @@
   "author": "Activeledger",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "typescript": "5.6.3"
   },
   "files": [

--- a/packages/nano-gateway/package.json
+++ b/packages/nano-gateway/package.json
@@ -37,7 +37,7 @@
   "author": "Activeledger",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "copyfiles": "2.4.1"
   },
   "files": [

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -32,7 +32,7 @@
   "author": "Activeledger",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "typescript": "5.6.3"
   },
   "files": [

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@activeledger/activedefinitions": "4.5.12",
     "@types/minimist": "1.2.2",
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "typescript": "5.6.3"
   },
   "files": [

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -47,7 +47,7 @@
     "@activeledger/activequery": "4.5.12",
     "@activeledger/activetoolkits": "4.5.12",
     "@activeledger/vm2": "^3.9.20",
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "typescript": "5.6.3"
   }
 }

--- a/packages/restore/package.json
+++ b/packages/restore/package.json
@@ -35,7 +35,7 @@
   "author": "Activeledger",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.0.0"
+    "@types/node": "24.10.1"
   },
   "files": [
     "es",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -35,8 +35,8 @@
   "author": "Activeledger",
   "license": "MIT",
   "devDependencies": {
-    "@types/levelup": "5.1.1",
-    "@types/node": "18.0.0",
+    "@types/levelup": "^5.1.5",
+    "@types/node": "24.10.1",
     "copyfiles": "2.4.1",
     "levelup": "5.1.1",
     "typescript": "5.6.3"

--- a/packages/toolkits/package.json
+++ b/packages/toolkits/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "devDependencies": {
     "@activeledger/activedefinitions": "4.5.12",
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "typescript": "5.6.3"
   },
   "files": [

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -35,7 +35,7 @@
   "author": "Activeledger",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.0.0",
+    "@types/node": "24.10.1",
     "typescript": "5.6.3"
   },
   "files": [


### PR DESCRIPTION
Consolidates the five open dependabot PRs into one.

They could not be merged independently: **#77 and #79 both bump mocha to
10.8.2** and conflict with each other, and all five rewrite
`package-lock.json`, so merging any one invalidated the remainder. Rebasing
them in sequence would have been five round-trips to reach the same tree.

| Dependency | From | To | Was |
|---|---|---|---|
| `@types/node` | 18.0.0 | **24.10.1** | #76 |
| `@types/levelup` | 5.1.1 | ^5.1.5 | #76 |
| `mocha` | 10.0.0 | 10.8.2 | #77, #79 |
| `ts-node` | 10.8.1 | 10.9.2 | #78 |
| `browserslist` | 4.23.0 | 4.28.9 | #80 (transitive) |

### One deliberate deviation: `@types/node` 24, not 26

Dependabot proposed 26.4.1. Every workflow runs `node-version: 24`, and that
is the LTS line we target. Types a major ahead of the runtime will happily
typecheck calls to APIs that do not exist in production — the failure only
shows up at runtime, on a node. Types should describe the runtime we ship on,
so this pins to the 24 line.

Both were verified to build; 24 is the deliberate choice, not a constraint.

### Notes

- `js-yaml` and `nanoid` are pulled transitively by the mocha bump and needed
  no direct change — which is what #77 and #79 were really doing.
- `browserslist` stays lockfile-only, exactly as #80 had it. An earlier
  attempt added it as a direct devDependency; that was backed out.
- `npm audit --omit=dev` → **0 vulnerabilities**.

### Verification

Built from genuinely clean (`packages/*/lib`, `packages/*/es`, `*.tsbuildinfo`
removed first, so nothing was skipped as up-to-date):

- **0 build errors**
- **201 tests passing**

Depends on #87 (TypeScript 5.6.3), already merged — 4.7.3 could not parse the
`const` type parameters in modern `@types/node`.

Closes #76, closes #77, closes #78, closes #79, closes #80