### PR TITLE
fix: a node on a non-default port had its restore engine disabled

### DIFF
--- a/packages/activeledger/src/cli/cli.ts
+++ b/packages/activeledger/src/cli/cli.ts
@@ -672,7 +672,37 @@ export class CLIHandler {
           parseInt(ActiveOptions.get<string>("port", 5260)) - 1
         ).toString();
 
-        // Disable auto starts as they have their own port settings
+        // activecore genuinely does have its own port setting, and it
+        // would collide with a node that has moved off the default, so it
+        // stays disabled here.
+        //
+        // activerestore does NOT. It binds no port and reads no port
+        // config - it reads config.json from its working directory and
+        // talks to this node's own storage. It was swept in alongside
+        // activecore to stop --testnet's generated instances each running
+        // a restore engine, which was a real performance concern on one
+        // machine, but the cost landed somewhere else entirely: ANY node
+        // set up on a non-default port had its restore engine silently
+        // disabled, which is most real deployments.
+        //
+        // What that costs is not obvious, because SPI still converges
+        // state and the node looks healthy. The 950 "UMID not found"
+        // documents SPI raises after a repair are never consumed, so
+        // missing umids are never backfilled, the events those
+        // transactions raised never replay, and activeledgererrors grows
+        // with nothing reading it. A node that was ever behind keeps a
+        // permanent hole in its event feed.
+        //
+        // The testnet case is now handled where it belongs, by testnet
+        // passing --disable-autostart explicitly, rather than inferred from a
+        // port number that cannot tell the two situations apart.
+        defConfig.autostart.core = false;
+      }
+
+      // An explicit opt out, for a generator standing up many instances on
+      // one machine that does not want a full set of background processes
+      // per node.
+      if (ActiveOptions.get<boolean>("disable-autostart", false)) {
         defConfig.autostart.core = false;
         defConfig.autostart.restore = false;
       }

--- a/packages/activeledger/src/cli/testnet.ts
+++ b/packages/activeledger/src/cli/testnet.ts
@@ -55,6 +55,13 @@ export class TestnetHandler {
             `--port ${5250 + (i + 1) * 10}`,
             `--data-dir .ds`,
             `--setup-only`,
+            // A testnet is many nodes on one machine, and a restore engine
+            // per instance is real load for no benefit locally. Said
+            // explicitly here rather than inferred from the port, which
+            // could not tell a testnet instance apart from a production
+            // node that had simply moved off 5260 - and so disabled restore
+            // on both.
+            `--disable-autostart`,
           ];
 
           // Push to Merge


### PR DESCRIPTION
Setup disabled **both** autostarts whenever a port was given that wasn't 5260:

```js
// Disable auto starts as they have their own port settings
defConfig.autostart.core = false;
defConfig.autostart.restore = false;
```

That is right for `activecore`, which really does have its own port and would
collide. It is **not** true of `activerestore` — it binds no port, reads no port
config, and takes its settings from `config.json` in its working directory.
Started by hand in a node directory on port 5610 it comes straight up:

```
Interagent Started
Interagent Starting Error Checker
```

The intent was to stop `--testnet`'s generated instances each running a restore
engine, which is a real cost with all of them on one machine. The cost landed
somewhere else: **any node set up on a non-default port — most real deployments —
had its restore engine silently disabled.**

A port number cannot tell a testnet instance apart from a production node that
moved off 5260, so the disable now lives where the intent does: testnet passes
`--disable-autostart` explicitly.

> Not `--no-autostart`: minimist reads `--no-x` as `x=false`, so that name
> silently set `autostart` false rather than the flag. Caught because the
> generated config still said `restore:true` when it shouldn't have.

## Why it matters, and why it went unnoticed

SPI still converges state, so the node looks healthy. But the 950 "UMID not
found" documents SPI raises after a repair are never consumed — missing umids
are never backfilled, the events those transactions raised never replay, and
`activeledgererrors` grows with nothing reading it. **A node that was ever
behind keeps a permanent hole in its event feed while its state is perfectly
correct.**

## Verified

| Setup | Result |
|---|---|
| `--port 5640` | `{"core":false,"restore":true}` |
| `--port 5650 --disable-autostart` | `{"core":false,"restore":false}` |
| no port at all | `{"core":false,"restore":true}` |

## Not verified end to end — worth stating

The network harness spawns node directly rather than through npm, so
`activerestore` isn't on `PATH` there and the child spawn can't succeed
regardless of this flag. **The config is now right; whether the spawn then works
is exercised by a real install, not by this suite.**

## Field check

This was confirmed on a live deployment — all four nodes reported
`{"core": false, "restore": false}` on port 5261, exactly as predicted.

But that deployment runs **dedicated restore containers** that start
`activerestore` explicitly, independent of the node's autostart flag, so restore
was working there and there was no error backlog (`activeledgererrors` total=0).
My prediction of a growing queue was wrong for that setup, and their multi-day
gap had a different cause entirely — the restore containers crashed on a
`config.json` startup race and didn't recover until a manual restart.

So this is a correctness fix and defence in depth, **not** a fix for an active
outage anywhere known. Worth being clear about that.