### PR TITLE
fix: package READMEs used a dead activeledger.io logo URL

### DIFF
--- a/docs/en-gb/ide/README.md
+++ b/docs/en-gb/ide/README.md
@@ -2,15 +2,13 @@
 
 In this guide we will explain how to setup the IDE so you can begin publishing smart contracts right away. As you can see in the image below the IDE will take care of everything for you, allowing you to concentrate on your smart contract logic.
 
-![Activeledger IDE](https://activeledger.io/wp-content/uploads/2018/10/developer-tools-demo.gif)
+![Activeledger IDE](https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/developer-tools-demo.gif)
 
 ## Tx Section
 
 ### 1. Connection Setup
 
 The first step is to configure the Activeledger node connections. On the top right you will see a spanner icon. Click this to load the General settings screen.
-
-![General Settings](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-50-00.png)
 
 Under the _Connections_ section add the location of your Activeledger node. If you're running a local testnet you can use the following settings:
 
@@ -29,8 +27,6 @@ As smart contracts are stored on the ledger itself you need to have an identity 
 
 On the left hand side select _Keys_, you will be taken to a screen which lists all the keys managed in the IDE. You will find a tab labeled _Generate_. Here you can create a new key and onboard it to a previously entered connection. (You don't have to onboard a key right away)
 
-![Key Management](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-50-32.png)
-
 ### 3. Namespaces
 
 [Namespaces](../contracts/deployment/namespace.md) are designed to prevent collisions. Contracts are stored inside a namespace as an Activeledger asset and they are referenced by unique stream IDs. They also allow additional libraries to be imported into the smart contract VM.
@@ -39,17 +35,11 @@ To register a namespace, on the left hand side select _Namespaces_ and you will 
 
 Select your key and enter a name for your namespace. After clicking save, the IDE will create a transaction request to the network the key is registered to and attempt to reserve your namespace if it hasn't already been taken.
 
-![Namespace Management](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-51-39.png)
-
 ### 4. Writing Smart Contracts
 
 Now the IDE is ready to publish your [smart contracts](../contracts/README.md). You can create a new smart contract from anywhere within the IDE by clicking the quick action button on the top left (the + icon). This will load up a code editor with built in auto completion. You can learn more about the basics of [writing a smart contract here](../contracts/standard.md).
 
-![Composing Smart Contracts](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-52-43.png)
-
 Clicking the save icon at the top of the editor will allow you to set the name and version of this smart contract. Remember, Activeledger supports multiple versions of contract code so you can continue to revise and update the contract but still run transactions against previous versions.
-
-![Version Smart Contracts](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-53-06.png)
 
 ### 5. Uploading Smart Contracts
 
@@ -57,20 +47,14 @@ Once you have written and saved your smart contract you need to publish it to an
 
 When you have selected your contract you need to choose the network you would like to upload to. Below the editor you will be able to select the key, namespace, and connection you would like to use. Clicking _upload_ will generate a new transaction with your smart contract as the payload.
 
-![Upload Smart Contracts](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-53-25.png)
-
 ### 6. Managing Smart Contracts
 
 On the same screen you will see a tab labeled _Editor_ this will list all the smart contracts the IDE is aware of, both local only and published. If the smart contract has been publish you can access its stream ID via 2 methods.
 Activeledger also supports contract labeling to make it easier to run smart contracts. This is can be done by going to the contract information. In the Editor tab click "Show" under "Info" or in an open contract, select the kebab icon in the top right and click "Show info".
 
-![Manage Smart Contracts](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-53-45.png)
-
 - The first "Stream ID" will show a dialog listing all the networks the smart contract has been uploaded to and the corresponding stream id.
 
 - The second "Info" will change the page and provide further information about the smart contract status. From this screen you can also add reference labels for a smart contract so you can run the contract using the label name instead of having to remember the longer stream id. Referenced contract names allow you to reuse a transaction across multiple networks but run different contracts.
-
-![Manage Smart Contracts Detail](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-53-51.png)
 
 ## BaaS
 

--- a/docs/zh-cn/ide/README.md
+++ b/docs/zh-cn/ide/README.md
@@ -2,13 +2,11 @@
 
 这个说明文档介绍了如何使用Activeledger官方的IDE来发布智能合约，在Activeledger的IDE与您的区块链网络链接后，它会自动处理决大部分事情，以帮助用户把他们的重心放在编写智能合约的逻辑上。
 
-![Activeledger IDE](https://activeledger.io/wp-content/uploads/2018/10/developer-tools-demo.gif)
+![Activeledger IDE](https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/developer-tools-demo.gif)
 
 ### 1. 构建链接
 
 首先，我们需要配置Activeledger的IDE来链接Activeledger的节点。在右上角你可以看到一个扳手样子的图标，单击打开通用设置菜单。
-
-![通用设置](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-50-00.png)
 
 在*Connections*区域所需要的添加节点的位置，运行本地测试网络的用户请使用以下设置：
 
@@ -28,8 +26,6 @@
 
 在左上角选择*Keys*，IDE会跳转到一个包含所有由当前IDE管理的密钥列表。在这个页面下提供一个*Generate*的选项，这个选项可以用来生成新的密钥并且注册在与IDE已经链接的网络上（用户也可以选择暂时不注册任何网络，仅仅生成密钥）。
 
-![密钥管理](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-50-32.png)
-
 ### 3. 命名空间
 
 [命名空间](../contracts/deployment/namespace.md) 可以有效避免区块链网络中的冲突，不同的智能合约与相对应的命名空间绑定而且它们对应不同的数据流ID。命名空间也可以用来在当前虚拟节点上加载额外的应用库。
@@ -38,17 +34,11 @@
 
 用户选择密钥并且为当前命名空间新建名字，在点击保存之后，IDE会向此密钥注册的网络传递一个交易信息并且试着注册当前命名空间的名字（如果这个名字没有被使用过）。
 
-![命名空间管理](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-51-39.png)
-
 ### 4. 自定义智能合约
 
 现在这个IDE可以用来发布你的 [智能合约](../contracts/README.md)，你可以随时通过IDE创建新的智能合约。通过点击IDE的加号（+）选项，IDE会弹出一个支持自动补全的代码编辑窗口，智能合约的基本信息详见 [自定义智能合约](../contracts/standard.md)。
 
-![更多关于自定义智能合约](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-52-43.png)
-
 点击编辑器顶端的保存按钮允许用户设置当前编辑的智能合约的名字及版本，值得一提的是，Activeledger支持不同版本智能合约的控制，所以用户可以审查并更改最新版本的合约但是同时使用过去版本的合约来保证一切交易正常运行。
-
-![智能合约版本控制](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-53-06.png)
 
 ### 5. 上传智能合约
 
@@ -56,16 +46,10 @@
 
 当要选取的智能合约确定之后，用户需要选择想要上传此合约的网络。在编辑器的下方用户需要选择密钥，命名空间和链接方式，用户需要点击*upload*来产生新的交易记录以完成智能合约的部署。
 
-![上传智能合约](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-53-25.png)
-
 ### 6. 管理智能合约
 
 在智能合约界面中，用户可以通过*Editor*的选项可以打开当前IDE的所有智能合约（本地和已经部署的）。如果智能合约已经部署在网络中，用户仍然有两种方式查看数据流ID。另外，Activeledger支持智能合约标记来简化运行智能合约的过程：通过在编辑器中单击"Info"下的"Show"选项或者在编辑器中右上角单击"Show info"。
 
-![管理智能合约](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-53-45.png)
-
 * 单击"Stream ID"下的按钮，将弹出一个对话框包含当前智能合约部署的网络和对应的数据流ID。
 
 * 单击"Info"下的按钮，将弹出一个包含更多智能合约信息的新界面，在这个界面用户可以为当前合约增加额外的标记信息，这些标记信息可以代替数据流ID来运行智能合约。对智能合约赋予额外的标记名字允许用户在不同的网络上面用不同的智能合约处理同一笔交易。
-
-![更多关于管理智能合约](https://activeledger.io/wp-content/uploads/2018/10/2018-10-09_11-53-51.png)

--- a/packages/activeledger/README.md
+++ b/packages/activeledger/README.md
@@ -17,7 +17,7 @@ Run the following command to create a 3 node local testnet.
 activeledger --testnet
 ```
 
-![Activeledger Create Testnet](https://www.activeledger.io/wp-content/uploads/2018/10/testnet-create.png)
+![Activeledger Create Testnet](https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/testnet-create.png)
 
 When the testnet has been created you can run all of them at once but running
 
@@ -30,5 +30,5 @@ Alternatively you can run each instance of Activeledger independantly by navigat
 ```bash
 activeledger
 ```
-![Activeledger Launch Testnet](https://www.activeledger.io/wp-content/uploads/2018/10/testnet-run.png)
+![Activeledger Launch Testnet](https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/testnet-run.png)
 

--- a/packages/activeledger/README.md
+++ b/packages/activeledger/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 #
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Activecontracts
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Activecore
 

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Activecrypto
 

--- a/packages/definitions/README.md
+++ b/packages/definitions/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Activedefinitions
 

--- a/packages/httpd/README.md
+++ b/packages/httpd/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Http Server Daemon
 

--- a/packages/hybrid/README.md
+++ b/packages/hybrid/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Activehybrid Connect
 

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Activelogger
 

--- a/packages/nano-gateway/README.md
+++ b/packages/nano-gateway/README.md
@@ -1,3 +1,5 @@
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
+
 # @activeledger/nano-gateway
 
 A lightweight, permissioned SSE + read gateway for [nano](https://github.com/activeledger/nano) light-node clients.

--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Activenetwork
 

--- a/packages/options/README.md
+++ b/packages/options/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Activeoptions
 

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Activeprotocol
 

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Activequery
 

--- a/packages/restore/README.md
+++ b/packages/restore/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Activerestore
 

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Activestorage
 

--- a/packages/toolkits/README.md
+++ b/packages/toolkits/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Activetoolkits
 

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png" alt="Activeledger" width="300"/>
+<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
 
 # Activeutilities
 


### PR DESCRIPTION
Every `packages/*/README.md` embedded the logo from
`https://www.activeledger.io/wp-content/uploads/2018/09/Asset-23.png`.

**That domain no longer serves the project.** It 301-redirects through a chain
of unrelated third-party sites:

```
www.activeledger.io  ->  activeledger.io
                     ->  phytopharma.com.ph
                     ->  parkingautomation.com.ph
                     ->  drivengroup.com.ph
                     ->  ...
```

So the logo was dead **everywhere**, not just on npm — and every visitor to one
of the 17 published package pages on npmjs.com was issuing a request into that
redirect chain. This is worth treating as more than a cosmetic fix.

The root `README.md` was unaffected because it uses the in-repo asset by
relative path. That cannot simply be copied into a package README: npm's
published tarball contains only that package's own files, so a relative path is
guaranteed to be dead on npmjs.com even when it resolves on GitHub.

## The fix

An absolute raw.githubusercontent URL, which works in both places:

```html
<img src="https://raw.githubusercontent.com/activeledger/activeledger/master/docs/assets/Asset-23.png" alt="Activeledger" width="300"/>
```

Presentation (`alt`, `width="300"`) matches the root README exactly.

17 files: 16 one-line swaps, plus `packages/nano-gateway/README.md`, which had
no logo at all and now matches its siblings.

## Verification

- `curl -sI` on the new URL → **HTTP/2 200**, `content-length: 24672`, matching
  the local `docs/assets/Asset-23.png` byte for byte
- No relative image paths remain in any `packages/*/README.md`
- The dead URL's redirect chain was confirmed independently with `curl -sIL`

## Follow-up, deliberately not in this PR

`packages/activeledger/README.md` carries two more images on the same dead
domain — `testnet-create.png` and `testnet-run.png`. Out of scope for a
targeted logo fix, but they are broken in the same way and point at the same
redirect chain, so they want the same treatment.