### PR TITLE
feat: SPI samples atomically, and any provably-stable node can answer

### DIFF
--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -1547,7 +1547,8 @@ export class Endpoints {
     return new Promise((resolve, reject) => {
       if (body.$streams) {
         // Restrict Access to any volatile requests
-        const fetchStream = [];
+        // Ids, not promises - they are read together in one call below.
+        const fetchStream: string[] = [];
 
         // Streams this node holds but cannot report on right now
         const unavailable: { _id: string; locked: boolean }[] = [];
@@ -1604,10 +1605,29 @@ export class Endpoints {
           // state@43 with meta@21. Writing that pair locally makes
           // meta._rev:state._rev permanently wrong, which is a worse fault
           // than the one being fixed and is not repairable by SPI.
-          const heldByAsker =
-            body.$umid && Locker.is(holdValue, body.$umid);
+          //
+          // What actually makes a locked stream safe to report is one
+          // thing only: the holder will never write it. A node that voted
+          // no never reaches commit(), so its copy cannot move.
+          //
+          // This used to demand something stricter and unrelated - that
+          // the lock be held by the ASKER'S OWN transaction - because that
+          // was the case it was written for (a broadcast contract update
+          // whose origin lags, where every peer holds the very stream the
+          // origin needs to ask about). But whose transaction holds the
+          // lock says nothing about whether this node's copy is stable.
+          // Two nodes can each be sitting on a rejected transaction for
+          // the same stream and both were refusing to answer, for no
+          // reason beyond not having been asked by the right umid.
+          //
+          // So ask the question that carries the safety: whoever holds
+          // this lock, have I voted against THEM? Streams held by a
+          // transaction this node is still voting on, or has voted yes on
+          // and may commit, are refused exactly as before.
+          const holder = Locker.holder(holdValue);
+          const holderWillNotCommit = !!holder && !!host?.willNotCommit(holder);
 
-          if (Locker.has(holdValue) && !(heldByAsker && host?.willNotCommit(body.$umid))) {
+          if (Locker.has(holdValue) && !holderWillNotCommit) {
             // Held by a transaction, so this node cannot report the stream
             // right now. Saying nothing is indistinguishable from "I do not
             // have it", and the caller votes on whatever comes back - so
@@ -1623,14 +1643,37 @@ export class Endpoints {
             // flight on every node when SPI runs.
             unavailable.push({ _id: body.$streams[i], locked: true });
           } else {
-            fetchStream.push(db.get(body.$streams[i]));
+            fetchStream.push(body.$streams[i]);
           }
         }
 
         if (fetchStream.length) {
-          // Wait for all streams to be returned
-          Promise.all(fetchStream)
-            .then((docs: any) => {
+          // ONE read for the whole sample, not one per stream.
+          //
+          // This used to be Promise.all() over a db.get() per id, and db is
+          // an HTTP client - so a sample of a stream plus its :stream meta
+          // was two independent requests to the data store, concurrent but
+          // unordered. A commit lands both documents in a single leveldb
+          // batch, so a batch completing between those two responses hands
+          // back state@43 paired with meta@21. Writing that pair makes
+          // meta._rev:state._rev permanently wrong and SPI cannot repair
+          // it - the torn read the lock check above exists to avoid.
+          //
+          // allDocs({keys}) is one request, and inside the store it is one
+          // driver.getMany() over all the keys, which cannot straddle a
+          // batch write. It is also N-1 fewer round trips per sample on a
+          // path that runs for every transaction that fails its position
+          // check.
+          //
+          // include_docs is set for CouchDB's benefit; LevelMe's keys
+          // branch returns the documents either way.
+          db.allDocs({ keys: fetchStream, include_docs: true })
+            .then((result: any) => {
+              // CouchDB and LevelMe both answer { rows: [{ doc }] } here.
+              // A key the node does not hold still occupies a row, with no
+              // doc - the ._id check below drops those, exactly as the
+              // previous code dropped a failed get().
+              const docs = (result?.rows || []).map((row: any) => row?.doc).filter(Boolean);
               // Could just pass docs but that will send unnecessary data at this point
               const streams = [];
               for (let i = docs.length; i--;) {

--- a/packages/network/src/network/locker.ts
+++ b/packages/network/src/network/locker.ts
@@ -92,6 +92,25 @@ export class Locker {
   }
 
   /**
+   * Which transaction currently holds this stream, if any.
+   *
+   * is() answers "is it this umid?", which only helps a caller that
+   * already knows which umid to guess. SPI needs the opposite direction:
+   * given a locked stream, find out who holds it, so it can ask whether
+   * that holder is ever going to commit. getLocks() could answer too, but
+   * it rebuilds the entire map through Object.fromEntries on every call -
+   * fine for the debug endpoint it was written for, wasteful on a sampling
+   * path that runs per stream per transaction.
+   *
+   * @static
+   * @param {string} stream
+   * @return {*}  {(string | undefined)} the holding umid, or undefined
+   */
+  public static holder(stream: string): string | undefined {
+    return this.cell.get(stream)?.umid;
+  }
+
+  /**
    * Attempts to lock streams
    *
    * @static

--- a/packages/storage/src/levelme.ts
+++ b/packages/storage/src/levelme.ts
@@ -447,53 +447,56 @@ export class LevelMe {
   }
 
   public async getMany(keys: string[]): Promise<any[]> {
-    if (ENABLE_CACHE) {
-      let tmpKeys = [];
-      let cached = [];
-      for (let i = keys.length; i--;) {
-        if (!this.cache.has(keys[i])) {
-          tmpKeys.push(LevelMe.DOC_PREFIX + keys[i]);
-        } else {
-          // No copy here, same as the cache-miss branch below (cached.push(data)
-          // shares the object with cache.set() unconditionally) - this was an
-          // inconsistent, incomplete defensive copy: a stream that's already
-          // warm skipped mutation exposure, one that wasn't didn't. Contract
-          // code itself never touches either one directly regardless -
-          // Activity.getState() (contracts/stream.ts) always deep-clones
-          // before handing state to a contract - so this copy wasn't
-          // load-bearing for correctness, just an extra allocation on every
-          // cache hit.
-          cached.push(this.cache.get(keys[i], 30000));
-        }
-      }
+    // All from cache, or all from disk - never a mixture.
+    //
+    // This used to serve whichever keys happened to be warm from the cache
+    // and fetch the rest from the driver. For one key that is just a cache;
+    // across several it silently breaks the one property a multi-key read
+    // is worth having, because the two halves are read at different times.
+    // The cache probe is synchronous but the driver read is awaited, so a
+    // batch write can land in between - and a caller asking for a stream
+    // and its :stream meta together could get the cached state from before
+    // that write paired with the meta from after it. A commit writes both
+    // in ONE batch precisely so no reader sees half of it; mixing sources
+    // hands back exactly the torn pair the batch existed to prevent, and a
+    // mismatched meta._rev:state._rev is not repairable afterwards.
+    //
+    // So: if every key is warm, answer from the cache - consistent, because
+    // nothing can mutate it between synchronous reads. Otherwise read the
+    // whole set from the driver in a single getMany, which cannot straddle
+    // a batch. The cost is re-reading a warm key when a sibling is cold,
+    // which is one extra key in an existing call.
+    const allCached =
+      ENABLE_CACHE && keys.every((key) => this.cache.has(key));
 
-      // Get uncached keys
-      if (tmpKeys.length) {
-        const result = await this.driver.getMany(tmpKeys);
-        // Loop and cache
-        for (let i = result.length; i--;) {
-          const data = await ActiveClone.deserialize(result[i]) as any;
-          this.cache.set(data._id, data);
-          cached.push(data);
-        }
-      }
-      return cached;
-    } else {
-      const tmpKeys = [];
-      for (let i = keys.length; i--;) {
-        tmpKeys.push(LevelMe.DOC_PREFIX + keys[i]);
-      }
-
-      // Get uncached keys
-      const result = await this.driver.getMany(tmpKeys);
-
-      // Loop and parse
-      const parsed = await Promise.all(result.map(async (data) => {
-          const doc = await ActiveClone.deserialize(data) as any;
-          return doc;
-      }));
-      return parsed;
+    if (allCached) {
+      // No defensive copy, matching the driver path below and the previous
+      // behaviour - Activity.getState() (contracts/stream.ts) deep-clones
+      // before any contract sees state, so this was never load-bearing.
+      return keys.map((key) => this.cache.get(key, 30000));
     }
+
+    const prefixed = keys.map((key) => LevelMe.DOC_PREFIX + key);
+    const result = await this.driver.getMany(prefixed);
+
+    const docs: any[] = [];
+    for (let i = 0; i < result.length; i++) {
+      // A key this node does not hold comes back undefined. Deserializing
+      // that threw, so a single absent stream failed the whole read - and
+      // SPI asks about streams a node may legitimately not have.
+      if (result[i] === undefined || result[i] === null) {
+        continue;
+      }
+      const data = (await ActiveClone.deserialize(result[i])) as any;
+      if (!data || !data._id) {
+        continue;
+      }
+      if (ENABLE_CACHE) {
+        this.cache.set(data._id, data);
+      }
+      docs.push(data);
+    }
+    return docs;
   }
 
   /**

--- a/tests/spi-origin-heal.test.ts
+++ b/tests/spi-origin-heal.test.ts
@@ -51,10 +51,20 @@ describe("Host.hasVotedAgainst (Activenetwork)", () => {
 
 describe("Endpoints.streams - answering about a locked stream (Activenetwork)", () => {
   const doc = { _id: STREAM, _rev: "42-746224aa" };
+  // The sample is one allDocs({keys}) rather than a get() per id, so that a
+  // stream and its :stream meta cannot be read either side of a commit
+  // batch. Answers in CouchDB's shape, which is what LevelMe returns too.
   const db: any = {
-    get: async (id: string) => (id === STREAM ? doc : { error: "not found" }),
+    allDocs: async ({ keys }: { keys: string[] }) => ({
+      rows: keys.map((key) => ({ doc: key === STREAM ? doc : undefined })),
+    }),
   };
-  const hostThatVotedAgainst: any = { willNotCommit: () => true };
+  // Umid-aware, so a test can prove which transaction was actually asked
+  // about rather than passing because the double says yes to everything.
+  const votedAgainst = (...umids: string[]): any => ({
+    willNotCommit: (umid: string) => umids.indexOf(umid) !== -1,
+  });
+  const hostThatVotedAgainst: any = votedAgainst("tx-under-way");
   const hostThatMayCommit: any = { willNotCommit: () => false };
 
   const ask = async (body: any, host?: any) =>
@@ -84,9 +94,11 @@ describe("Endpoints.streams - answering about a locked stream (Activenetwork)", 
     expect(content).to.deep.equal([{ _id: STREAM, locked: true }]);
   });
 
-  it("refuses a DIFFERENT transaction, however this node voted", async () => {
-    // The exception is only ever about the asker's own round. Another
-    // transaction's write is still in flight as far as this one knows.
+  it("answers a DIFFERENT transaction, because the HOLDER is the one that was voted down", async () => {
+    // This used to refuse: the rule demanded the lock be held by the
+    // asker's own transaction. That condition never carried any safety -
+    // whose round is asking says nothing about whether this node's copy is
+    // about to move. What matters is that the HOLDER will never write it.
     Locker.hold(STREAM, "tx-under-way");
 
     const content = await ask(
@@ -94,14 +106,29 @@ describe("Endpoints.streams - answering about a locked stream (Activenetwork)", 
       hostThatVotedAgainst
     );
 
-    expect(content).to.deep.equal([{ _id: STREAM, locked: true }]);
+    expect(content).to.deep.equal([doc]);
   });
 
-  it("refuses when no umid is offered at all", async () => {
-    // An older node, or any caller that does not identify its round
+  it("answers when no umid is offered at all, since the holder is looked up not guessed", async () => {
+    // The asker no longer has to identify its round for this to work, so an
+    // older node - or any caller that omits $umid - is served too.
     Locker.hold(STREAM, "tx-under-way");
 
     const content = await ask({ $streams: [STREAM] }, hostThatVotedAgainst);
+
+    expect(content).to.deep.equal([doc]);
+  });
+
+  it("refuses when the node voted against a DIFFERENT transaction to the one holding the lock", async () => {
+    // The safety property, stated the hard way: having voted something down
+    // is only relevant if that something is what holds this stream. Here the
+    // node rejected an unrelated round while the holder is still live.
+    Locker.hold(STREAM, "tx-under-way");
+
+    const content = await ask(
+      { $streams: [STREAM], $umid: "tx-under-way" },
+      votedAgainst("a-completely-different-tx")
+    );
 
     expect(content).to.deep.equal([{ _id: STREAM, locked: true }]);
   });

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -50,6 +50,61 @@ describe("LevelMe write path (Activestorage) - hpe-14 regressions", () => {
       expect(result).to.have.length(1);
       expect(result[0].name).to.equal("alpha");
     });
+
+    // A multi-key read used to serve whichever keys were warm from the cache
+    // and fetch the rest from disk. Across several keys that quietly breaks
+    // the only property worth having, because the two halves are read at
+    // different moments: the cache probe is synchronous but the driver read
+    // is awaited, so a commit can land in between and pair a cached state
+    // from before it with a meta from after. A commit writes a stream and
+    // its :stream meta in ONE batch precisely so nobody sees half of it.
+    it("does not mix a cached document with a freshly read one", async () => {
+      await db.bulkDocs(
+        [
+          { _id: "streamA", name: "alpha", counter: 1 },
+          { _id: "streamA:stream", name: "alpha-meta", counter: 1 },
+        ],
+        { new_edits: true }
+      );
+
+      // Warm streamA only, leaving its companion cold
+      const [warm] = await db.getMany(["streamA"]);
+      expect(warm.name).to.equal("alpha");
+
+      const pair = await db.getMany(["streamA", "streamA:stream"]);
+      const state = pair.find((d: any) => d._id === "streamA");
+      const meta = pair.find((d: any) => d._id === "streamA:stream");
+
+      expect(state, "state should be present").to.not.equal(undefined);
+      expect(meta, "meta should be present").to.not.equal(undefined);
+      // Content is unchanged...
+      expect(state.name).to.equal("alpha");
+      expect(meta.name).to.equal("alpha-meta");
+      // ...but it is a different object, because a cold sibling forces the
+      // whole set to be re-read together rather than half-served from cache.
+      // Previously this returned the cached instance itself.
+      expect(state).to.not.equal(warm);
+    });
+
+    it("still serves from cache when every requested key is warm", async () => {
+      // The consistency rule must not become "never use the cache" - an
+      // all-warm read has nothing to straddle, because nothing can mutate
+      // the cache between two synchronous reads.
+      await db.bulkDocs(
+        [
+          { _id: "streamA", name: "alpha", counter: 1 },
+          { _id: "streamA:stream", name: "alpha-meta", counter: 1 },
+        ],
+        { new_edits: true }
+      );
+
+      const first = await db.getMany(["streamA", "streamA:stream"]);
+      const second = await db.getMany(["streamA", "streamA:stream"]);
+
+      const firstState = first.find((d: any) => d._id === "streamA");
+      const secondState = second.find((d: any) => d._id === "streamA");
+      expect(secondState).to.equal(firstState); // same reference: cache served it
+    });
   });
 
   describe("bulkDocs() change-event shape and error signalling (ac05364)", () => {


### PR DESCRIPTION
Two changes to **why SPI abstains**. Both narrow the cases where a node refuses
to report a stream, without touching the property that makes refusing correct.

A busy diverged stream currently never self-heals — `spiConsensus` abstains on
any stream some node answered `{_id, locked: true}` for, and on a hot stream
that condition is near-permanent. That is why varnir's storm needed a human.

## 1. One read per sample, not one per stream

`Endpoints.streams()` built a `db.get()` per id and `Promise.all`'d them. `db`
is an **HTTP client**, so sampling a stream and its `:stream` meta was two
independent requests to the data store — concurrent and unordered. A commit
writes both documents in a single leveldb batch, so a batch completing between
those two responses hands back `state@43` paired with `meta@21`. Writing that
pair makes `meta._rev:state._rev` permanently wrong, and SPI cannot repair it.

That torn read is the *entire justification* for refusing under lock — the
comment in `streams()` says so. Now it is one `allDocs({keys})`: one request,
and one `driver.getMany()` inside the store, which cannot straddle a batch.
Also N-1 fewer round trips on a path that runs for every transaction failing
its position check.

**`LevelMe.getMany()` had to be fixed for that to mean anything.** It served
whichever keys were warm from cache and fetched the rest from disk. For one key
that is just a cache; across several it reintroduces exactly the torn pair,
because the cache probe is synchronous while the driver read is awaited — so a
commit can land between them and pair a cached state from *before* it with a
meta from *after*. It now answers entirely from cache when every key is warm,
and otherwise re-reads the whole set together.

## 2. The holder decides, not the asker

A locked stream was reportable only when the lock was held by **the asker's own
transaction** *and* this node had voted against it:

```js
const heldByAsker = body.$umid && Locker.is(holdValue, body.$umid);
if (Locker.has(holdValue) && !(heldByAsker && host?.willNotCommit(body.$umid)))
```

Only half of that carries any safety. A node that voted no never reaches
`commit()`, so its copy cannot move — **that** is the proof. Whose round is
asking says nothing about whether this node's copy is stable. While that
condition stood, two nodes each sitting on a rejected transaction for the same
stream both refused to answer, for no reason beyond not having been asked by
the right umid.

```js
const holder = Locker.holder(holdValue);
const holderWillNotCommit = !!holder && !!host?.willNotCommit(holder);
if (Locker.has(holdValue) && !holderWillNotCommit)
```

Streams held by a transaction still being voted on, or voted yes and heading
for commit, are refused exactly as before.

`Locker` gains `holder()`. `getLocks()` could have answered, but rebuilds the
whole map through `Object.fromEntries` per call — fine for the debug endpoint
it was written for, wasteful per stream per transaction.

## Tests

**Two tests in `spi-origin-heal` changed direction rather than being fixed.**
They asserted the asker's umid had to match, which is the rule this removes.
That is a deliberate behaviour change, not a broken test being patched. A new
test keeps the safety honest: having voted down some *other* transaction does
not license reading a stream held by a live one.

The storage test was **confirmed to fail against the old `getMany`** rather
than merely passing against the new one:

```
AssertionError: expected { _id: 'streamA', ... } to not equal { _id: 'streamA', ... }
```

A companion test asserts the cache is still used when every key is warm, so the
consistency rule cannot quietly become "never use the cache".

## Verification

- **204 unit tests passing**
- **4-node network harness green** — including `spi-origin`, `spi-non-origin`,
  `contract-origin-laggard-converged`, and `contract-origin-laggard-spi-rewrote`,
  which asserts the literal `SPI REWRITING` line. The existing origin heal is
  unaffected.

## What this does not do

It does **not** relax the lock check itself. That is the change that would let a
healthy busy stream be sampled mid-commit, and it only becomes safe now that
sampling is atomic. Worth doing next, with the harness, as its own PR.

Unrelated, found while preparing this: **master's `package-lock.json` reports
4.5.13 while `package.json` reports 4.5.14** — `set-version.mjs` bumps the
manifests but not the lockfile. Deliberately left out of this diff.