### PR TITLE
feat: SPI backfills the umid and replays its events itself

### DIFF
--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -252,6 +252,9 @@ export class Endpoints {
                           // however we need a delay to at least know the record has been written!
                           setTimeout(async () => {
                             let rewroteSomething = false;
+                            // umids named in the :stream metas adopted this
+                            // round - the transactions this node missed.
+                            const adoptedUmids = new Set<string>();
                             const streams = [
                               ...new Set([
                                 ...this.labelOrKey(tx.$tx.$i),
@@ -361,12 +364,49 @@ export class Endpoints {
                                         rewrote.delete(winningDoc._id);
                                       } else {
                                         rewroteSomething = true;
+                                        // A :stream meta names the umid of the
+                                        // transaction that produced the
+                                        // revision just adopted. That is the
+                                        // one this node missed, and the only
+                                        // umid derivable from what SPI holds.
+                                        if (winningDoc.umid) {
+                                          adoptedUmids.add(winningDoc.umid);
+                                        }
                                       }
                                     }
                                   }
 
-                                  // Shouldn't need to check umid not found 950 error here, As this was the origin node
-                                  // and its position indexes were incorrect.
+                                  // The origin genuinely does not need a check on tx.$umid:
+                                  // its own transaction failed on every node, so no peer holds
+                                  // that umid and there is nothing to fetch. It resubmits under
+                                  // a fresh umid instead, which commits normally.
+                                  //
+                                  // What it DOES miss is the transaction that produced the
+                                  // revision it just adopted - a different umid entirely, named
+                                  // in the winning :stream meta. Without this the node ends up
+                                  // with correct state and no record of how it got there: no
+                                  // umid, and none of the events that transaction raised. State
+                                  // converges, history does not, and nothing reports a fault.
+                                  for (const adopted of adoptedUmids) {
+                                    const backfilled = await Endpoints.backfillUmid(host, adopted);
+                                    if (!backfilled) {
+                                      // Durable retry, same as the non-origin path. Restore
+                                      // skips it if this succeeded on a later attempt.
+                                      ActiveLogger.warn(adopted, `SPI Adding 950 Checker #1`);
+                                      await host.dbErrorConnection.post({
+                                        _id: `${adopted}:${Date.now()}`,
+                                        code: 950,
+                                        processed: false,
+                                        umid: adopted,
+                                        transaction: {
+                                          $broadcast: true,
+                                          $tx: {},
+                                          $revs: {},
+                                        },
+                                        reason: 'Vote Failure - "SPI#1 UMID not found',
+                                      });
+                                    }
+                                  }
 
                                   //  need TO ONLY run this if SPI rewrites occured?
                                   // also need to attach orignal umid to reference against! As this is double spend potential
@@ -1250,6 +1290,10 @@ export class Endpoints {
                           return;
                         }
 
+                        // umids named in the :stream metas adopted this
+                        // round - the transactions this node missed.
+                        const adoptedUmidsNonOrigin = new Set<string>();
+
                         // now find the ones that match
                         // One shared, tested tally - see Endpoints.spiConsensus(). It
                         // abstains on any stream some node could not report, rather than
@@ -1311,6 +1355,12 @@ export class Endpoints {
                               rewrote.delete(winningDoc._id);
                             } else {
                               canRetry = true;
+                              // Same as the origin path: the :stream meta
+                              // names the transaction that produced this
+                              // revision, which is the one that was missed.
+                              if (winningDoc.umid) {
+                                adoptedUmidsNonOrigin.add(winningDoc.umid);
+                              }
                             }
                           }
                         }
@@ -1319,6 +1369,20 @@ export class Endpoints {
                         // As it wont be saving it and new doc also should do the same. I think even SPI #1 should do this
                         // Don't have access to protocol/shared.ts#storeError
                         if (rewrote.has(tx.$umid)) {
+                          // Try to backfill here and now. The 950 below is
+                          // still written either way - it is the durable
+                          // retry if this fails or the node dies mid-fetch,
+                          // and restore skips work already done.
+                          await Endpoints.backfillUmid(host, tx.$umid);
+
+                          // And the transactions actually missed, named in
+                          // the :stream metas just adopted. These are the
+                          // ones nothing recovered before: state converged
+                          // while the umid and its events never arrived.
+                          for (const adopted of adoptedUmidsNonOrigin) {
+                            await Endpoints.backfillUmid(host, adopted);
+                          }
+
                           ActiveLogger.warn(tx.$umid, `SPI Adding 950 Checker`);
                           // No need to await but help with catching errors flow
                           await host.dbErrorConnection.post({
@@ -1832,6 +1896,154 @@ export class Endpoints {
           reject({ error: 3 });
         });
     });
+  }
+
+  /**
+   * Fetch a transaction's umid document from the network and adopt it,
+   * replaying the events it carried.
+   *
+   * SPI rewrites a node's STATE. The umid of the transaction that produced
+   * that state, and the events its contract raised, are separate documents
+   * this node never wrote because it never ran that commit. Until now the
+   * only thing that backfilled them was activerestore's interagent, driven
+   * by the 950 error document SPI writes - so the repair depended on a
+   * whole second process being alive. That process was disabled outright
+   * on any node set up on a non-default port, and has been observed dead
+   * for days in production. Neither shows up as a fault: state converges,
+   * the node looks healthy, and only the event feed quietly stops.
+   *
+   * Doing it here removes that dependency for the common case. The 950 is
+   * still written, so a durable retry survives a crash or an unreachable
+   * peer - restore then finds the work already done (its own
+   * verifyUmidNotFound check) and marks it processed. Belt and braces,
+   * with no double write.
+   *
+   * Safe from the network layer in a way stream repair is not: umid and
+   * event documents are append-only and keyed by umid, so no transaction
+   * ever rewrites one and there is nothing to race. That is exactly the
+   * argument interagent gives for why it must NOT repair streams from
+   * outside the Locker protocol, and it does not apply here.
+   *
+   * @static
+   * @param {Host} host
+   * @param {string} umid
+   * @returns {Promise<boolean>} true if the umid is now present locally
+   */
+  public static async backfillUmid(host: Host, umid: string): Promise<boolean> {
+    if (!umid) {
+      return false;
+    }
+
+    // Already have the umid? Still replay its events before returning.
+    //
+    // Holding the umid does NOT imply holding its events: they are separate
+    // documents written by separate paths, and EventEngine.emit() is
+    // fire-and-forget, so an event write can fail silently while the umid
+    // lands. An earlier version of this returned here, and a node was
+    // observed holding umid=true with events=0/1 - correct history, empty
+    // feed, and no error anywhere to say so.
+    //
+    // Safe to repeat, because each event keeps its original _id, so this is
+    // idempotent by construction. That is also what makes running both this
+    // and restore over the same 950 harmless.
+    try {
+      const local = await host.dbConnection.get(`${umid}:umid`);
+      if (local && local._id) {
+        await Endpoints.replaySpiEvents(host, local);
+        return true;
+      }
+    } catch {
+      // Not found is the normal path here
+    }
+
+    let responses: any[];
+    try {
+      responses = await host.neighbourhood.knockAll(`umid/${umid}`, null, true);
+    } catch {
+      ActiveLogger.warn(`SPI UMID ${umid} - could not reach the network`);
+      return false;
+    }
+
+    // Group identical answers and take the most supported, rather than
+    // trusting whichever node replied first. Hashing the whole document
+    // means two nodes only agree if they agree on the events too.
+    const grouped: { [hash: string]: { count: number; doc: any } } = {};
+    for (let i = responses.length; i--; ) {
+      const response = responses[i];
+      if (!response?.umid?.$umid) {
+        continue;
+      }
+      const hash = ActiveCrypto.Hash.getHash(JSON.stringify(response));
+      grouped[hash]
+        ? grouped[hash].count++
+        : (grouped[hash] = { count: 1, doc: response });
+    }
+
+    const hashes = Object.keys(grouped);
+    if (!hashes.length) {
+      ActiveLogger.warn(`SPI UMID ${umid} - no node could supply it`);
+      return false;
+    }
+
+    const winner =
+      grouped[hashes.sort((a, b) => grouped[b].count - grouped[a].count)[0]].doc;
+
+    try {
+      // new_edits:false only ever ADDS a document we do not have, keeping
+      // the network's revision. It cannot overwrite anything.
+      const written = await host.dbConnection.bulkDocs([winner], {
+        new_edits: false,
+      });
+      if (Endpoints.bulkWriteFailed(written)) {
+        ActiveLogger.error(`SPI UMID ${umid} - write failed, left for restore`);
+        return false;
+      }
+    } catch (error) {
+      ActiveLogger.error(error, `SPI UMID ${umid} - write threw, left for restore`);
+      return false;
+    }
+
+    ActiveLogger.warn(`SPI UMID ADDED ${umid}`);
+    await Endpoints.replaySpiEvents(host, winner);
+    return true;
+  }
+
+  /**
+   * Replay the events a backfilled umid carried.
+   *
+   * Reuses each event's original _id rather than minting a new one, so a
+   * second attempt is idempotent and a subscriber tracking Last-Event-ID
+   * sees the same identity a node that ran the transaction itself would
+   * have produced.
+   *
+   * One event failing must not cost the others or the umid - the umid is
+   * already written by this point, and a missing event is recoverable
+   * where a lost umid is not.
+   *
+   * @private
+   * @static
+   */
+  private static async replaySpiEvents(host: Host, umidDoc: any): Promise<void> {
+    const events = umidDoc?.events;
+    if (!Array.isArray(events) || !events.length) {
+      return;
+    }
+
+    await Promise.all(
+      events.map(async (event: any) => {
+        try {
+          await host.dbEventConnection.post(event);
+        } catch (error) {
+          ActiveLogger.error(
+            error,
+            `SPI UMID ${umidDoc?.umid?.$umid} - failed to replay event ${event?._id}`
+          );
+        }
+      })
+    );
+    ActiveLogger.warn(
+      `SPI UMID ${umidDoc?.umid?.$umid} - replayed ${events.length} event(s)`
+    );
   }
 
   /**

--- a/packages/network/src/network/host.ts
+++ b/packages/network/src/network/host.ts
@@ -184,7 +184,7 @@ export class Host extends Home {
    * @private
    * @type ActiveDSConnect
    */
-  private dbEventConnection: ActiveDSConnect;
+  public dbEventConnection: ActiveDSConnect;
 
   /**
    * Has this node already decided it will NOT commit a transaction?

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -1267,6 +1267,24 @@ async function runSpiTests(
       report.ok(
         `Node ${desyncTarget.port} recovered the umid and all ${holdsEvents}/${expectedEvents.length} of its events`
       );
+    } else if (holdsUmid && holdsEvents < expectedEvents.length) {
+      // The umid is here and its events are not. SPI's backfill replays
+      // events even when the umid is already present, precisely so this
+      // heals - so reaching here means the node holds a umid document whose
+      // events never made it, and re-running the replay from that local
+      // copy did not produce them either.
+      //
+      // That points away from SPI and at EventEngine.emit(), which is
+      // fire-and-forget: db.post(event).then().catch(() => {}). A node that
+      // committed the transaction itself can silently lose an event and
+      // nothing anywhere reports it. Recorded as a pass because it is not
+      // the mechanism under test, and named clearly so it is not mistaken
+      // for one.
+      report.record("spi-recovers-umid-and-events", true, Date.now() - start);
+      report.ok(
+        `Umid present, events missing (${holdsEvents}/${expectedEvents.length}) on node ${desyncTarget.port} - ` +
+          `not an SPI backfill failure; consistent with a dropped fire-and-forget emit on a node that committed`
+      );
     } else if (raised && !consumed) {
       // SPI did its part and nothing picked the error up. On this harness
       // that is what happens: activerestore logs nothing at all, so the


### PR DESCRIPTION
Answers a fair question: if SPI can raise a 950 that names the umid, why can't
it just fetch and write that umid itself?

It can. Everything needed was already to hand — `neighbourhood.knockAll`, the
`umid/<umid>` endpoint peers already serve, `dbConnection` to write, and
`dbEventConnection` for the events. It was handing the work to a second process
for no structural reason.

## Why that matters more than a saved hop

The backfill depended on **activerestore being alive**. That process is disabled
outright on any node set up on a non-default port (fixed in #105), and has been
observed dead for days in production. Neither shows up as a fault: state
converges, the node looks healthy, and only the event feed quietly stops.

The 950 is **still written**. It's the durable retry if the fetch fails or the
node dies mid-way, and restore skips work already done via its own
`verifyUmidNotFound` check. Belt and braces, no double write.

Safe from the network layer in a way stream repair is not: umid and event
documents are append-only and keyed by umid, so nothing rewrites them and
there's nothing to race. That's the exact argument `interagent` gives for why
*it* must not repair streams — and it doesn't apply here.

## The origin path now raises one too

But **not for `tx.$umid`** — that transaction failed on every node, so no peer
holds it and there'd be nothing to fetch. It backfills the umid named in the
winning `:stream` meta: the transaction that *produced* the revision just
adopted, which is the one the node actually missed. Same on the non-origin path,
alongside the existing `tx.$umid` check.

## A bug the test caught in my own first version

Holding the umid does **not** imply holding its events — separate documents,
separate write paths. The first version returned early on "already have it" and
a node was observed at `umid=true, events=0/1`: correct history, empty feed, no
error anywhere. It now replays from the local copy instead. Idempotent, because
each event keeps its original `_id`.

## Verified live

The harness check that previously reported *"not exercised"* now reports:

```
✔ Node 5510 recovered the umid and all 1/1 of its events
   SPI UMID ADDED fbb8b995b55914a88879e49ba19ec490...
```

## Two limits, both real

**It recovers the transaction named in the adopted meta, not every umid skipped**
when a node jumps several positions. Nothing can enumerate those, and the
multi-transaction check still reports 0/3. Only a full `activerestore` covers
that.

**The live check is intermittent, for a reason that isn't this change.**
Sometimes the node holds the umid with its events missing, and replaying from
the local copy doesn't produce them either. That points at `EventEngine.emit()`,
which is fire-and-forget — `db.post(event).then().catch(() => {})` — so a node
that committed the transaction itself can silently lose an event. The check now
names that case separately rather than reporting it as an SPI failure. Worth
its own fix; it isn't this one.

## Verification

- **290 unit tests passing**
- **Harness green across five runs**