### PR TITLE
fix: a fully published release reported itself as failed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -200,16 +200,21 @@ jobs:
           # Still not there. Now republish, treating "already staged" as the
           # confirmation it is.
           echo "::warning::not visible after 90s, republishing: $missing"
+          staged=""
           for dir in $missing; do
             out="$( (cd "$dir" && npm publish --access public --registry https://registry.npmjs.org/) 2>&1 )" || true
             echo "$out"
             case "$out" in
               *"previously staged version"*)
-                echo "$dir was already staged - npm has it" ;;
+                echo "$dir was already staged - npm has it"
+                staged="$staged $dir" ;;
             esac
           done
 
-          for attempt in 1 2 3 4; do
+          # npm's staging can stay unreadable for minutes. At v4.5.13
+          # activenetwork was accepted but invisible for about five of them,
+          # so four tries at 20s was nowhere near enough patience.
+          for attempt in $(seq 1 18); do
             sleep 20
             missing="$(missing_dirs)"
             if [ -z "$missing" ]; then
@@ -218,8 +223,28 @@ jobs:
             fi
           done
 
-          echo "::error::still missing from npmjs at $target: $missing"
-          exit 1
+          # Anything still invisible that npm answered "previously staged" for
+          # HAS been accepted: that error is the registry refusing to take the
+          # same version twice, which it would not say about a version it does
+          # not hold. Treating it as a failure marks a complete release broken,
+          # and the cost is not cosmetic - the job aborts before the GitHub
+          # Release step, so the release has to be created by hand afterwards.
+          # That is exactly what happened to v4.5.13. Only packages npm never
+          # acknowledged are a real error.
+          unaccounted=""
+          for dir in $missing; do
+            case " $staged " in
+              *" $dir "*) ;;
+              *) unaccounted="$unaccounted $dir" ;;
+            esac
+          done
+
+          if [ -n "$unaccounted" ]; then
+            echo "::error::still missing from npmjs at $target:$unaccounted"
+            exit 1
+          fi
+
+          echo "::warning::npm accepted$missing at $target but has not surfaced them yet - treating as published"
 
       - name: Resolve release tag
         id: releasetag


### PR DESCRIPTION
v4.5.13 published **all 17 packages** to npmjs and the workflow marked the
release failed.

## What happened

npm accepted `activenetwork`, then held it in staging — accepted but not yet
readable — for roughly five minutes. The verify step waits 90s, republishes
whatever is still invisible, waits `4 x 20s`, and errors. It gave up about
three minutes early.

It had already been told it was wrong. The republish came back with:

```
npm error code E409
npm error 409 Conflict - Cannot publish over previously staged version "4.5.13".
packages/network was already staged - npm has it
```

…and then the step failed anyway. That error is the registry refusing to take
the same version twice. It is not something npm says about a version it does
not hold — it is positive confirmation, and the step logged it and discarded it.

## Why it matters beyond a red tick

`Verify every package reached npmjs` runs **before** `Create GitHub Release`.
Aborting there skips release creation entirely, so v4.5.13's GitHub Release had
to be made by hand afterwards, and the Actions tab shows a failed release that
in fact shipped cleanly. The next person to read that history has to re-derive
all of this to know whether the release is trustworthy.

## The fix

- Wait `18 x 20s` after the republish instead of `4 x 20s` — six minutes of
  patience against a registry observed taking five.
- Record which directories npm answered `previously staged` for, and fail only
  on packages it **never acknowledged**. If everything still invisible was
  staged, warn and pass.

A genuinely absent package still fails the release. Only the "npm has it, npm
just isn't showing it yet" case changes.

## Verification

The accounting logic was extracted and tested standalone, since it otherwise
only executes during a real release:

| Case | Result |
|---|---|
| v4.5.13 exactly (network missing, was staged) | PASS |
| Genuinely absent, never acknowledged | FAIL `packages/network` |
| Mixed — one staged, one absent | FAIL `packages/query` only |
| Both staged | PASS |
| Nothing missing | PASS |
| Substring trap — `packages/net` vs `packages/network` | FAIL (correctly not matched) |

The last one is why the comparison is space-padded on both sides: a prefix must
not be satisfied by a longer sibling.