### PR TITLE
feat: a node that cannot report no longer vetoes the ones that can

### DIFF
--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -702,10 +702,27 @@ export class Endpoints {
    * equals what this node already holds, so nothing is rewritten, nothing
    * is logged, and the node stays behind while SPI reports success.
    *
-   * So a stream is only decided when the sample for it is complete.
-   * Abstaining leaves the node out of date for now and it will try again
-   * on the next transaction, which is recoverable; acting on a partial
-   * sample is not.
+   * The first fix for that abstained whenever ANY node could not report.
+   * That was too blunt in both directions. On a hot stream some node is
+   * nearly always mid-transaction, so streams every node held identically
+   * still logged NOWINNER on every round - 218 times in two hours on one
+   * production stream, about a copy nothing disagreed about. And the same
+   * veto is why a genuinely diverged busy stream never healed: the one
+   * condition that has to clear for repair to happen is the condition
+   * traffic guarantees will not.
+   *
+   * The rule now is that silence does not vote and does not veto. A
+   * revision must clear consensusReached AND be held by more nodes than
+   * could not report, so nothing the unseen nodes hold could overturn it.
+   * Three agreeing with one silent is decided; two agreeing with two
+   * silent is not, because if both silent nodes disagreed the real picture
+   * would be a 2-2 split, which is a fork and needs a human.
+   *
+   * Every vote counted still comes from a node that is provably not
+   * moving, so a partial sample never puts an unstable revision into the
+   * tally - only a smaller one. Abstaining leaves the node out of date for
+   * now and it will try again on the next transaction, which is
+   * recoverable; acting on a sample that could be overturned is not.
    *
    * @static
    * @param {any[]} networkStreams one entry per node, as knockAll returns
@@ -787,10 +804,25 @@ export class Endpoints {
     for (let g = ids.length; g--; ) {
       const id = ids[g];
 
-      if (unreported[id]) {
-        abstained[id] = `sample incomplete, ${unreported[id]} node(s) could not report`;
-        continue;
-      }
+      // A node that could not report does not vote - but it does not get to
+      // veto the ones that could, either.
+      //
+      // This used to abstain the whole stream the moment ANY node answered
+      // with the locked marker, however many others had agreed. On a hot
+      // stream some node is nearly always mid-transaction, so a stream that
+      // all four nodes held byte-identically still logged NOWINNER on every
+      // single round - 218 times in two hours on one production stream,
+      // against a copy nothing disagreed about. Worse, the same veto is why
+      // a genuinely diverged busy stream never healed: the one condition
+      // that has to clear for repair to happen is the condition traffic
+      // guarantees will not.
+      //
+      // Every vote still comes from a node that is provably not moving, so
+      // nothing unstable enters the tally. The only change is that silence
+      // now counts as absence rather than as an objection, which is what
+      // consensusReached already exists to handle. If the nodes that could
+      // answer do not reach it between them, this still abstains.
+      const silent = unreported[id] || 0;
 
       const revisions = tally[id] || {};
       let winner = "";
@@ -831,8 +863,23 @@ export class Endpoints {
       if (forked) {
         abstained[id] =
           "forked - two revisions at the same position, needs a human";
+      } else if (winner && max <= silent) {
+        // Enough nodes agreed to clear the threshold, but not enough to
+        // outnumber the ones that said nothing. Silence is not evidence
+        // either way, and a rewrite is destructive - force_rev overwrites
+        // whatever is here - so a winner that could be overturned by the
+        // nodes we could not see is not a winner worth acting on.
+        //
+        // Two agreeing with two silent is the case this catches: if both
+        // silent nodes hold something else the real picture is a 2-2 split,
+        // which is a fork and needs a human, not a coin toss. Three
+        // agreeing with one silent is decided, because nothing the silent
+        // node holds can change the answer.
+        abstained[id] = `inconclusive - ${max} agreed on ${winner} but ${silent} node(s) could not report`;
       } else if (winner) {
         winners[id] = { rev: winner, votes: max, doc: revisions[winner].doc };
+      } else if (silent) {
+        abstained[id] = `no revision reached consensus, ${silent} node(s) could not report`;
       } else {
         abstained[id] = "no revision reached consensus";
       }

--- a/tests/endpoints.test.ts
+++ b/tests/endpoints.test.ts
@@ -248,7 +248,9 @@ describe("Endpoints.spiConsensus (Activenetwork)", () => {
   });
 
   it("abstains on a stream a node could not report, rather than voting on the rest", () => {
-    // The node3 case: peers busy, so only the stale local answer counts
+    // The node3 case: peers busy, so only the stale local answer counts.
+    // One vote cannot clear a threshold of 2, so this abstains on the
+    // threshold alone - a lone stale answer must never carry a stream.
     const { winners, abstained } = Endpoints.spiConsensus(
       [
         [{ _id: "088067", locked: true }, identity],
@@ -259,7 +261,8 @@ describe("Endpoints.spiConsensus (Activenetwork)", () => {
     );
 
     expect(winners["088067"]).to.equal(undefined);
-    expect(abstained["088067"]).to.contain("sample incomplete");
+    expect(abstained["088067"]).to.contain("no revision reached consensus");
+    expect(abstained["088067"]).to.contain("2 node(s) could not report");
 
     // and the stream nobody was busy with is still decided
     expect(winners["8e55d6"].rev).to.equal("2-5559ccf9");
@@ -358,7 +361,14 @@ describe("Endpoints.spiConsensus - one vote per node (Activenetwork)", () => {
   });
 
   it("counts a doubled locked marker once", () => {
-    const { abstained } = Endpoints.spiConsensus(
+    // One node answers locked twice for the same stream; two others agree.
+    //
+    // Deduplication now has a visible consequence rather than only showing
+    // up in a message. Counted once, silence is 1 against 2 agreeing votes
+    // and the stream is decided. Counted twice it would be 2 against 2, and
+    // a winner that silence could overturn is not acted on - so the bug
+    // would turn a decidable stream into an abstention.
+    const { winners, abstained } = Endpoints.spiConsensus(
       [
         [
           { _id: "088067", locked: true },
@@ -370,7 +380,9 @@ describe("Endpoints.spiConsensus - one vote per node (Activenetwork)", () => {
       2
     );
 
-    expect(abstained["088067"]).to.contain("1 node(s) could not report");
+    expect(abstained["088067"]).to.equal(undefined);
+    expect(winners["088067"].rev).to.equal(stale._rev);
+    expect(winners["088067"].votes).to.equal(2);
   });
 });
 

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -977,6 +977,52 @@ async function runSpiTests(
       ? report.ok(`Transaction succeeded via node ${originNode.port} as origin, desynced peer included (${ms}ms)`)
       : report.fail(`Failed: ${JSON.stringify(result.$summary)}`);
   }
+
+  // A stream every node agrees on must not be abstained about.
+  //
+  // This is the production symptom that had no coverage. SPI NOWINNER was
+  // logged over and over for streams all four nodes held byte-identically
+  // - 218 times in two hours on one live stream - because a single node
+  // being mid-transaction vetoed the whole decision. Nothing disagreed;
+  // the sample was simply never complete, and on a busy stream it never
+  // would be.
+  //
+  // Convergence alone would not have caught this, because the stream WAS
+  // converged the whole time. The fault lived only in the logs, which is
+  // exactly where nobody was looking.
+  await new Promise((r) => setTimeout(r, 1500));
+  report.phase("SPI: no abstention on a stream nothing disagrees about");
+  {
+    const start = Date.now();
+    // Give the last repair cycle time to settle before reading - SPI
+    // convergence is eventual, so sampling immediately can catch nodes
+    // mid-transition and fail on the test's own pacing.
+    const { byNode, converged } = await waitForConvergence(nodes, returnerId, 10000);
+    const revs = Array.from(new Set(byNode.map((n) => n.rev)));
+
+    // Only meaningful if the network really did agree - against a genuinely
+    // split stream a clean log would prove nothing, so say so rather than
+    // reporting a pass.
+    const abstained = nodes
+      .filter((node) => healedBy(node, returnerId).indexOf("SPI abstained") !== -1)
+      .map((node) => node.port);
+
+    const ok = converged && abstained.length === 0;
+    report.record("spi-no-abstain-when-agreed", ok, Date.now() - start);
+    if (!converged) {
+      report.fail(
+        `Precondition failed - nodes disagree (${byNode
+          .map((n) => `${n.port}=${n.rev}`)
+          .join(", ")}), so this check proves nothing`
+      );
+    } else if (abstained.length) {
+      report.fail(
+        `All nodes hold ${revs[0]} yet node(s) ${abstained.join(", ")} logged SPI NOWINNER for it`
+      );
+    } else {
+      report.ok(`All nodes hold ${revs[0]} and none abstained about it`);
+    }
+  }
 }
 
 /**

--- a/tests/spi-consensus-matrix.test.ts
+++ b/tests/spi-consensus-matrix.test.ts
@@ -1,0 +1,230 @@
+import { expect } from "chai";
+import "mocha";
+import { Endpoints } from "../packages/network/src/network/endpoints";
+
+/**
+ * The SPI decision matrix.
+ *
+ * spiConsensus() decides whether a node rewrites its own copy of a stream,
+ * and the rewrite is destructive - force_rev overwrites whatever is there,
+ * in either direction, with no revision tree to fall back on. So the
+ * interesting cases are not "does it pick the majority" but every shape
+ * where it must REFUSE to pick one.
+ *
+ * These are drawn from real production incidents rather than invented:
+ * the 3-1 lag that needed a hand repair, the ahead-minority contract
+ * stream, the 218-per-hour NOWINNER on streams nothing disagreed about,
+ * and the 2-2 split that has no automatic answer.
+ *
+ * Revisions are `<position>-md5(content)`, so two revisions at the same
+ * position with different hashes are two different histories, and two at
+ * different positions are the same history at different points. That
+ * distinction is the whole basis of what is safe to do automatically.
+ */
+
+// Four-node network at the default 60% consensus: ceil(0.6 * 4 - 1) = 2
+const THRESHOLD = 2;
+
+const ID = "088067b4";
+const at = (rev: string) => ({ _id: ID, _rev: rev });
+const locked = { _id: ID, locked: true };
+
+// Same history, different points
+const pos38 = at("38-c54a2e1c");
+const pos39 = at("39-246bc890");
+// Same point, different history - a genuine fork
+const pos39other = at("39-ffffffff");
+
+const decide = (nodes: any[][], threshold = THRESHOLD) =>
+  Endpoints.spiConsensus(nodes, threshold);
+
+describe("SPI decision matrix - what a node will and will not rewrite to", () => {
+  describe("clear majorities", () => {
+    it("adopts a revision three of four nodes agree on", () => {
+      const { winners, abstained } = decide([[pos39], [pos39], [pos39], [pos38]]);
+
+      expect(abstained[ID]).to.equal(undefined);
+      expect(winners[ID].rev).to.equal(pos39._rev);
+      expect(winners[ID].votes).to.equal(3);
+    });
+
+    it("pulls an AHEAD minority back, because direction is not a tiebreak when votes differ", () => {
+      // The live case: n1 alone at position 45, the other three at 44. A
+      // revision one node holds never had consensus - three agreeing IS
+      // the network's state - so the ahead copy is discarded. Position
+      // only ever breaks a tie, and 3 vs 1 is not a tie.
+      const ahead = at("45-90e6051d");
+      const majority = at("44-b7ff64f1");
+
+      const { winners } = decide([[ahead], [majority], [majority], [majority]]);
+
+      expect(winners[ID].rev).to.equal(majority._rev);
+      expect(winners[ID].votes).to.equal(3);
+    });
+
+    it("pulls a BEHIND minority forward, by the same rule", () => {
+      const behind = at("41-9fb997cf");
+      const majority = at("42-6ae23e97");
+
+      const { winners } = decide([[behind], [majority], [majority], [majority]]);
+
+      expect(winners[ID].rev).to.equal(majority._rev);
+    });
+  });
+
+  describe("forks - the cases with no safe automatic answer", () => {
+    it("refuses a 2-2 split at the same position", () => {
+      // Each side committed something the other did not, at the same point
+      // in the stream's history. Content addressing means there is nothing
+      // to tell them apart on merit, and picking either destroys a real
+      // transaction.
+      const { winners, abstained } = decide([
+        [pos39],
+        [pos39],
+        [pos39other],
+        [pos39other],
+      ]);
+
+      expect(winners[ID]).to.equal(undefined);
+      expect(abstained[ID]).to.contain("forked");
+      expect(abstained[ID]).to.contain("needs a human");
+    });
+
+    it("still refuses a fork when one side is also silent", () => {
+      const { winners, abstained } = decide([[pos39], [pos39], [pos39other], [pos39other], [locked]]);
+
+      expect(winners[ID]).to.equal(undefined);
+      expect(abstained[ID]).to.contain("forked");
+    });
+
+    it("does NOT call it a fork when the positions differ", () => {
+      // Equal support, different positions: one side simply applied
+      // something the other has not. Adopting the later one loses nothing,
+      // because the lagging copy has no history of its own.
+      const { winners, abstained } = decide([[pos38], [pos38], [pos39], [pos39]]);
+
+      expect(abstained[ID]).to.equal(undefined);
+      expect(winners[ID].rev).to.equal(pos39._rev);
+    });
+  });
+
+  describe("silence does not vote, and does not veto", () => {
+    it("decides when three agree and one is locked", () => {
+      // The 218-per-hour case. All four nodes held this identically; one
+      // was simply mid-transaction. Every round abstained and logged
+      // NOWINNER about a copy nothing disagreed about.
+      const { winners, abstained } = decide([[pos39], [pos39], [pos39], [locked]]);
+
+      expect(abstained[ID]).to.equal(undefined);
+      expect(winners[ID].rev).to.equal(pos39._rev);
+      expect(winners[ID].votes).to.equal(3);
+    });
+
+    it("refuses when two agree and two are silent, because the unseen could overturn it", () => {
+      // If both silent nodes disagreed the real picture would be 2-2,
+      // which is a fork. A winner that silence could overturn is not one
+      // worth a destructive write.
+      const { winners, abstained } = decide([[pos39], [pos39], [locked], [locked]]);
+
+      expect(winners[ID]).to.equal(undefined);
+      expect(abstained[ID]).to.contain("inconclusive");
+      expect(abstained[ID]).to.contain("2 node(s) could not report");
+    });
+
+    it("refuses when a lone answer cannot clear the threshold at all", () => {
+      const { winners, abstained } = decide([[pos38], [locked], [locked], [locked]]);
+
+      expect(winners[ID]).to.equal(undefined);
+      expect(abstained[ID]).to.contain("no revision reached consensus");
+    });
+
+    it("refuses when every node is silent", () => {
+      const { winners, abstained } = decide([[locked], [locked], [locked], [locked]]);
+
+      expect(winners[ID]).to.equal(undefined);
+      expect(abstained[ID]).to.contain("could not report");
+    });
+
+    it("never lets a stale minority win just because the rest went quiet", () => {
+      // The failure this whole mechanism exists to avoid: the asking node's
+      // own stale revision carrying its own vote, so the winner equals what
+      // it already holds, nothing is rewritten, nothing is logged, and it
+      // stays behind while SPI reports success.
+      const { winners, abstained } = decide([[pos38], [pos38], [locked], [locked]]);
+
+      expect(winners[ID]).to.equal(undefined);
+      expect(abstained[ID]).to.contain("inconclusive");
+    });
+  });
+
+  describe("counting - one vote per node", () => {
+    it("counts a node that repeats a revision only once", () => {
+      // A single node must not carry a stream by answering twice.
+      const { winners, abstained } = decide([[pos38, pos38], [locked], [locked], [locked]]);
+
+      expect(winners[ID]).to.equal(undefined);
+      expect(abstained[ID]).to.contain("no revision reached consensus");
+    });
+
+    it("counts a node that repeats a locked marker only once", () => {
+      const { winners } = decide([[locked, locked], [pos39], [pos39]]);
+
+      // Silence of 1 against 2 agreeing - decided. Double counting would
+      // make it 2 against 2 and abstain.
+      expect(winners[ID].votes).to.equal(2);
+    });
+
+    it("ignores a node that failed to answer at all", () => {
+      const { winners } = decide([[pos39], [pos39], [pos39], [], null as any]);
+
+      expect(winners[ID].rev).to.equal(pos39._rev);
+    });
+
+    it("ignores a not-found, which carries neither id nor revision", () => {
+      const { winners } = decide([
+        [pos39],
+        [pos39],
+        [pos39],
+        [{ error: "not found" } as any],
+      ]);
+
+      expect(winners[ID].rev).to.equal(pos39._rev);
+    });
+  });
+
+  describe("per stream, not per response", () => {
+    it("decides an unlocked stream in the same response as a locked one", () => {
+      // A response carrying one locked entry is the common case, not a
+      // rarity - the streams SPI arbitrates are the ones the failing
+      // transaction declared, so they are exactly the ones under lock. If
+      // one locked entry stopped every stream in that response from being
+      // decided, a node could abstain forever.
+      const other = { _id: "8e55d6", _rev: "2-5559ccf9" };
+
+      const { winners } = decide([
+        [locked, other],
+        [locked, other],
+        [pos39, other],
+        [pos39, other],
+      ]);
+
+      expect(winners["8e55d6"].rev).to.equal("2-5559ccf9");
+    });
+  });
+
+  describe("thresholds other than the four-node default", () => {
+    it("a three-node network decides on two against one silent", () => {
+      const { winners } = decide([[pos39], [pos39], [locked]], 2);
+
+      expect(winners[ID].votes).to.equal(2);
+    });
+
+    it("a higher threshold still governs, whatever the silence", () => {
+      // Three agreeing does not clear a threshold of 4.
+      const { winners, abstained } = decide([[pos39], [pos39], [pos39], [locked]], 4);
+
+      expect(winners[ID]).to.equal(undefined);
+      expect(abstained[ID]).to.contain("no revision reached consensus");
+    });
+  });
+});


### PR DESCRIPTION
`spiConsensus` abstained on a stream the moment **any** node answered with the
locked marker, however many others had agreed. On a busy stream some node is
nearly always mid-transaction, so this cost two things at once:

- Streams every node held **byte-identically** still logged `SPI NOWINNER` on
  every round — 218 times in two hours on one production stream, about a copy
  nothing disagreed about.
- The same veto is why a genuinely diverged busy stream **never healed**: the
  condition that must clear for repair to happen is the condition traffic
  guarantees will not. That is why the last divergence needed a hand repair.

## The rule

Silence now counts as **absence**, not objection. A revision must clear
`consensusReached` **and** be held by more nodes than could not report, so
nothing the unseen nodes hold could overturn it.

| Sample | Result |
|---|---|
| three agreeing, one silent | **decided** — nothing silent can change it |
| two agreeing, two silent | **refused** — if both silent disagreed the real picture is a 2-2 split, which is a fork and needs a human, not a coin toss |
| one answer, three silent | refused on the threshold alone |

Every vote counted still comes from a node that is provably not moving, so a
short sample never puts an unstable revision into the tally — only a smaller
one. Forks, thresholds and one-vote-per-node are untouched.

## What this deliberately is not

This is **not** "let locked nodes report". A node mid-commit still says nothing,
because its copy may be about to move and `force_rev` overwrites in either
direction — three peers reporting a pre-batch revision could pull a
correctly-committed node backwards, destroying a committed state. Fixing the
torn read (#100) removed one of the lock check's two jobs; this one remains.

## Tests

A new **`spi-consensus-matrix`** suite covers the decision matrix, drawn from
real incidents rather than invented: clear majorities in both directions, the
ahead-minority contract stream, 2-2 forks, position ties, every shape of
silence, one-vote-per-node, per-stream isolation, and non-default thresholds.

**Nine of them fail against the old rule**, so they discriminate rather than
merely pass. The ones that pass both ways are regression guards.

Two existing tests changed direction because the rule changed — a deliberate
behaviour change, not a broken test being patched. The doubled-locked-marker
test gains a *better* observable: deduplication now decides whether a stream is
decidable at all, rather than only altering a log message.

### Live

`spi-no-abstain-when-agreed` asserts that no node logged `SPI NOWINNER` for a
stream all four hold identically. **Convergence alone could never have caught
this** — the stream was converged the whole time; the fault lived only in the
logs, which is exactly where nobody was looking. The check fails loudly if the
nodes turn out to disagree, rather than passing vacuously on a clean log.

## Verification

- **222 unit tests passing**
- **Three consecutive clean 4-node harness runs**, including `spi-origin`,
  `spi-non-origin`, `contract-origin-laggard-spi-rewrote` and the new check

One transparency note: an early harness run hit a 20s HTTP timeout in
`negative-locked-contract`. It did not recur in three subsequent runs and is
unrelated to this change, but it is worth knowing that check can flake under
load.