### PR TITLE
fix: activestorage published without its compiled lib

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,6 +90,13 @@ jobs:
       - name: Build all packages
         run: npm run build
 
+      # Last gate before anything leaves the runner. A tarball missing its
+      # entry point cannot be unpublished once it is on npm - 4.5.11, 4.5.12
+      # and 4.5.13 are all permanently broken because of one missing `files`
+      # field - so this fails the release instead.
+      - name: Check every package ships its entry points
+        run: node scripts/check-package-contents.mjs
+
       - name: Publish to GitHub Packages
         run: npm publish --workspaces --access public --registry https://npm.pkg.github.com/
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,5 +53,13 @@ jobs:
             echo "::endgroup::"
           done
 
+      # Catches a package whose build output exists but which npm would
+      # leave out of the tarball. v4.5.11-4.5.13 shipped activestorage
+      # with no lib/ at all: on the registry, right version, resolvable,
+      # and MODULE_NOT_FOUND on require. Cheap, and it runs on every PR
+      # rather than only at release, so the next one cannot reach npm.
+      - name: Check every package ships its entry points
+        run: node scripts/check-package-contents.mjs
+
       - name: Run tests
         run: npm test

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -17,6 +17,10 @@
   ],
   "homepage": "https://github.com/activeledger/activeledger",
   "main": "./lib/index.js",
+  "files": [
+    "es",
+    "lib"
+  ],
   "scripts": {
     "start": "node lib/index.js",
     "test": "cd ../../ && npm test",

--- a/scripts/check-package-contents.mjs
+++ b/scripts/check-package-contents.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * Fails if any package would publish a tarball that cannot be required.
+ *
+ * v4.5.11 through v4.5.13 shipped @activeledger/activestorage with no lib/
+ * at all. Its package.json still said `main: "./lib/index.js"`, so every
+ * one of those releases threw MODULE_NOT_FOUND on require() - the package
+ * was on the registry, resolvable, the right version, and unusable.
+ *
+ * The cause: `packages/.gitignore` ignores `lib` and `es`, and npm falls
+ * back to .gitignore when a package has no `files` field and no
+ * .npmignore. Every other package declares `files: ["es", "lib"]`, which
+ * overrides that. activestorage was the only one that did not, so it was
+ * the only one whose build output was silently dropped. Under lerna this
+ * never showed, because lerna packed by its own rules; dropping lerna in
+ * 4.5.11 handed packing to npm and the latent bug became live.
+ *
+ * Nothing caught it. The release workflow verifies each version is
+ * FETCHABLE from the registry, which it was. Being fetchable is not the
+ * same as being usable, and no test imports the published artefact. It
+ * took a deploy failing on someone else's machine to notice.
+ *
+ * So this asserts the weakest thing that would have caught it: whatever
+ * `main`, `types` and `module` point at must actually be inside the
+ * tarball. Run it after a build - `npm pack` runs `prepack`, not
+ * `prepublishOnly`, so it does not build for you.
+ */
+import { execFileSync } from "child_process";
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join } from "path";
+
+const readJson = (p) => JSON.parse(readFileSync(p, "utf8"));
+
+// The fields that name an entry point a consumer will actually resolve.
+const ENTRY_FIELDS = ["main", "types", "typings", "module"];
+
+const problems = [];
+const notBuilt = [];
+let checked = 0;
+
+for (const dir of readdirSync("packages")) {
+  const manifestPath = join("packages", dir, "package.json");
+  if (!existsSync(manifestPath)) continue;
+
+  const pkg = readJson(manifestPath);
+  if (!pkg.name || pkg.private) continue;
+
+  const entries = ENTRY_FIELDS.filter((f) => typeof pkg[f] === "string").map(
+    (f) => [f, pkg[f].replace(/^\.\//, "")]
+  );
+  if (!entries.length) continue;
+
+  let listed;
+  try {
+    // --json gives the exact file list npm would ship, which is the only
+    // thing worth asserting against. Reading the directory instead would
+    // miss the whole failure mode: the files were on disk, and npm left
+    // them out.
+    const out = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+      cwd: join("packages", dir),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    listed = new Set(JSON.parse(out)[0].files.map((f) => f.path));
+  } catch (e) {
+    problems.push(`${pkg.name}: could not compute tarball contents (${e.message})`);
+    continue;
+  }
+
+  checked++;
+  for (const [field, target] of entries) {
+    // Only assert against what has actually been built. A package that is
+    // not built yet has nothing to exclude, and failing on it would report
+    // the wrong thing: nano-gateway is deliberately outside the root build
+    // chain and builds itself from prepublishOnly at publish time, so its
+    // output is legitimately absent here and its published tarball is fine.
+    //
+    // The bug being guarded against is narrower and entirely different:
+    // the file is ON DISK and npm leaves it OUT. That is the only case
+    // this fails on, which keeps the check quiet enough to be trusted.
+    if (!existsSync(join("packages", dir, target))) {
+      notBuilt.push(`${pkg.name} (${field} -> ${target})`);
+      continue;
+    }
+    if (!listed.has(target)) {
+      problems.push(
+        `${pkg.name}: ${field} is "${pkg[field]}" and ${target} exists on disk, ` +
+          `but npm leaves it OUT of the tarball (${listed.size} files). Add a ` +
+          `"files" entry covering it - a package whose entry point is missing ` +
+          `installs fine, resolves fine, and throws MODULE_NOT_FOUND on require.`
+      );
+    }
+  }
+}
+
+if (problems.length) {
+  console.error("Packages that would publish an unusable tarball:\n");
+  for (const p of problems) console.error(`  - ${p}`);
+  console.error(
+    `\n${problems.length} problem(s) across ${checked} package(s) checked.`
+  );
+  process.exit(1);
+}
+
+if (notBuilt.length) {
+  // Not a failure: these build themselves at publish time. Printed so an
+  // empty pass is never mistaken for full coverage.
+  console.log(`Not built here, so not checked (built at publish time):`);
+  for (const n of notBuilt) console.log(`  - ${n}`);
+}
+
+console.log(`All ${checked} publishable packages ship the entry points they have built.`);


### PR DESCRIPTION
**v4.5.11, v4.5.12 and v4.5.13 all shipped `@activeledger/activestorage` with
no `lib/` and no `es/`.** 38 files, none of them compiled. The manifest still
said `main: "./lib/index.js"`, so `require()` threw `MODULE_NOT_FOUND` on a
package that installed cleanly, resolved fine, and reported the right version.

It surfaced as a blocked node deploy — the image build's
`node -e "require('@activeledger/activestorage')"` sanity check failed, which
aborted the roll before any node moved.

## Bisected, not guessed

| Version | Files | `lib/` entries | |
|---|---|---|---|
| 4.5.9 | 151 | 67 | OK |
| 4.5.10 | 151 | 67 | OK |
| 4.5.11 | 38 | **0** | broken |
| 4.5.12 | 38 | **0** | broken |
| 4.5.13 | 38 | **0** | broken |

## Cause

`packages/.gitignore` ignores `lib` and `es`. npm falls back to `.gitignore`
when a package has no `files` field and no `.npmignore`. All 16 other packages
declare `files: ["es", "lib"]`, which overrides that ignore — **activestorage
is the only one that never had it.**

Under lerna this never showed, because lerna packed by its own rules. Dropping
lerna in 4.5.11 handed packing to plain `npm publish --workspaces` and made a
long-latent bug live. Nothing in the package changed: its manifest is
byte-identical to 4.5.9 apart from version numbers.

## The fix

One `files` field. Tarball goes **38 → 113 files**, `lib/index.js` present.

## Why this got out, and the guard

The release workflow verifies every package is **fetchable** from the registry.
It was. Fetchable is not usable, and nothing in the repo imports the published
artefact — so three releases went out broken and it took a deploy failing on
another machine to notice.

`scripts/check-package-contents.mjs` asserts that whatever `main`, `types` and
`module` point at is actually **inside the tarball**. It runs in CI on every
push and PR, and again in `publish.yml` before anything leaves the runner —
a broken tarball cannot be unpublished, so it has to fail before, not after.

It fails **only** when the file exists on disk and npm leaves it out, which is
the real failure mode. `nano-gateway` sits outside the root build chain and
builds itself from `prepublishOnly`, so its output is legitimately absent
locally and its published tarball is fine; failing on that would have made the
check noise and noise gets ignored.

**Tested both directions:**

- With the fix → passes, 17 packages checked
- With the fix reverted → fails with exactly the v4.5.13 symptom:
  `main is "./lib/index.js" and lib/index.js exists on disk, but npm leaves it OUT of the tarball (38 files)`

## Verification

Clean build (`lib/`, `es/`, `.tsbuildinfo` removed first): **0 errors, 201 tests
passing**, guard green.

Needs a **4.5.14** release — 4.5.11 through 4.5.13 cannot be repaired in place.