### PR TITLE
test: cover the SPI sampling endpoint, the storage layer, and forks

### DIFF
--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -957,6 +957,25 @@ async function runSpiTests(
       : report.fail(`Failed: ${JSON.stringify(result.$summary)}`);
   }
 
+  // The transaction succeeding is a question about the transaction, not
+  // about the network. A round that commits on three nodes while the
+  // fourth stays behind answers it with a cheerful yes - and being behind
+  // is precisely the fault worth catching, because that node then vetoes
+  // every future transaction touching the stream. Read convergence off the
+  // nodes themselves.
+  {
+    const start = Date.now();
+    const { byNode, converged } = await waitForConvergence(nodes, identity.streamId, 10000);
+    report.record("spi-origin-converged", converged, Date.now() - start);
+    converged
+      ? report.ok(`All ${nodes.length} nodes agree on ${byNode[0].rev}`)
+      : report.fail(
+          `Transaction succeeded but nodes disagree: ${byNode
+            .map((n) => `${n.port}=${n.rev}`)
+            .join(", ")}`
+        );
+  }
+
   // Let the network fully settle/converge after the previous repair cycle
   // before injecting a fresh desync - SPI convergence is explicitly
   // asynchronous/eventual (architecture.md: "There is no single moment
@@ -976,6 +995,83 @@ async function runSpiTests(
     ok
       ? report.ok(`Transaction succeeded via node ${originNode.port} as origin, desynced peer included (${ms}ms)`)
       : report.fail(`Failed: ${JSON.stringify(result.$summary)}`);
+  }
+
+  {
+    const start = Date.now();
+    const { byNode, converged } = await waitForConvergence(nodes, identity.streamId, 10000);
+    report.record("spi-non-origin-converged", converged, Date.now() - start);
+    converged
+      ? report.ok(`All ${nodes.length} nodes agree on ${byNode[0].rev}`)
+      : report.fail(
+          `Transaction succeeded but nodes disagree: ${byNode
+            .map((n) => `${n.port}=${n.rev}`)
+            .join(", ")}`
+        );
+  }
+
+  // A genuine fork must NOT be resolved silently.
+  //
+  // Two nodes committing different content at the same position is the one
+  // shape with no safe automatic answer: revisions are position-md5, so
+  // there is nothing to tell the two sides apart on merit, and adopting
+  // either destroys the other's transaction. The tally is supposed to
+  // abstain and say so. Nothing has ever tested that end to end, and a
+  // mechanism that quietly picked a side would look exactly like a
+  // mechanism that worked.
+  //
+  // Uses its own throwaway identity: this deliberately leaves a stream
+  // broken, and it must not be one anything later depends on.
+  report.phase("SPI: a genuine fork is refused rather than guessed");
+  {
+    const start = Date.now();
+    const forkIdentity = await onboard(nodes[0].baseUrl);
+    await waitForConvergence(nodes, forkIdentity.streamId, 10000);
+
+    // Same position on every node, two different contents - a real fork,
+    // not a lag.
+    const half = Math.floor(nodes.length / 2);
+    for (let i = 0; i < nodes.length; i++) {
+      const current = await storageGet(nodes[i].storageUrl, forkIdentity.streamId);
+      await storagePut(nodes[i].storageUrl, forkIdentity.streamId, {
+        ...current,
+        forkMarker: i < half ? "side-a" : "side-b",
+      });
+    }
+
+    const injected = await revisionsAcross(nodes, forkIdentity.streamId);
+    const positions = new Set(injected.byNode.map((n) => n.rev.split("-")[0]));
+    const contents = new Set(injected.byNode.map((n) => n.rev));
+
+    // The injection itself has to be a real fork or the check proves
+    // nothing: one position, more than one revision.
+    const isFork = positions.size === 1 && contents.size > 1;
+
+    // Give SPI every chance to do the wrong thing - against the FORKED
+    // stream specifically. touchStream() runs on the shared identity and
+    // would neither exercise this fork nor leave that stream alone for the
+    // checks that follow.
+    await runContract(nodes[0].baseUrl, forkIdentity, namespace, returnerId, {
+      message: "fork-probe",
+    }).catch(() => undefined);
+    await new Promise((r) => setTimeout(r, 2000));
+
+    const after = await revisionsAcross(nodes, forkIdentity.streamId);
+    const stillSplit = new Set(after.byNode.map((n) => n.rev)).size > 1;
+
+    const ok = isFork && stillSplit;
+    report.record("spi-fork-not-guessed", ok, Date.now() - start);
+    if (!isFork) {
+      report.fail(
+        `Could not inject a fork (positions ${Array.from(positions).join("/")}, revisions ${contents.size}) - the check proves nothing`
+      );
+    } else if (!stillSplit) {
+      report.fail(
+        `A same-position fork was silently resolved to ${after.byNode[0].rev} - one side's transaction was destroyed`
+      );
+    } else {
+      report.ok(`Fork left intact for a human: ${Array.from(new Set(after.byNode.map((n) => n.rev))).join(" vs ")}`);
+    }
   }
 
   // A stream every node agrees on must not be abstained about.

--- a/tests/spi-streams-endpoint.test.ts
+++ b/tests/spi-streams-endpoint.test.ts
@@ -1,0 +1,272 @@
+import { expect } from "chai";
+import "mocha";
+import { Endpoints } from "../packages/network/src/network/endpoints";
+import { Locker } from "../packages/network/src/network/locker";
+
+/**
+ * The sampling endpoint itself - what a node hands back when another node
+ * asks it to arbitrate a stream.
+ *
+ * Everything spiConsensus decides is decided from these answers, so the
+ * shapes matter as much as the decisions. In particular a node that cannot
+ * report has to say so: staying silent is indistinguishable from "I do not
+ * have it", and a caller that treats absence as a non-answer will let a
+ * minority revision - including its own stale one - carry the vote.
+ */
+
+const STREAM = "6f3d7e2a9b1c4d5e8f0a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f70";
+const OTHER = "aa3d7e2a9b1c4d5e8f0a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6faa";
+
+const doc = { _id: STREAM, _rev: "42-746224aa" };
+const otherDoc = { _id: OTHER, _rev: "7-9931aa20" };
+
+/** Records how the store was asked, so N+1 reads cannot creep back in. */
+function makeDb(docs: any[] = [doc, otherDoc]) {
+  const calls = { allDocs: 0, get: 0, keys: [] as string[][] };
+  return {
+    calls,
+    db: {
+      allDocs: async ({ keys }: { keys: string[] }) => {
+        calls.allDocs++;
+        calls.keys.push(keys);
+        return {
+          rows: keys.map((key) => ({ doc: docs.find((d) => d._id === key) })),
+        };
+      },
+      get: async (id: string) => {
+        calls.get++;
+        return docs.find((d) => d._id === id) || { error: "not found" };
+      },
+    } as any,
+  };
+}
+
+const votedAgainst = (...umids: string[]): any => ({
+  willNotCommit: (umid: string) => umids.indexOf(umid) !== -1,
+});
+
+const ask = async (db: any, body: any, host?: any) =>
+  (await Endpoints.streams(db, body, host)) as any;
+
+describe("Endpoints.streams - the sampling endpoint (Activenetwork)", () => {
+  afterEach(() => {
+    Locker.release(STREAM, "holder-tx");
+    Locker.release(OTHER, "holder-tx");
+    Locker.release(STREAM, "other-tx");
+  });
+
+  describe("how the store is asked", () => {
+    it("reads the whole sample in ONE call, not one per stream", async () => {
+      // A get() per id is two independent round trips for a stream and its
+      // meta, and a commit landing between them yields a mismatched pair
+      // that cannot be repaired afterwards.
+      const { db, calls } = makeDb();
+
+      await ask(db, { $streams: [STREAM, `${STREAM}:stream`, OTHER] });
+
+      expect(calls.allDocs).to.equal(1);
+      expect(calls.get).to.equal(0);
+      expect(calls.keys[0]).to.have.length(3);
+    });
+
+    it("does not ask about streams it already refused", async () => {
+      Locker.hold(STREAM, "holder-tx");
+      const { db, calls } = makeDb();
+
+      await ask(db, { $streams: [STREAM, OTHER] }, votedAgainst());
+
+      expect(calls.keys[0]).to.deep.equal([OTHER]);
+    });
+
+    it("asks for nothing at all when every stream is refused", async () => {
+      Locker.hold(STREAM, "holder-tx");
+      const { db, calls } = makeDb();
+
+      const response = await ask(db, { $streams: [STREAM] }, votedAgainst());
+
+      expect(calls.allDocs).to.equal(0);
+      expect(response.content).to.deep.equal([{ _id: STREAM, locked: true }]);
+    });
+  });
+
+  describe("what it answers", () => {
+    it("mixes real documents and locked markers in one response", async () => {
+      Locker.hold(STREAM, "holder-tx");
+      const { db } = makeDb();
+
+      const { content } = await ask(db, { $streams: [STREAM, OTHER] }, votedAgainst());
+
+      expect(content).to.have.length(2);
+      expect(content).to.deep.include({ _id: STREAM, locked: true });
+      expect(content).to.deep.include(otherDoc);
+    });
+
+    it("gives the locked marker no revision, so an older node ignores it exactly as it ignored silence", async () => {
+      Locker.hold(STREAM, "holder-tx");
+      const { db } = makeDb();
+
+      const { content } = await ask(db, { $streams: [STREAM] }, votedAgainst());
+
+      expect(content[0]).to.not.have.property("_rev");
+      expect(content[0].locked).to.equal(true);
+    });
+
+    it("omits a stream this node simply does not hold", async () => {
+      // Absent is not the same as locked - the tally must be able to tell
+      // "I do not have it" from "I cannot say".
+      const { db } = makeDb([doc]);
+
+      const { content } = await ask(db, { $streams: [STREAM, "never-seen"] });
+
+      expect(content).to.have.length(1);
+      expect(content[0]._id).to.equal(STREAM);
+    });
+
+    it("answers 200 with whatever it refused when the store read fails outright", async () => {
+      Locker.hold(STREAM, "holder-tx");
+      const db: any = {
+        allDocs: async () => {
+          throw new Error("store unreachable");
+        },
+      };
+
+      const response = await ask(db, { $streams: [STREAM, OTHER] }, votedAgainst());
+
+      expect(response.statusCode).to.equal(200);
+      expect(response.content).to.deep.equal([{ _id: STREAM, locked: true }]);
+    });
+  });
+
+  describe("volatile is never served", () => {
+    it("refuses a :volatile request outright", async () => {
+      // Volatile holds key material for some contracts. It is not part of
+      // consensus and must never leave the node through this path.
+      const { db } = makeDb();
+      let rejected: any;
+      try {
+        await ask(db, { $streams: [`${STREAM}:volatile`] });
+      } catch (e) {
+        rejected = e;
+      }
+
+      expect(rejected).to.not.equal(undefined);
+      expect(rejected.statusCode).to.equal(403);
+    });
+
+    it("refuses the whole request when a :volatile id is smuggled in alongside valid ones", async () => {
+      const { db, calls } = makeDb();
+      let rejected: any;
+      try {
+        await ask(db, { $streams: [STREAM, `${OTHER}:volatile`] });
+      } catch (e) {
+        rejected = e;
+      }
+
+      expect(rejected?.statusCode).to.equal(403);
+      expect(calls.allDocs, "must not read anything on a rejected request").to.equal(0);
+    });
+  });
+
+  describe("who may be answered about a locked stream", () => {
+    it("answers when the holder has been voted down", async () => {
+      Locker.hold(STREAM, "holder-tx");
+      const { db } = makeDb();
+
+      const { content } = await ask(
+        db,
+        { $streams: [STREAM], $umid: "anyone" },
+        votedAgainst("holder-tx")
+      );
+
+      expect(content).to.deep.equal([doc]);
+    });
+
+    it("refuses when the holder may still commit", async () => {
+      Locker.hold(STREAM, "holder-tx");
+      const { db } = makeDb();
+
+      const { content } = await ask(db, { $streams: [STREAM] }, votedAgainst("someone-else"));
+
+      expect(content).to.deep.equal([{ _id: STREAM, locked: true }]);
+    });
+
+    it("refuses when there is no host to ask about the holder", async () => {
+      Locker.hold(STREAM, "holder-tx");
+      const { db } = makeDb();
+
+      const { content } = await ask(db, { $streams: [STREAM] });
+
+      expect(content).to.deep.equal([{ _id: STREAM, locked: true }]);
+    });
+
+    it("decides each stream on its own holder", async () => {
+      // Two streams in one request, locked by different transactions, only
+      // one of which this node rejected.
+      Locker.hold(STREAM, "holder-tx");
+      Locker.hold(OTHER, "other-tx");
+      const { db } = makeDb();
+
+      const { content } = await ask(db, { $streams: [STREAM, OTHER] }, votedAgainst("holder-tx"));
+
+      expect(content).to.deep.include(doc);
+      expect(content).to.deep.include({ _id: OTHER, locked: true });
+    });
+
+    it("treats a :stream meta as locked by its base stream's holder", async () => {
+      // The lock is taken on the stream id; the meta document rides with
+      // it. Answering about the meta while refusing the state would hand
+      // back exactly the mismatched pair the lock exists to prevent.
+      Locker.hold(STREAM, "holder-tx");
+      const { db } = makeDb();
+
+      const { content } = await ask(db, { $streams: [`${STREAM}:stream`] }, votedAgainst("someone-else"));
+
+      expect(content).to.deep.equal([{ _id: `${STREAM}:stream`, locked: true }]);
+    });
+  });
+});
+
+describe("Locker.holder (Activenetwork)", () => {
+  const A = STREAM;
+
+  afterEach(() => {
+    Locker.release(A, "tx-1");
+    Locker.release(A, "tx-2");
+  });
+
+  it("is undefined for a stream nobody holds", () => {
+    expect(Locker.holder(A)).to.equal(undefined);
+  });
+
+  it("names the transaction holding it", () => {
+    Locker.hold(A, "tx-1");
+    expect(Locker.holder(A)).to.equal("tx-1");
+  });
+
+  it("goes back to undefined once released", () => {
+    Locker.hold(A, "tx-1");
+    Locker.release(A, "tx-1");
+    expect(Locker.holder(A)).to.equal(undefined);
+  });
+
+  it("still names the original holder after a competing hold is refused", () => {
+    // hold() refuses rather than steals, so the answer must not change.
+    Locker.hold(A, "tx-1");
+    expect(Locker.hold(A, "tx-2")).to.equal(false);
+    expect(Locker.holder(A)).to.equal("tx-1");
+  });
+
+  it("agrees with is() in both directions", () => {
+    Locker.hold(A, "tx-1");
+    const holder = Locker.holder(A) as string;
+
+    expect(Locker.is(A, holder)).to.equal(true);
+    expect(Locker.is(A, "tx-2")).to.equal(false);
+    expect(Locker.has(A)).to.equal(true);
+  });
+
+  it("agrees with getLocks(), which is the slower way to the same answer", () => {
+    Locker.hold(A, "tx-1");
+    expect(Locker.holder(A)).to.equal(Locker.getLocks()[A]?.umid);
+  });
+});

--- a/tests/storage-read-write.test.ts
+++ b/tests/storage-read-write.test.ts
@@ -1,0 +1,401 @@
+import { LevelMe } from "../packages/storage/src/levelme";
+import { expect } from "chai";
+import "mocha";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * Read/write behaviour of the storage engine, and the read cache in front
+ * of it.
+ *
+ * Everything SPI decides is decided from what this layer hands back, and
+ * the repair it performs is a raw overwrite with no revision tree to fall
+ * back on. So the properties worth pinning down are not "can it store a
+ * document" but the ones a wrong answer would silently corrupt:
+ * read-after-write, whether the cache can serve something the disk no
+ * longer holds, whether concurrent writers can interleave into a
+ * half-applied state, and whether a multi-key read is a consistent view of
+ * one moment or a stitched-together set of several.
+ *
+ * The last one is not hypothetical. A commit writes a stream and its
+ * :stream meta in ONE batch precisely so nobody observes half of it, and a
+ * reader that pairs a pre-batch state with a post-batch meta produces a
+ * mismatched meta._rev:state._rev that SPI cannot repair afterwards.
+ */
+describe("LevelMe read/write and cache behaviour (Activestorage)", () => {
+  let tmpDir: string;
+  let db: LevelMe;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "activeledger-rw-test-"));
+    db = new LevelMe(tmpDir + path.sep, "activeledger", "level");
+    await db.open();
+  });
+
+  afterEach(async () => {
+    await db.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const write = (docs: any[], options: any = { new_edits: true }) =>
+    db.bulkDocs(docs, options);
+
+  describe("read-after-write", () => {
+    it("a write is visible to the very next read", async () => {
+      await write([{ _id: "s1", value: "first" }]);
+      expect((await db.get("s1")).value).to.equal("first");
+    });
+
+    it("an overwrite is visible immediately, and the cache does not serve the old copy", async () => {
+      await write([{ _id: "s1", value: "first" }]);
+      await db.get("s1"); // warm the cache with the OLD value
+      await write([{ _id: "s1", value: "second" }]);
+
+      // If the write did not invalidate what the read cached, this returns
+      // "first" - a document that no longer exists on disk.
+      expect((await db.get("s1")).value).to.equal("second");
+    });
+
+    it("the same is true through the multi-key path", async () => {
+      await write([{ _id: "s1", value: "first" }]);
+      await db.getMany(["s1"]);
+      await write([{ _id: "s1", value: "second" }]);
+
+      const [doc] = await db.getMany(["s1"]);
+      expect(doc.value).to.equal("second");
+    });
+
+    it("raw and resolved reads of the same id do not poison each other", async () => {
+      // They store different shapes under the same id, so they need
+      // distinct cache keys or one mode serves the other's data.
+      await write([{ _id: "s1", value: "first" }]);
+
+      const raw = await db.get("s1", true);
+      const resolved = await db.get("s1");
+
+      expect(raw._id).to.equal("s1");
+      expect(resolved._id).to.equal("s1");
+      expect(resolved.value).to.equal("first");
+
+      await write([{ _id: "s1", value: "second" }]);
+      expect((await db.get("s1", true))._id).to.equal("s1");
+      expect((await db.get("s1")).value).to.equal("second");
+    });
+  });
+
+  describe("revisions", () => {
+    it("advances position and changes the hash when content changes", async () => {
+      await write([{ _id: "s1", value: "first" }]);
+      const first = (await db.get("s1"))._rev;
+      await write([{ _id: "s1", value: "second" }]);
+      const second = (await db.get("s1"))._rev;
+
+      const [p1, h1] = first.split("-");
+      const [p2, h2] = second.split("-");
+      expect(parseInt(p2, 10)).to.equal(parseInt(p1, 10) + 1);
+      expect(h2).to.not.equal(h1);
+    });
+
+    it("is content addressed - identical content anywhere gives an identical hash", async () => {
+      // This is what lets a repair recompute a revision locally and check
+      // it against the one it is adopting, and what makes two revisions at
+      // the same position with different hashes a genuine fork.
+      await write([{ _id: "a", shape: { x: 1 } }]);
+      await write([{ _id: "b", shape: { x: 1 } }]);
+
+      const a = (await db.get("a"))._rev.split("-")[1];
+      const b = (await db.get("b"))._rev.split("-")[1];
+      expect(a).to.not.equal(b); // _id participates, so these differ
+
+      // but the same document rewritten unchanged does not move at all
+      const before = (await db.get("a"))._rev;
+      await write([{ _id: "a", shape: { x: 1 }, _rev: before }]);
+      expect((await db.get("a"))._rev).to.equal(before);
+    });
+
+    it("force_rev writes the revision verbatim, in either direction", async () => {
+      // The repair primitive. It does not compare against what is there,
+      // which is exactly why a caller has to verify the hash itself - the
+      // store will happily hold a revision that does not describe its own
+      // content.
+      await write([{ _id: "s1", value: "first" }]);
+      await write([{ _id: "s1", value: "second" }]);
+      const forward = (await db.get("s1"))._rev;
+      expect(parseInt(forward.split("-")[0], 10)).to.equal(2);
+
+      await write([{ _id: "s1", value: "rolled back" }], {
+        new_edits: true,
+        force_rev: "1-deadbeefdeadbeefdeadbeefdeadbeef",
+      });
+
+      const back = await db.get("s1");
+      expect(back._rev).to.equal("1-deadbeefdeadbeefdeadbeefdeadbeef");
+      expect(back.value).to.equal("rolled back");
+    });
+  });
+
+  describe("multi-key reads are one consistent view", () => {
+    it("returns a stream and its :stream meta from the same moment", async () => {
+      await write([
+        { _id: "s1", value: "state-1" },
+        { _id: "s1:stream", value: "meta-1" },
+      ]);
+
+      const pair = await db.getMany(["s1", "s1:stream"]);
+      const state = pair.find((d: any) => d._id === "s1");
+      const meta = pair.find((d: any) => d._id === "s1:stream");
+
+      expect(state.value).to.equal("state-1");
+      expect(meta.value).to.equal("meta-1");
+    });
+
+    it("a batch is observed whole or not at all, never half", async () => {
+      // Both documents move in one batch. However many times a reader
+      // samples them, it must never see one at generation 1 and the other
+      // at generation 2 - that pairing is the fault SPI cannot repair.
+      //
+      // Be clear about what this does and does not prove. It is a stress
+      // guard on batch atomicity, not a reproduction of the cache-mixing
+      // bug: it was run against the pre-fix mixing implementation and
+      // still passed, because producing a torn pair that way needs a write
+      // to land inside the exact await between the cache probe and the
+      // driver read, which a loop this size will not reliably hit.
+      //
+      // The mixing property is pinned down deterministically instead by
+      // "does not mix a cached document with a freshly read one" in
+      // storage.test.ts, which does fail against the old implementation.
+      // This one earns its place by covering what that cannot - that a
+      // multi-document batch stays indivisible under real concurrent load,
+      // however the layers underneath are rearranged later.
+      //
+      // The warm-one-side read is kept because it is the realistic access
+      // pattern: plenty of callers read a stream without its meta.
+      await write([
+        { _id: "s1", gen: 1 },
+        { _id: "s1:stream", gen: 1 },
+      ]);
+
+      const readings: string[] = [];
+      const reader = (async () => {
+        for (let i = 0; i < 300; i++) {
+          await db.get("s1"); // warms one side only
+          const pair = await db.getMany(["s1", "s1:stream"]);
+          const state = pair.find((d: any) => d._id === "s1");
+          const meta = pair.find((d: any) => d._id === "s1:stream");
+          if (state && meta) readings.push(`${state.gen}:${meta.gen}`);
+        }
+      })();
+
+      const writer = (async () => {
+        for (let gen = 2; gen <= 20; gen++) {
+          await write([
+            { _id: "s1", gen },
+            { _id: "s1:stream", gen },
+          ]);
+        }
+      })();
+
+      await Promise.all([reader, writer]);
+
+      const torn = Array.from(new Set(readings)).filter((r) => {
+        const [a, b] = r.split(":");
+        return a !== b;
+      });
+      expect(torn, `torn pairs observed: ${torn.join(", ")}`).to.have.length(0);
+      expect(readings.length).to.be.greaterThan(0);
+    });
+
+    it("handles a set where some keys exist and some never did", async () => {
+      await write([{ _id: "here", value: 1 }]);
+
+      const docs = await db.getMany(["here", "never", "also-never"]);
+      expect(docs).to.have.length(1);
+      expect(docs[0]._id).to.equal("here");
+    });
+
+    it("survives a large key set without dropping or duplicating", async () => {
+      const ids = Array.from({ length: 200 }, (_, i) => `bulk-${i}`);
+      await write(ids.map((id) => ({ _id: id, n: id })));
+
+      const docs = await db.getMany(ids);
+      const seen = new Set(docs.map((d: any) => d._id));
+      expect(docs).to.have.length(ids.length);
+      expect(seen.size).to.equal(ids.length);
+    });
+  });
+
+  describe("concurrency", () => {
+    it("serialises concurrent writes to the same document without losing one", async () => {
+      await write([{ _id: "hot", n: 0 }]);
+
+      await Promise.all(
+        Array.from({ length: 25 }, (_, i) => write([{ _id: "hot", n: i + 1 }]))
+      );
+
+      const doc = await db.get("hot");
+      // Whichever won, the document must be internally coherent: a real
+      // value, and a revision whose position reflects the writes applied.
+      expect(doc).to.have.property("n");
+      expect(parseInt(doc._rev.split("-")[0], 10)).to.be.greaterThan(1);
+    });
+
+    it("keeps unrelated documents independent under concurrent load", async () => {
+      const ids = Array.from({ length: 40 }, (_, i) => `c-${i}`);
+
+      await Promise.all(ids.map((id) => write([{ _id: id, id }])));
+
+      for (const id of ids) {
+        const doc = await db.get(id);
+        expect(doc.id, `${id} should hold its own value`).to.equal(id);
+      }
+    });
+
+    it("interleaved reads never observe a document that was never written", async () => {
+      await write([{ _id: "s1", value: "v0" }]);
+
+      const values = new Set<string>();
+      await Promise.all([
+        (async () => {
+          for (let i = 1; i <= 20; i++) await write([{ _id: "s1", value: `v${i}` }]);
+        })(),
+        (async () => {
+          for (let i = 0; i < 100; i++) {
+            const doc = await db.get("s1");
+            if (doc?.value) values.add(doc.value);
+          }
+        })(),
+      ]);
+
+      for (const v of values) {
+        expect(/^v\d+$/.test(v), `unexpected value observed: ${v}`).to.equal(true);
+      }
+    });
+  });
+
+  describe("deletion", () => {
+    it("a deleted document stops being readable", async () => {
+      await write([{ _id: "gone", value: 1 }]);
+      await db.get("gone"); // warm the cache first
+      await db.del("gone");
+
+      let found = true;
+      try {
+        const doc = await db.get("gone");
+        found = !!doc?.value;
+      } catch {
+        found = false;
+      }
+      // The cache must not keep serving a document the disk no longer has.
+      expect(found).to.equal(false);
+    });
+
+    it("does not disturb its neighbours", async () => {
+      await write([
+        { _id: "keep-1", value: 1 },
+        { _id: "drop", value: 2 },
+        { _id: "keep-2", value: 3 },
+      ]);
+      await db.del("drop");
+
+      expect((await db.get("keep-1")).value).to.equal(1);
+      expect((await db.get("keep-2")).value).to.equal(3);
+    });
+  });
+
+  describe("allDocs", () => {
+    beforeEach(async () => {
+      await write(
+        Array.from({ length: 10 }, (_, i) => ({
+          _id: `range-${String(i).padStart(2, "0")}`,
+          n: i,
+        }))
+      );
+    });
+
+    it("returns the requested keys, in the shape callers expect", async () => {
+      const result: any = await db.allDocs({
+        keys: ["range-00", "range-01"],
+        include_docs: true,
+      });
+
+      expect(result.rows).to.have.length(2);
+      for (const row of result.rows) {
+        expect(row).to.have.property("doc");
+        expect(row.doc._id).to.match(/^range-0[01]$/);
+      }
+    });
+
+    it("honours a limit", async () => {
+      const result: any = await db.allDocs({ limit: 3 });
+      expect(result.rows.length).to.be.at.most(3);
+    });
+
+    it("honours a start key", async () => {
+      const result: any = await db.allDocs({ startkey: "range-05" });
+      const ids = result.rows.map((r: any) => r.doc?._id || r.id).filter(Boolean);
+      for (const id of ids) {
+        if (id.startsWith("range-")) {
+          expect(id >= "range-05", `${id} should not precede range-05`).to.equal(true);
+        }
+      }
+    });
+
+    it("does not return meta-store internals as if they were documents", async () => {
+      // The keyspace holds meta alongside documents; a range read that ran
+      // off the end of the document prefix would hand a caller something
+      // that is not a stream at all.
+      const result: any = await db.allDocs({});
+      for (const row of result.rows) {
+        const id = row.doc?._id || row.id;
+        if (id) expect(id.startsWith("ÿ"), `${id} looks like a meta key`).to.equal(false);
+      }
+    });
+  });
+
+  describe("document shapes that have broken things before", () => {
+    it("round-trips a large document unchanged", async () => {
+      // Documents are compressed on write; a value large enough to matter
+      // has to come back byte-identical or a revision computed over it
+      // stops matching everyone else's.
+      const big = "x".repeat(200_000);
+      await write([{ _id: "big", blob: big }]);
+
+      const doc = await db.get("big");
+      expect(doc.blob).to.have.length(big.length);
+      expect(doc.blob).to.equal(big);
+    });
+
+    it("round-trips nested structures and unicode", async () => {
+      const value = {
+        _id: "shapes",
+        nested: { a: [1, 2, { b: "ünïcødé ✅ 中文" }] },
+        empty: {},
+        list: [],
+        zero: 0,
+        no: false,
+      };
+      await write([value]);
+
+      const doc = await db.get("shapes");
+      expect(doc.nested.a[2].b).to.equal("ünïcødé ✅ 中文");
+      expect(doc.zero).to.equal(0);
+      expect(doc.no).to.equal(false);
+      expect(doc.list).to.deep.equal([]);
+    });
+
+    it("keeps an id containing a colon distinct from its base", async () => {
+      // ":stream", ":volatile" and ":data" siblings all live in the same
+      // keyspace as the stream itself.
+      await write([
+        { _id: "col", which: "state" },
+        { _id: "col:stream", which: "meta" },
+        { _id: "col:volatile", which: "volatile" },
+      ]);
+
+      expect((await db.get("col")).which).to.equal("state");
+      expect((await db.get("col:stream")).which).to.equal("meta");
+      expect((await db.get("col:volatile")).which).to.equal("volatile");
+    });
+  });
+});


### PR DESCRIPTION
**222 → 265 unit tests, plus four live checks.** Written against gaps a sweep of
the existing suite turned up, not to raise a number.

## SPI sampling endpoint — new file

`Endpoints.streams()` decides what every tally is computed from, and almost none
of its surface was covered. Now pinned down:

- **A sample is ONE store call**, not one per stream. An N+1 here is exactly
  what let a commit land between a stream and its `:stream` meta.
- Refused streams are **not read at all**.
- A locked marker carries **no `_rev`**, so an older node ignores it exactly as
  it ignored silence.
- A stream this node **does not hold is omitted**, not marked locked — "I do not
  have it" and "I cannot say" must stay distinguishable, because the tally
  treats them differently.
- A failed store read still answers **200 with whatever was refused**.
- `:volatile` is refused outright, **including when smuggled in beside valid
  ids**, with nothing read on a rejected request.

Plus `Locker.holder()`, which the previous change introduced untested.

## Storage — new file

Read-after-write, including that a write invalidates what a read cached, through
both the single- and multi-key paths, and that raw and resolved reads do not
poison each other. Revision semantics: position advances, content addressing
holds, an unchanged rewrite does not move, and `force_rev` writes verbatim in
either direction. Concurrency: 25 writers on one document, 40 on their own, and
interleaved readers that must never observe a value nobody wrote. Deletion,
`allDocs` ranges and limits, meta keys never surfacing as documents, and shapes
that have broken things before — a 200KB document, unicode, ids with a colon.

## Live

`spi-origin` and `spi-non-origin` asserted only that the **client got a clean
response**. This file's own comment calls that the wrong question — a round that
commits on three nodes while the fourth stays behind answers it with a cheerful
yes, and being behind is the fault worth catching. Added
`spi-origin-converged` and `spi-non-origin-converged`, which read convergence
off the nodes.

**`spi-fork-not-guessed`** injects a real same-position fork — one position, two
contents — and asserts the network leaves it alone. Nothing tested that end to
end, and a mechanism that quietly picked a side would look exactly like one that
worked. It refuses to conclude anything if the injection was not a genuine fork:

```
✔ Fork left intact for a human: 2-b269e49e... vs 2-fcb336ce...
```

## Two honesty notes

**The concurrent torn-pair test is a stress guard, not a reproduction.** I ran it
against the pre-fix mixing implementation and it still passed, because tearing
that way needs a write to land inside one exact `await`. Its comment says so and
points at the deterministic test that does discriminate. A test that cannot fail
is decoration, and I would rather label it than let it look like proof.

**An earlier draft of the fork check called `touchStream()`**, which runs against
the *shared* identity — so it neither exercised the fork nor left that stream
alone, and it broke `contract-update-majority-commits` two phases later. That
failure looked like a real regression in the merged veto change until I traced
it. Fixed to probe the forked stream itself.

## Verification

- **265 unit tests passing**
- **Three consecutive clean 4-node harness runs**