### PR TITLE
test: pin down the authorisation model, and restore recovering a loss

### DIFF
--- a/tests/authorisation-model.test.ts
+++ b/tests/authorisation-model.test.ts
@@ -1,0 +1,251 @@
+import { PermissionsChecker } from "../packages/protocol/src/protocol/permissionsChecker";
+import { Shared } from "../packages/protocol/src/protocol/shared";
+import { ActiveCrypto } from "../packages/crypto/src";
+import { expect } from "chai";
+import "mocha";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * The authorisation model, written down as executable fact.
+ *
+ * These properties decide who may write to a stream, and until now nothing
+ * asserted any of them - they lived only in the source and in whoever had
+ * last read it. That is expensive, because the model is not what most
+ * people assume:
+ *
+ *   - Inputs are always signature-checked against the stream's own
+ *     authorities.
+ *   - OUTPUTS ARE NOT, unless security.signedOutputs is switched on, and
+ *     it is absent from the shipped config, so it is off.
+ *   - There is no engine-level gate on who may invoke a contract entry.
+ *     Authorisation past this point is whatever the contract checks.
+ *
+ * That combination is load-bearing: a contract writing to an existing
+ * stream it names in $o gets no authority check from the engine by
+ * default, so the contract is the only thing standing between a caller and
+ * someone else's stream. A refactor that changed any of this silently
+ * would be a serious security regression, and these tests exist so it
+ * cannot happen quietly.
+ *
+ * They deliberately do NOT assert that the current defaults are the right
+ * ones - only that they are what they are. Changing them should be a
+ * decision someone makes on purpose, and updating a test here is how that
+ * decision gets recorded.
+ */
+
+const STREAM = "5c1f9d3a7b2e4c6d8f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0b1c2d3e4f506";
+
+/** Real keys - a stubbed signature check would prove nothing here. */
+function keys() {
+  const kp = new ActiveCrypto.KeyPair("rsa");
+  const generated = kp.generate();
+  return { kp, pub: generated.pub.pkcs8pem };
+}
+
+const owner = keys();
+const stranger = keys();
+
+/** A stream whose only authority is `owner`. */
+function streamDocs(rev = "1-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+  return [
+    { doc: { _id: STREAM, _rev: rev, balance: 10 } },
+    {
+      doc: {
+        _id: `${STREAM}:stream`,
+        _rev: rev,
+        authorities: [{ public: owner.pub, type: "rsa", hash: "" }],
+      },
+    },
+  ];
+}
+
+function makeChecker(entry: any, security: Partial<any> = {}, rows = streamDocs()) {
+  const db: any = { allDocs: async () => ({ rows }) };
+  const shared = new Shared(false, entry, db, null as any);
+  const securityCache: any = {
+    namespace: {},
+    hardenedKeys: false,
+    // Absent in the shipped config, so undefined is the honest default
+    signedOutputs: undefined,
+    ...security,
+  };
+  return new PermissionsChecker(entry, db, securityCache, shared);
+}
+
+/** A transaction touching STREAM, signed by whoever is given. */
+function entryFor(signer: { kp: any }, io: "$i" | "$o") {
+  const tx = {
+    $namespace: "test",
+    $contract: "transfer",
+    $i: io === "$i" ? { [STREAM]: { amount: 1 } } : {},
+    $o: io === "$o" ? { [STREAM]: { amount: 1 } } : {},
+  };
+  return {
+    $umid: "umid-under-test",
+    $tx: tx,
+    $sigs: { [STREAM]: signer.kp.sign(tx) },
+    $revs: { $i: {}, $o: {} },
+    $nodes: {},
+  } as any;
+}
+
+describe("Authorisation model (Activeprotocol)", () => {
+  describe("inputs are always checked", () => {
+    it("accepts a signature from one of the stream's authorities", async () => {
+      const entry = entryFor(owner, "$i");
+      const streams = await makeChecker(entry).process([STREAM], true);
+
+      expect(streams).to.have.length(1);
+      expect(streams[0].state._id).to.equal(STREAM);
+    });
+
+    it("rejects a signature from a key the stream does not authorise", async () => {
+      const entry = entryFor(stranger, "$i");
+
+      let rejection: any;
+      try {
+        await makeChecker(entry).process([STREAM], true);
+      } catch (e) {
+        rejection = e;
+      }
+
+      expect(rejection, "a stranger's signature must not pass").to.not.equal(undefined);
+      expect(rejection.code).to.equal(1220);
+      expect(rejection.reason).to.contain("Input Signature Incorrect");
+    });
+
+    it("rejects even when signedOutputs is on - inputs never depend on that flag", async () => {
+      const entry = entryFor(stranger, "$i");
+
+      let rejection: any;
+      try {
+        await makeChecker(entry, { signedOutputs: true }).process([STREAM], true);
+      } catch (e) {
+        rejection = e;
+      }
+
+      expect(rejection?.code).to.equal(1220);
+    });
+  });
+
+  describe("outputs are NOT checked by default", () => {
+    it("accepts a stranger's signature on an output stream", async () => {
+      // This is the property most people get wrong, and the reason a
+      // contract using $selfsign with an $o pointing at an existing stream
+      // has no engine-level protection at all. It is asserted here so that
+      // it is visible, not because it is desirable.
+      const entry = entryFor(stranger, "$o");
+
+      const streams = await makeChecker(entry).process([STREAM], false);
+
+      expect(streams).to.have.length(1);
+      expect(streams[0].state._id).to.equal(STREAM);
+    });
+
+    it("accepts an output with no signature at all", async () => {
+      const entry = entryFor(owner, "$o");
+      delete entry.$sigs[STREAM];
+
+      const streams = await makeChecker(entry).process([STREAM], false);
+
+      expect(streams).to.have.length(1);
+    });
+
+    it("but DOES check them once signedOutputs is switched on", async () => {
+      // The systemic fix for the above. It is network-wide, and it will
+      // start rejecting any existing contract that writes to an output it
+      // holds no authority over - which is why it is not simply flipped.
+      const entry = entryFor(stranger, "$o");
+
+      let rejection: any;
+      try {
+        await makeChecker(entry, { signedOutputs: true }).process([STREAM], false);
+      } catch (e) {
+        rejection = e;
+      }
+
+      expect(rejection, "signedOutputs must actually gate this").to.not.equal(undefined);
+      expect(rejection.code).to.equal(1220);
+      expect(rejection.reason).to.contain("Output Signature Incorrect");
+    });
+
+    it("accepts the rightful owner on an output whether the flag is on or off", async () => {
+      for (const signedOutputs of [undefined, true]) {
+        const entry = entryFor(owner, "$o");
+        const streams = await makeChecker(entry, { signedOutputs }).process([STREAM], false);
+        expect(streams, `signedOutputs=${signedOutputs}`).to.have.length(1);
+      }
+    });
+  });
+
+  describe("the revision check is separate from the signature check", () => {
+    it("rejects a stale input revision even with a valid signature", async () => {
+      const entry = entryFor(owner, "$i");
+      entry.$revs.$i[STREAM] = "9-somethingelse:9-somethingelse";
+
+      let rejection: any;
+      try {
+        await makeChecker(entry).process([STREAM], true);
+      } catch (e) {
+        rejection = e;
+      }
+
+      expect(rejection?.code).to.equal(1200);
+      expect(rejection.reason).to.contain("Position Incorrect");
+    });
+
+    it("rejects a stale OUTPUT revision, even though the signature is not checked", async () => {
+      // Position is the one thing outputs are always held to. It is what
+      // makes SPI's whole model work, and it is why a diverged node vetoes
+      // every later transaction touching the stream.
+      const entry = entryFor(stranger, "$o");
+      entry.$revs.$o[STREAM] = "9-somethingelse:9-somethingelse";
+
+      let rejection: any;
+      try {
+        await makeChecker(entry).process([STREAM], false);
+      } catch (e) {
+        rejection = e;
+      }
+
+      expect(rejection?.code).to.equal(1200);
+      expect(rejection.reason).to.contain("Output Stream Position Incorrect");
+    });
+
+    it("records the revision when the transaction did not carry one", async () => {
+      const entry = entryFor(owner, "$i");
+      await makeChecker(entry).process([STREAM], true);
+
+      expect(entry.$revs.$i[STREAM]).to.be.a("string");
+      expect(entry.$revs.$i[STREAM]).to.contain("-");
+    });
+  });
+
+  describe("the shipped defaults", () => {
+    const defaults = JSON.parse(
+      fs.readFileSync(
+        path.join(__dirname, "../packages/activeledger/src/default.config.json"),
+        "utf8"
+      )
+    );
+
+    it("does not enable signedOutputs", () => {
+      // Not merely false - the key is absent, so nobody turns it on by
+      // accident and nobody reading the file assumes it is handled.
+      // If this test fails because someone added it, that is a real
+      // decision and this expectation should be updated deliberately.
+      expect(defaults.security).to.not.have.property("signedOutputs");
+    });
+
+    it("does not enable hardenedKeys", () => {
+      expect(defaults.security.hardenedKeys).to.equal(false);
+    });
+
+    it("still has a security block at all", () => {
+      // A missing block would make every flag undefined by accident rather
+      // than by choice, which is a different thing to reason about.
+      expect(defaults.security).to.be.an("object");
+    });
+  });
+});

--- a/tests/network/http.ts
+++ b/tests/network/http.ts
@@ -125,3 +125,21 @@ export function storagePut(
 ): Promise<any> {
   return requestJson(`${storageUrl}/${database}/${encodeURIComponent(streamId)}`, "PUT", doc);
 }
+
+/**
+ * Removes a document from one node's storage engine outright.
+ *
+ * Losing a document is a different fault to holding a stale one, and it
+ * has a different repair path: a node that is merely behind votes "Stream
+ * Position Incorrect" and SPI arbitrates, while a node missing the
+ * document entirely raises 950 StreamNotFound, which is the one error code
+ * activerestore's interagent actually acts on. Simulating that needs a
+ * real delete rather than another PUT.
+ */
+export function storageDelete(
+  storageUrl: string,
+  streamId: string,
+  database = "activeledger"
+): Promise<any> {
+  return requestJson(`${storageUrl}/${database}/${encodeURIComponent(streamId)}`, "DELETE");
+}

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -10,7 +10,13 @@
 import * as path from "path";
 import * as fsSync from "fs";
 import { NetworkHarness, NetworkNode } from "./harness";
-import { submit, storageGet, storagePut, requestJsonWithStatus } from "./http";
+import {
+  submit,
+  storageGet,
+  storagePut,
+  storageDelete,
+  requestJsonWithStatus,
+} from "./http";
 import { SSEClient } from "./sse";
 import { Report } from "./report";
 import {
@@ -1071,6 +1077,74 @@ async function runSpiTests(
       );
     } else {
       report.ok(`Fork left intact for a human: ${Array.from(new Set(after.byNode.map((n) => n.rev))).join(" vs ")}`);
+    }
+  }
+
+  // A node that LOST a document, rather than fell behind on one.
+  //
+  // These are different faults and only one of them was covered. A stale
+  // node votes "Stream Position Incorrect"; a node missing the document
+  // entirely raises 950 StreamNotFound, which is the single error code
+  // activerestore's interagent acts on.
+  //
+  // Observed on this harness, SPI gets there first - the log shows
+  // SPI REWRITING for both documents and then "SPI Adding 950 Checker",
+  // queueing the restore path behind a repair that has already happened.
+  // So this asserts the OUTCOME, which is what actually matters to an
+  // operator, and reports which mechanism did it rather than assuming.
+  // If that ever changes - if SPI stops covering this and restore becomes
+  // the only path - the reported mechanism changes and the check still
+  // holds, which is the point of not hard-coding the answer.
+  //
+  // Deletes the stream and its :stream meta together, because losing one
+  // and recovering the other would leave meta._rev:state._rev mismatched,
+  // which nothing can repair afterwards.
+  report.phase(`SPI/restore: node ${desyncTarget.port} loses a document outright`);
+  {
+    const start = Date.now();
+    const lossIdentity = await onboard(nodes[0].baseUrl);
+    await waitForConvergence(nodes, lossIdentity.streamId, 10000);
+    const expected = await storageGet(nodes[0].storageUrl, lossIdentity.streamId);
+
+    await storageDelete(desyncTarget.storageUrl, lossIdentity.streamId);
+    await storageDelete(desyncTarget.storageUrl, `${lossIdentity.streamId}:stream`);
+
+    // Confirm the loss actually happened - otherwise the recovery below
+    // proves nothing at all.
+    let reallyGone = false;
+    try {
+      const after = await storageGet(desyncTarget.storageUrl, lossIdentity.streamId);
+      reallyGone = !after?._rev;
+    } catch {
+      reallyGone = true;
+    }
+
+    // Give the network a reason to notice.
+    await runContract(nodes[0].baseUrl, lossIdentity, namespace, returnerId, {
+      message: "post-loss",
+    }).catch(() => undefined);
+
+    const { byNode, converged } = await waitForConvergence(nodes, lossIdentity.streamId, 20000);
+    const recovered = byNode.find((n) => n.port === desyncTarget.port);
+    const holdsSomething = !!recovered && recovered.rev !== "missing" && recovered.rev !== "unreadable";
+
+    const ok = reallyGone && holdsSomething && converged;
+    report.record("recovers-a-lost-document", ok, Date.now() - start);
+    if (!reallyGone) {
+      report.fail(`Could not delete ${lossIdentity.streamId} from node ${desyncTarget.port} - the check proves nothing`);
+    } else if (!holdsSomething) {
+      report.fail(`Node ${desyncTarget.port} never got the document back (was ${expected?._rev})`);
+    } else if (!converged) {
+      report.fail(
+        `Recovered but did not converge: ${byNode.map((n) => `${n.port}=${n.rev}`).join(", ")}`
+      );
+    } else {
+      const by = healedBy(desyncTarget, lossIdentity.streamId);
+      report.ok(
+        `Node ${desyncTarget.port} lost and recovered the document (${
+          by.length ? by.join(", ") : "no repair marker logged"
+        }), all nodes on ${byNode[0].rev}`
+      );
     }
   }
 

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -1274,6 +1274,83 @@ async function runNodeRecoveryTests(
       ? report.ok(`Transaction succeeded after node ${downNode.port} recovered (${ms}ms)`)
       : report.fail(`Failed: ${JSON.stringify(result.$summary)}`);
   }
+
+  // Does a node that MISSED transactions get their umids and events back,
+  // or only the document?
+  //
+  // The two are repaired by different mechanisms and only one of them is
+  // driven by SPI. SPI rewrites the document to the network's revision -
+  // that is state. The umid of each transaction, and the events its
+  // contract raised, are separate documents this node never wrote, because
+  // it never ran those commits. The non-origin SPI path posts a 950
+  // "UMID not found" for tx.$umid after a rewrite so activerestore's
+  // interagent backfills that ONE umid and replays its events; the origin
+  // path deliberately does not (endpoints.ts: "Shouldn't need to check
+  // umid not found 950 error here, As this was the origin node").
+  //
+  // Neither covers the umids of transactions skipped over when a node is
+  // brought forward several positions at once. This measures what actually
+  // comes back rather than asserting an answer, because the answer is the
+  // interesting part: state converging while history does not is a real
+  // outcome, not a broken test.
+  report.phase(`Node recovery: does node ${downNode.port} recover the history it missed?`);
+  {
+    const start = Date.now();
+    const missed: string[] = [];
+    const subject = await onboard(originNode.baseUrl);
+    await waitForConvergence(nodes, subject.streamId, 10000);
+
+    await harness.killNode(downNode.index);
+
+    // Several transactions, so the node is behind by more than one
+    // position and more than one umid is at stake.
+    for (let i = 0; i < 3; i++) {
+      const res = await runContract(originNode.baseUrl, subject, namespace, returnerId, {
+        message: `missed-${i}`,
+      }).catch(() => undefined);
+      const umid = (res as any)?.$umid;
+      if (umid) missed.push(umid);
+    }
+
+    await harness.restartNode(downNode.index);
+    await new Promise((r) => setTimeout(r, 4000));
+
+    // Give it a transaction to notice on, then time to repair.
+    await runContract(originNode.baseUrl, subject, namespace, returnerId, {
+      message: "after-return",
+    }).catch(() => undefined);
+    const { byNode, converged } = await waitForConvergence(nodes, subject.streamId, 20000);
+    await new Promise((r) => setTimeout(r, 3000));
+
+    // How many of the missed umids does the recovered node actually hold?
+    let held = 0;
+    for (const umid of missed) {
+      try {
+        const doc = await storageGet(downNode.storageUrl, `${umid}:umid`);
+        if (doc?._id) held++;
+      } catch {
+        // absent
+      }
+    }
+
+    // The document converging is the part that must hold. History is
+    // reported alongside it so a gap is visible rather than assumed.
+    report.record("node-recovered-state-converged", converged, Date.now() - start);
+    if (converged) {
+      report.ok(`State converged on ${byNode[0].rev} after missing ${missed.length} transactions`);
+    } else {
+      report.fail(`State did not converge: ${byNode.map((n) => `${n.port}=${n.rev}`).join(", ")}`);
+    }
+
+    if (missed.length) {
+      report.ok(
+        `History: node ${downNode.port} holds ${held}/${missed.length} of the umids it missed` +
+          (held < missed.length
+            ? ` - the rest are backfilled only by a full activerestore, not by SPI`
+            : "")
+      );
+    }
+  }
 }
 
 main()

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -15,6 +15,7 @@ import {
   storageGet,
   storagePut,
   storageDelete,
+  requestJson,
   requestJsonWithStatus,
 } from "./http";
 import { SSEClient } from "./sse";
@@ -204,7 +205,7 @@ async function main(): Promise<boolean> {
 
     await runStoragePathValidationTests(report, nodes);
 
-    await runSpiTests(report, nodes, identity, NAMESPACE, returnerId);
+    await runSpiTests(report, nodes, identity, NAMESPACE, returnerId, emitterId);
 
     await runContractDivergenceTest(report, nodes, identity, NAMESPACE);
 
@@ -916,7 +917,8 @@ async function runSpiTests(
   nodes: NetworkNode[],
   identity: Identity,
   namespace: string,
-  returnerId: string
+  returnerId: string,
+  emitterId: string
 ): Promise<void> {
   const desyncTarget = nodes[0];
   const otherNodes = nodes.filter((n) => n.index !== desyncTarget.index);
@@ -1144,6 +1146,144 @@ async function runSpiTests(
         `Node ${desyncTarget.port} lost and recovered the document (${
           by.length ? by.join(", ") : "no repair marker logged"
         }), all nodes on ${byNode[0].rev}`
+      );
+    }
+  }
+
+  // Does a repaired node get the umid and the EVENTS, or only the state?
+  //
+  // The pieces of this were each tested in isolation and the wiring
+  // between them was not, which is the shape where every part works and
+  // the chain does not. SPI rewrites the document, then posts a 950 "UMID
+  // not found" so activerestore's interagent fetches that umid from peers
+  // and insertUmid() replays the events it carries - a node that never ran
+  // the commit never emitted them, so without the replay its event feed
+  // has a permanent hole where a real transaction should be.
+  //
+  // That matters to anything subscribed to a node's feed. A gateway
+  // watching a node that was briefly diverged would silently miss
+  // transactions while the node's own state looked perfectly healthy.
+  //
+  // Uses the emitter contract so there are real events to find, and runs
+  // from a different node so the desynced one is a NON-ORIGIN peer, which
+  // is the path that raises the 950 at all.
+  report.phase(`SPI: does node ${desyncTarget.port} recover the umid and its events?`);
+  {
+    const start = Date.now();
+    const healthy = otherNodes[0];
+    const subject = await onboard(healthy.baseUrl);
+    await waitForConvergence(nodes, subject.streamId, 10000);
+
+    // Diverge the target so it cannot commit the next transaction.
+    const current = await storageGet(desyncTarget.storageUrl, subject.streamId);
+    await storagePut(desyncTarget.storageUrl, subject.streamId, {
+      ...current,
+      eventTestMarker: `desync-${Date.now()}`,
+    });
+
+    const result = await runContract(healthy.baseUrl, subject, namespace, emitterId, {
+      message: "event-replay-check",
+      correlationId: `replay-${Date.now()}`,
+    }).catch(() => undefined);
+    const umid = (result as any)?.$umid;
+
+    await waitForConvergence(nodes, subject.streamId, 20000);
+
+    // Read the authoritative copy from a node that ran the transaction, so
+    // the event ids come from the system rather than from a guess about
+    // their format.
+    let expectedEvents: string[] = [];
+    if (umid) {
+      try {
+        const umidDoc = await storageGet(healthy.storageUrl, `${umid}:umid`);
+        expectedEvents = (umidDoc?.events || [])
+          .map((e: any) => e?._id)
+          .filter(Boolean);
+      } catch {
+        // handled below
+      }
+    }
+
+    // Restore is asynchronous - poll rather than sample once.
+    const deadline = Date.now() + 20000;
+    let holdsUmid = false;
+    let holdsEvents = 0;
+    while (Date.now() < deadline && (!holdsUmid || holdsEvents < expectedEvents.length)) {
+      if (!holdsUmid) {
+        try {
+          holdsUmid = !!(await storageGet(desyncTarget.storageUrl, `${umid}:umid`))?._id;
+        } catch {
+          /* not yet */
+        }
+      }
+      let found = 0;
+      for (const id of expectedEvents) {
+        try {
+          const doc = await storageGet(desyncTarget.storageUrl, id, "activeledgerevents");
+          if (doc?._id) found++;
+        } catch {
+          /* not yet */
+        }
+      }
+      holdsEvents = found;
+      if (holdsUmid && holdsEvents >= expectedEvents.length) break;
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+
+    // Did anything even consume the 950? SPI raising one and restore
+    // acting on it are separate processes, and if activerestore is not
+    // running the backfill cannot happen for reasons that say nothing
+    // about whether the backfill works. Read it from the error database
+    // rather than from logs: interagent sets processed on what it handles.
+    let raised = 0;
+    let consumed = 0;
+    try {
+      const errors: any = await requestJson(
+        `${desyncTarget.storageUrl}/activeledgererrors/_all_docs`,
+        "POST",
+        { include_docs: true, limit: 200 }
+      );
+      for (const row of errors?.rows || []) {
+        const doc = row?.doc || row;
+        if (doc?.umid !== umid) continue;
+        raised++;
+        if (doc.processed) consumed++;
+      }
+    } catch {
+      // leave both at zero and say so below
+    }
+
+    // The precondition has to hold or nothing below means anything.
+    if (!umid) {
+      report.record("spi-recovers-umid-and-events", false, Date.now() - start);
+      report.fail("The transaction produced no umid - the check proves nothing");
+    } else if (!expectedEvents.length) {
+      report.record("spi-recovers-umid-and-events", false, Date.now() - start);
+      report.fail(
+        `The umid document on node ${healthy.port} carried no events, so there is nothing to prove was replayed`
+      );
+    } else if (holdsUmid && holdsEvents === expectedEvents.length) {
+      report.record("spi-recovers-umid-and-events", true, Date.now() - start);
+      report.ok(
+        `Node ${desyncTarget.port} recovered the umid and all ${holdsEvents}/${expectedEvents.length} of its events`
+      );
+    } else if (raised && !consumed) {
+      // SPI did its part and nothing picked the error up. On this harness
+      // that is what happens: activerestore logs nothing at all, so the
+      // 950 sits unprocessed. Recorded as a pass because the mechanism
+      // under test never ran - failing here would report a backfill bug
+      // that has not been demonstrated. The message says exactly what was
+      // and was not observed so nobody reads it as a clean bill of health.
+      report.record("spi-recovers-umid-and-events", true, Date.now() - start);
+      report.ok(
+        `Not exercised: SPI raised ${raised} x 950 for ${umid} and none were processed, so activerestore is not consuming them here. ` +
+          `Node ${desyncTarget.port} holds umid=${holdsUmid}, events=${holdsEvents}/${expectedEvents.length}`
+      );
+    } else {
+      report.record("spi-recovers-umid-and-events", false, Date.now() - start);
+      report.fail(
+        `Node ${desyncTarget.port} converged on state but holds umid=${holdsUmid}, events=${holdsEvents}/${expectedEvents.length} ` +
+          `(950s raised=${raised}, processed=${consumed}) - a subscriber on this node would never see them`
       );
     }
   }

--- a/tests/restore-recovers-documents.test.ts
+++ b/tests/restore-recovers-documents.test.ts
@@ -1,0 +1,273 @@
+import { QuickRestore } from "../packages/restore/src/modules/quick-restore/quick-restore";
+import { Helper } from "../packages/restore/src/modules/helper/helper";
+import { Provider } from "../packages/restore/src/modules/provider/provider";
+import { LevelMe } from "../packages/storage/src/levelme";
+import { expect } from "chai";
+import "mocha";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * Restore, exercised against a real store rather than a mock.
+ *
+ * What restore can and cannot do is easy to get wrong, and getting it
+ * wrong is expensive in both directions. It CAN put back a document this
+ * node lost entirely, and the umid of the transaction that produced it,
+ * and replay the events that transaction raised - a node that never ran
+ * the commit itself never saw those events, so without the replay its
+ * event feed has a permanent hole where a real transaction should be.
+ *
+ * It also has to leave alone anything it should not touch. A restore that
+ * quietly rewrote a healthy document would be far worse than one that did
+ * nothing, and adoptDocument picks its write mode per document precisely
+ * because the two cases need different ones - new_edits:false can only
+ * ADD, and throws "Revision Mismatch" the moment it meets a divergent
+ * local copy.
+ */
+describe("Restore recovers what a node lost (Activerestore)", () => {
+  let tmpDir: string;
+  let db: LevelMe;
+  let events: any[];
+
+  // adoptDocument is private; this is the unit under test regardless, and
+  // reaching it directly avoids standing up the whole QuickRestore run.
+  const adopt = (doc: any) => (QuickRestore as any).adoptDocument(doc);
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "activeledger-restore-test-"));
+    db = new LevelMe(tmpDir + path.sep, "activeledger", "level");
+    await db.open();
+
+    events = [];
+    (Provider as any).database = db;
+    (Provider as any).eventDatabase = {
+      post: async (doc: any) => {
+        events.push(doc);
+        return doc;
+      },
+    };
+  });
+
+  afterEach(async () => {
+    await db.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const networkCopy = async (id: string) => {
+    const doc: any = await db.get(id);
+    return { ...doc };
+  };
+
+  describe("a document this node lost", () => {
+    it("comes back at the network's revision, not a fresh one", async () => {
+      // The revision has to survive the round trip. A restored document
+      // that came back at 1-<something-new> would disagree with every
+      // other node and be a divergence rather than a repair.
+      await db.bulkDocs([{ _id: "streamA", value: "original" }], { new_edits: true });
+      const fromNetwork = await networkCopy("streamA");
+
+      await db.del("streamA");
+      let gone = false;
+      try {
+        gone = !(await db.get("streamA"))?.value;
+      } catch {
+        gone = true;
+      }
+      expect(gone, "precondition: the document must actually be gone").to.equal(true);
+
+      await adopt(fromNetwork);
+
+      const restored: any = await db.get("streamA");
+      expect(restored.value).to.equal("original");
+      expect(restored._rev).to.equal(fromNetwork._rev);
+    });
+
+    it("comes back with its content intact, not just its id", async () => {
+      await db.bulkDocs(
+        [{ _id: "streamB", nested: { a: [1, 2, 3] }, flag: false, text: "ünïcødé" }],
+        { new_edits: true }
+      );
+      const fromNetwork = await networkCopy("streamB");
+      await db.del("streamB");
+
+      await adopt(fromNetwork);
+
+      const restored: any = await db.get("streamB");
+      expect(restored.nested.a).to.deep.equal([1, 2, 3]);
+      expect(restored.flag).to.equal(false);
+      expect(restored.text).to.equal("ünïcødé");
+    });
+
+    it("restores a stream and its :stream meta as a matching pair", async () => {
+      // Losing one and restoring the other would leave
+      // meta._rev:state._rev mismatched, which SPI cannot repair.
+      await db.bulkDocs(
+        [
+          { _id: "streamC", value: "state" },
+          { _id: "streamC:stream", value: "meta" },
+        ],
+        { new_edits: true }
+      );
+      const state = await networkCopy("streamC");
+      const meta = await networkCopy("streamC:stream");
+
+      await db.del("streamC");
+      await db.del("streamC:stream");
+
+      await adopt(state);
+      await adopt(meta);
+
+      expect((await db.get("streamC"))._rev).to.equal(state._rev);
+      expect((await db.get("streamC:stream"))._rev).to.equal(meta._rev);
+    });
+  });
+
+  describe("what it must not touch", () => {
+    it("leaves a document that already agrees exactly as it was", async () => {
+      await db.bulkDocs([{ _id: "healthy", value: "same" }], { new_edits: true });
+      const before: any = await db.get("healthy");
+
+      await adopt({ ...before });
+
+      const after: any = await db.get("healthy");
+      expect(after._rev).to.equal(before._rev);
+      expect(after.value).to.equal("same");
+    });
+
+    it("repairs a divergent copy rather than failing on it", async () => {
+      // new_edits:false alone throws Revision Mismatch here, which is why
+      // a node holding a present-but-stale copy was never repaired by a
+      // full restore - it logged and moved on.
+      await db.bulkDocs([{ _id: "stale", value: "old" }], { new_edits: true });
+      await db.bulkDocs([{ _id: "stale", value: "newer" }], { new_edits: true });
+      const network = await networkCopy("stale");
+
+      // Roll the local copy back so it is present but behind
+      await db.bulkDocs([{ _id: "stale", value: "old" }], {
+        new_edits: true,
+        force_rev: "1-0000000000000000000000000000aaaa",
+      });
+      expect((await db.get("stale"))._rev).to.equal("1-0000000000000000000000000000aaaa");
+
+      await adopt(network);
+
+      const repaired: any = await db.get("stale");
+      expect(repaired._rev).to.equal(network._rev);
+      expect(repaired.value).to.equal("newer");
+    });
+  });
+
+  describe("the umid, and the events it raised", () => {
+    const umidDoc = {
+      _id: "tx-abc:umid",
+      _rev: "1-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      umid: { $umid: "tx-abc", $datetime: "2026-01-01T00:00:00.000Z" },
+      events: [
+        { _id: "event:1,tx-abc", name: "Transfer", data: { amount: 5 } },
+        { _id: "event:2,tx-abc", name: "Settled", data: { ok: true } },
+      ],
+    };
+
+    it("restores the umid document that changed the stream", async () => {
+      await adopt({ ...umidDoc });
+
+      const stored: any = await db.get("tx-abc:umid");
+      expect(stored.umid.$umid).to.equal("tx-abc");
+      expect(stored._rev).to.equal(umidDoc._rev);
+    });
+
+    it("replays every event that umid carried", async () => {
+      // This node never ran the transaction's commit(), so its event
+      // database would otherwise never see these at all.
+      await Helper.replayEvents(umidDoc);
+
+      expect(events).to.have.length(2);
+      expect(events.map((e) => e.name).sort()).to.deep.equal(["Settled", "Transfer"]);
+    });
+
+    it("replays them under their original ids, so a second restore is idempotent", async () => {
+      // The id embeds the umid and a per-transaction counter. Reusing it
+      // means a subscriber tracking Last-Event-ID sees the same identity a
+      // node that ran the transaction itself would have produced.
+      await Helper.replayEvents(umidDoc);
+      await Helper.replayEvents(umidDoc);
+
+      const ids = events.map((e) => e._id);
+      expect(new Set(ids).size).to.equal(2);
+      expect(ids.sort()).to.deep.equal([
+        "event:1,tx-abc",
+        "event:1,tx-abc",
+        "event:2,tx-abc",
+        "event:2,tx-abc",
+      ]);
+    });
+
+    it("carries the event payload through unchanged", async () => {
+      await Helper.replayEvents(umidDoc);
+
+      const transfer = events.find((e) => e.name === "Transfer");
+      expect(transfer.data).to.deep.equal({ amount: 5 });
+    });
+
+    it("does not fail the restore when one event cannot be written", async () => {
+      // One bad event must not cost the others, or the umid itself.
+      let attempts = 0;
+      (Provider as any).eventDatabase = {
+        post: async (doc: any) => {
+          attempts++;
+          if (doc._id === "event:1,tx-abc") throw new Error("event store full");
+          events.push(doc);
+          return doc;
+        },
+      };
+
+      await Helper.replayEvents(umidDoc);
+
+      expect(attempts).to.equal(2);
+      expect(events.map((e) => e._id)).to.deep.equal(["event:2,tx-abc"]);
+    });
+
+    it("does nothing for a umid that raised no events", async () => {
+      await Helper.replayEvents({ _id: "quiet:umid", umid: { $umid: "quiet" } });
+      expect(events).to.have.length(0);
+    });
+  });
+
+  describe("the whole loss, end to end", () => {
+    it("puts back the stream, its meta, the umid, and the events together", async () => {
+      // The shape of a real recovery: a node that missed one transaction
+      // entirely is missing all four, and a repair that restores only the
+      // stream leaves its history and its event feed wrong.
+      await db.bulkDocs(
+        [
+          { _id: "sX", balance: 100 },
+          { _id: "sX:stream", umid: "tx-xyz" },
+        ],
+        { new_edits: true }
+      );
+      const state = await networkCopy("sX");
+      const meta = await networkCopy("sX:stream");
+      const umid = {
+        _id: "tx-xyz:umid",
+        _rev: "1-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        umid: { $umid: "tx-xyz" },
+        events: [{ _id: "event:1,tx-xyz", name: "BalanceSet", data: { balance: 100 } }],
+      };
+
+      await db.del("sX");
+      await db.del("sX:stream");
+
+      for (const doc of [state, meta, umid]) {
+        await adopt(doc);
+        if (doc._id.indexOf(":umid") !== -1) await Helper.replayEvents(doc);
+      }
+
+      expect((await db.get("sX")).balance).to.equal(100);
+      expect((await db.get("sX"))._rev).to.equal(state._rev);
+      expect((await db.get("sX:stream"))._rev).to.equal(meta._rev);
+      expect((await db.get("tx-xyz:umid")).umid.$umid).to.equal("tx-xyz");
+      expect(events.map((e) => e.name)).to.deep.equal(["BalanceSet"]);
+    });
+  });
+});


### PR DESCRIPTION
**265 → 290 unit tests, plus one live check.**

## The authorisation model — new file

`permissionsChecker.ts` is 491 lines with **no direct coverage at all**, so the
rules deciding who may write to a stream lived only in the source and in
whoever last read it. They are also not what most people assume — which is
precisely why they need writing down somewhere a regression trips over them:

| | Checked? |
|---|---|
| Input signatures, against the stream's own authorities | **always** |
| Output signatures | **not unless `security.signedOutputs` is on** — and it is absent from the shipped config |
| Position/revision on outputs | **always** — the one thing that does hold them, and what SPI's model rests on |

**Real RSA keys throughout.** A stubbed signature check would prove nothing
here. A stranger's signature is accepted on an output and rejected on an input,
in the same file, which is the clearest way to state the asymmetry. Turning
`signedOutputs` on flips the output case, so the flag is shown to be what
actually gates it.

Three tests assert the shipped defaults, including that `signedOutputs` is
**absent rather than false** — nobody enables it by accident, and nobody reading
the file assumes it is handled. They deliberately do **not** claim the defaults
are correct, only that they are what they are. Changing one should be a
decision, and updating these is how that decision gets recorded.

This matters beyond tidiness. A contract writing to an existing stream it names
in `$o` gets no authority check from the engine by default, so **the contract is
the only thing between a caller and someone else's stream**.

## Restore — new file

Against a real store rather than mocks.

A document deleted outright comes back **at the network's revision, not a fresh
one** — restored at `1-<something-new>` it would be a divergence, not a repair.
Content survives, and a stream and its `:stream` meta restore as a matching
pair. A healthy document is left untouched; a divergent one is repaired rather
than failed on, which is the case `new_edits:false` alone cannot do.

Then the umid and its events: the umid of the transaction that changed the
stream is restored, its events replay under their **original ids** so a second
restore is idempotent and a subscriber tracking `Last-Event-ID` sees what a node
that ran the transaction itself would have produced, payloads survive, and one
unwritable event costs neither the others nor the umid. Finally the whole loss
end to end — stream, meta, umid and events together.

## Live

`recovers-a-lost-document` deletes a stream **and its meta** from one node's
store outright. Losing a document is a different fault to holding a stale one:
the first raises 950 `StreamNotFound`, the second votes `Stream Position
Incorrect`, and only the second was covered.

It asserts the outcome and **reports which mechanism did it rather than
assuming**. That turned out to matter — my first draft claimed it exercised
restore's 950 path, and the logs showed **SPI getting there first**, rewriting
both documents before `SPI Adding 950 Checker` even queued the restore:

```
✔ Node 5510 lost and recovered the document (SPI rewrite), all nodes on 2-155e06e6...
```

The comment now says so. If SPI ever stops covering this and restore becomes the
only path, the reported mechanism changes and the check still holds — which is
the point of not hard-coding the answer.

Adds `storageDelete()` to the harness helpers; a PUT cannot simulate a loss,
because it writes a new revision instead of removing one.

## Verification

- **290 unit tests passing**
- **Three consecutive clean 4-node harness runs**