### PR TITLE
feat: walk a stream's umid history backwards to recover what was missed

### DIFF
--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -2062,6 +2062,31 @@ export class Endpoints {
   private static readonly UMID_WALK_LIMIT = 100;
 
   /**
+   * Pause between hops, so a walk never competes with live traffic.
+   *
+   * These are old umids. The stream data and the transactions happening now
+   * are what matter, which is why a node fast-forwards to the tip and
+   * repairs its history afterwards - late repair, never no repair. There is
+   * nothing to gain from fetching a hundred of them as fast as the network
+   * will answer.
+   *
+   * Node is single threaded and every hop is I/O, so a walk already yields
+   * constantly and does not hold the CPU away from anything. This is about
+   * the resources it shares regardless of that: the storage engine and the
+   * sockets. Spacing the hops turns a burst into a trickle - a full
+   * hundred-hop walk spreads over about five seconds instead of hammering
+   * for as long as it takes.
+   *
+   * A separate process would not help here. It would not reclaim CPU that
+   * is not being spent, and it would not avoid the shared store or network
+   * either - it would only move which process makes the same calls, while
+   * making repair depend on that process being alive.
+   */
+  // Not readonly so a test can drive a hundred hops without waiting five
+  // real seconds for them. Production never writes to it.
+  public static UMID_WALK_HOP_DELAY_MS = 50;
+
+  /**
    * Recover every umid a stream is missing, by walking its history
    * backwards.
    *
@@ -2155,10 +2180,33 @@ export class Endpoints {
       }
 
       cursor = Endpoints.previousUmidFor(doc, streamId);
+
+      // Deliberately after a successful hop, not before the first one: a
+      // walk with nothing to do costs nothing at all, and the common case
+      // is exactly that.
+      if (cursor) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, Endpoints.UMID_WALK_HOP_DELAY_MS)
+        );
+      }
     }
 
     return { recovered, stoppedAt: "start of stream" };
   }
+
+  /** Walks running right now, so the same one never runs twice at once. */
+  private static historyRepairInFlight = new Set<string>();
+
+  /** When each umid was last checked, so a busy stream stays quiet. */
+  private static historyRepairLastRun = new Map<string, number>();
+
+  /**
+   * How long before the same umid is worth checking again.
+   *
+   * A gap does not heal itself, so skipping only ever delays a repair -
+   * the next commit past the window finds it.
+   */
+  private static readonly HISTORY_REPAIR_COOLDOWN_MS = 30_000;
 
   /**
    * After a commit, check whether this node is missing the history behind
@@ -2183,12 +2231,40 @@ export class Endpoints {
    * @param {Host} host
    * @param {string} umid the transaction just committed here
    */
-  public static repairHistoryAfterCommit(host: Host, umid: string): void {
+  public static repairHistoryAfterCommit(host: Host, umid: string): Promise<void> {
     if (!umid) {
-      return;
+      return Promise.resolve();
     }
 
-    void (async () => {
+    // One at a time, and not on every single commit.
+    //
+    // Two separate problems. A walk that ran twice over the same umid would
+    // duplicate the network fetches for no gain, and two overlapping walks
+    // down the same chain would race each other into the same writes -
+    // harmless, because every write here is idempotent, but pure waste and
+    // exactly the sort of thing that turns into a thundering herd on a busy
+    // stream.
+    //
+    // And the check itself is not free: it asks the network for the umid
+    // just written, which on a healthy node finds nothing missing. Doing
+    // that per commit would add a broadcast per transaction to a path that
+    // was previously silent. The cooldown makes it per stream per window
+    // instead, which keeps a busy stream quiet while still noticing a gap
+    // within seconds of one appearing.
+    //
+    // Skipping is always safe: a gap does not heal itself, so the next
+    // commit after the window finds it. Late repair, never no repair.
+    if (Endpoints.historyRepairInFlight.has(umid)) {
+      return Promise.resolve();
+    }
+    const lastRun = Endpoints.historyRepairLastRun.get(umid) || 0;
+    if (Date.now() - lastRun < Endpoints.HISTORY_REPAIR_COOLDOWN_MS) {
+      return Promise.resolve();
+    }
+    Endpoints.historyRepairInFlight.add(umid);
+    Endpoints.historyRepairLastRun.set(umid, Date.now());
+
+    return (async () => {
       try {
         // Deliberately NOT the local copy.
         //
@@ -2258,8 +2334,36 @@ export class Endpoints {
       } catch (error) {
         // Detached from the transaction path - must never surface into it
         ActiveLogger.error(error, `SPI WALK (post-commit) failed for ${umid}`);
+      } finally {
+        // Always, or one thrown error wedges this umid permanently
+        Endpoints.historyRepairInFlight.delete(umid);
+        Endpoints.pruneHistoryRepairMemory();
       }
     })();
+  }
+
+  /**
+   * Keeps the cooldown map from being a slow memory leak.
+   *
+   * One entry per umid repaired would grow for the life of the process.
+   * Entries older than the cooldown cannot affect a decision, so they are
+   * dropped once the map is big enough to be worth the sweep.
+   *
+   * @private
+   * @static
+   */
+  private static pruneHistoryRepairMemory(): void {
+    if (Endpoints.historyRepairLastRun.size < 1000) {
+      return;
+    }
+    const cutoff = Date.now() - Endpoints.HISTORY_REPAIR_COOLDOWN_MS;
+    for (const [key, at] of Array.from(
+      Endpoints.historyRepairLastRun.entries()
+    )) {
+      if (at < cutoff) {
+        Endpoints.historyRepairLastRun.delete(key);
+      }
+    }
   }
 
   /**

--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -254,7 +254,12 @@ export class Endpoints {
                             let rewroteSomething = false;
                             // umids named in the :stream metas adopted this
                             // round - the transactions this node missed.
-                            const adoptedUmids = new Set<string>();
+                            // Streams repaired this round. The umid to walk
+                            // from is read off each stream's own :stream meta
+                            // afterwards, rather than taken from whichever
+                            // document happened to be rewritten - a round may
+                            // rewrite only the state, and that carries no umid.
+                            const repairedStreams = new Set<string>();
                             const streams = [
                               ...new Set([
                                 ...this.labelOrKey(tx.$tx.$i),
@@ -369,9 +374,9 @@ export class Endpoints {
                                         // revision just adopted. That is the
                                         // one this node missed, and the only
                                         // umid derivable from what SPI holds.
-                                        if (winningDoc.umid) {
-                                          adoptedUmids.add(winningDoc.umid);
-                                        }
+                                        repairedStreams.add(
+                                          winningDoc._id.replace(":stream", "")
+                                        );
                                       }
                                     }
                                   }
@@ -387,25 +392,24 @@ export class Endpoints {
                                   // with correct state and no record of how it got there: no
                                   // umid, and none of the events that transaction raised. State
                                   // converges, history does not, and nothing reports a fault.
-                                  for (const adopted of adoptedUmids) {
-                                    const backfilled = await Endpoints.backfillUmid(host, adopted);
-                                    if (!backfilled) {
-                                      // Durable retry, same as the non-origin path. Restore
-                                      // skips it if this succeeded on a later attempt.
-                                      ActiveLogger.warn(adopted, `SPI Adding 950 Checker #1`);
-                                      await host.dbErrorConnection.post({
-                                        _id: `${adopted}:${Date.now()}`,
-                                        code: 950,
-                                        processed: false,
-                                        umid: adopted,
-                                        transaction: {
-                                          $broadcast: true,
-                                          $tx: {},
-                                          $revs: {},
-                                        },
-                                        reason: 'Vote Failure - "SPI#1 UMID not found',
-                                      });
-                                    }
+                                  // NOT awaited, deliberately. The client is
+                                  // waiting on the resubmission below, and a
+                                  // walk is up to UMID_WALK_LIMIT sequential
+                                  // network fetches - putting that in front of
+                                  // the response would trade a latency problem
+                                  // for a correctness one nobody asked for.
+                                  // History repair is pure backfill: nothing in
+                                  // this transaction depends on it.
+                                  //
+                                  // Fire-and-forget is only acceptable here
+                                  // because the 950 makes it durable. A failed
+                                  // walk leaves a work item restore picks up,
+                                  // so this is an optimisation over that path
+                                  // rather than a replacement for it - which is
+                                  // the difference between this and an emit
+                                  // that vanishes silently.
+                                  for (const streamId of repairedStreams) {
+                                    Endpoints.repairHistoryInBackground(host, streamId, "#1");
                                   }
 
                                   //  need TO ONLY run this if SPI rewrites occured?
@@ -1292,7 +1296,7 @@ export class Endpoints {
 
                         // umids named in the :stream metas adopted this
                         // round - the transactions this node missed.
-                        const adoptedUmidsNonOrigin = new Set<string>();
+                        const repairedStreamsNonOrigin = new Set<string>();
 
                         // now find the ones that match
                         // One shared, tested tally - see Endpoints.spiConsensus(). It
@@ -1358,9 +1362,9 @@ export class Endpoints {
                               // Same as the origin path: the :stream meta
                               // names the transaction that produced this
                               // revision, which is the one that was missed.
-                              if (winningDoc.umid) {
-                                adoptedUmidsNonOrigin.add(winningDoc.umid);
-                              }
+                              repairedStreamsNonOrigin.add(
+                                winningDoc._id.replace(":stream", "")
+                              );
                             }
                           }
                         }
@@ -1379,8 +1383,9 @@ export class Endpoints {
                           // the :stream metas just adopted. These are the
                           // ones nothing recovered before: state converged
                           // while the umid and its events never arrived.
-                          for (const adopted of adoptedUmidsNonOrigin) {
-                            await Endpoints.backfillUmid(host, adopted);
+                          // Same reasoning as the origin path - not awaited.
+                          for (const streamId of repairedStreamsNonOrigin) {
+                            Endpoints.repairHistoryInBackground(host, streamId, "#2");
                           }
 
                           ActiveLogger.warn(tx.$umid, `SPI Adding 950 Checker`);
@@ -2044,6 +2049,233 @@ export class Endpoints {
     ActiveLogger.warn(
       `SPI UMID ${umidDoc?.umid?.$umid} - replayed ${events.length} event(s)`
     );
+  }
+
+  /**
+   * How far back a single walk will go before giving up.
+   *
+   * A node this far behind has a bigger problem than one stream, and a
+   * full activerestore is the right tool - grinding through an unbounded
+   * chain one network fetch at a time would be slower and would hold the
+   * SPI path open while doing it.
+   */
+  private static readonly UMID_WALK_LIMIT = 100;
+
+  /**
+   * Recover every umid a stream is missing, by walking its history
+   * backwards.
+   *
+   * SPI can adopt a stream's current revision, but that leaves a node with
+   * correct state and no record of how it got there - no umids, and none
+   * of the events those transactions raised. backfillUmid() fixes the most
+   * recent one, because the :stream meta names it. Everything before that
+   * was unreachable: nothing could enumerate what had been skipped.
+   *
+   * It can now, because each umid records what it replaced. refStreams
+   * .updated carries `prev` per stream - the umid that transaction
+   * superseded - so the history is a linked list walked one hop at a time:
+   *
+   *   :stream meta  ->  umid U0  --prev-->  U1  --prev-->  U2  ...
+   *
+   * The alternative was a list of transactions per stream, which is what
+   * meta.txs was and why it was abandoned: it grew without limit on any
+   * busy stream. A backward pointer is one field per stream per
+   * transaction whatever the history length, and this walk fetches only
+   * the hops actually missing rather than scanning a global index and
+   * discarding almost all of it.
+   *
+   * Stops at the first umid already held (the common case is one or two
+   * hops), at a creation, at a broken chain, or at UMID_WALK_LIMIT.
+   *
+   * @static
+   * @param {Host} host
+   * @param {string} streamId the stream being repaired
+   * @param {string} fromUmid the network's current umid for that stream
+   * @returns {Promise<{ recovered: string[]; stoppedAt: string }>}
+   */
+  public static async walkUmidHistory(
+    host: Host,
+    streamId: string,
+    fromUmid: string
+  ): Promise<{ recovered: string[]; stoppedAt: string }> {
+    const recovered: string[] = [];
+    const seen = new Set<string>();
+    let cursor: string | undefined = fromUmid;
+
+    while (cursor) {
+      if (seen.has(cursor)) {
+        // A chain should never loop. If one does, stop rather than spin -
+        // and say so, because it means something upstream is wrong.
+        return { recovered, stoppedAt: "loop detected" };
+      }
+      seen.add(cursor);
+
+      if (recovered.length >= Endpoints.UMID_WALK_LIMIT) {
+        ActiveLogger.warn(
+          `SPI WALK ${streamId} - stopped at ${Endpoints.UMID_WALK_LIMIT}, a full restore is the right tool from here`
+        );
+        return { recovered, stoppedAt: "limit reached" };
+      }
+
+      // Do we already have it? Everything before it is here too, because a
+      // node only gains umids by walking this same chain or by committing
+      // in order - so this is where the walk stops, and it is what keeps
+      // the common case cheap.
+      let held = false;
+      try {
+        const local = await host.dbConnection.get(`${cursor}:umid`);
+        held = !!(local && local._id);
+      } catch {
+        held = false;
+      }
+
+      // Call backfillUmid even when held, and stop afterwards rather than
+      // before. Holding the umid does NOT imply holding its events - they
+      // are separate documents and EventEngine.emit() is fire-and-forget,
+      // so an event can be missing under a umid that is present. An earlier
+      // version of this returned on `held` without calling through, which
+      // silently removed the replay that ran before the walk existed.
+      // Replaying is idempotent (events keep their original _id), so the
+      // one extra pass at the terminus costs nothing but closes that hole.
+      const ok = await Endpoints.backfillUmid(host, cursor);
+      if (!ok) {
+        return { recovered, stoppedAt: `could not recover ${cursor}` };
+      }
+      if (held) {
+        return { recovered, stoppedAt: "reached a umid already held" };
+      }
+      recovered.push(cursor);
+
+      // Read the hop we just adopted to find the one before it.
+      let doc: any;
+      try {
+        doc = await host.dbConnection.get(`${cursor}:umid`);
+      } catch {
+        return { recovered, stoppedAt: "adopted umid could not be read back" };
+      }
+
+      cursor = Endpoints.previousUmidFor(doc, streamId);
+    }
+
+    return { recovered, stoppedAt: "start of stream" };
+  }
+
+  /**
+   * Repair a stream's umid history without holding anything up.
+   *
+   * Started, never awaited. The transaction that triggered SPI has a client
+   * waiting on it, and a walk is up to UMID_WALK_LIMIT sequential network
+   * fetches - nothing in the transaction depends on the history being back,
+   * so making the client wait for it would be trading a real latency cost
+   * for no correctness gain.
+   *
+   * Safe to fire and forget only because of what happens when it fails: a
+   * 950 is written, restore picks it up, and the work survives a crash.
+   * That is the difference between this and a bare emit that disappears -
+   * the fast path is an optimisation over a durable one, not a replacement
+   * for it.
+   *
+   * @private
+   * @static
+   */
+  private static repairHistoryInBackground(
+    host: Host,
+    streamId: string,
+    label: string
+  ): void {
+    void (async () => {
+      try {
+        const adopted = await Endpoints.currentUmidFor(host, streamId);
+        if (!adopted) {
+          return;
+        }
+
+        const walk = await Endpoints.walkUmidHistory(host, streamId, adopted);
+        if (walk.recovered.length) {
+          ActiveLogger.warn(
+            `SPI WALK ${label} ${streamId} recovered ${walk.recovered.length} umid(s), stopped: ${walk.stoppedAt}`
+          );
+          return;
+        }
+
+        // Nothing recovered and nothing was missing is the common case -
+        // the walk stopped immediately on a umid already held. Only a walk
+        // that could not do its job earns a durable retry.
+        if (walk.stoppedAt.indexOf("already held") !== -1) {
+          return;
+        }
+
+        ActiveLogger.warn(adopted, `SPI Adding 950 Checker ${label}`);
+        await host.dbErrorConnection.post({
+          _id: `${adopted}:${Date.now()}`,
+          code: 950,
+          processed: false,
+          umid: adopted,
+          transaction: {
+            $broadcast: true,
+            $tx: {},
+            $revs: {},
+          },
+          reason: `Vote Failure - "SPI${label} UMID not found`,
+        });
+      } catch (error) {
+        // Must never surface into the transaction path it was detached from
+        ActiveLogger.error(error, `SPI WALK ${label} ${streamId} failed`);
+      }
+    })();
+  }
+
+  /**
+   * The umid this node currently believes produced a stream's state.
+   *
+   * Read from the stream's own :stream meta after a repair, rather than
+   * from whichever document the tally happened to rewrite. A round may
+   * rewrite only the state document, which carries no umid at all - taking
+   * it from there meant the walk simply never started in exactly the case
+   * it was built for.
+   *
+   * @private
+   * @static
+   */
+  private static async currentUmidFor(
+    host: Host,
+    streamId: string
+  ): Promise<string | undefined> {
+    try {
+      const meta = await host.dbConnection.get(`${streamId}:stream`);
+      return meta?.umid || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * The umid a given umid document replaced, for one stream.
+   *
+   * Reads refStreams.updated, matching on the stream id. A creation lives
+   * in refStreams.new and carries no prev, which is what makes the start of
+   * a stream a natural terminator.
+   *
+   * @private
+   * @static
+   */
+  private static previousUmidFor(
+    umidDoc: any,
+    streamId: string
+  ): string | undefined {
+    const updated = umidDoc?.streams?.updated;
+    if (!Array.isArray(updated)) {
+      return undefined;
+    }
+    for (const entry of updated) {
+      if (!entry) continue;
+      // Ids may carry a virtual prefix depending on where they were built.
+      const id: string = entry.id || "";
+      if (id === streamId || id.endsWith(streamId) || streamId.endsWith(id)) {
+        return entry.prev || undefined;
+      }
+    }
+    return undefined;
   }
 
   /**

--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -2161,6 +2161,108 @@ export class Endpoints {
   }
 
   /**
+   * After a commit, check whether this node is missing the history behind
+   * the transaction it just wrote - and if so, go and get it.
+   *
+   * SPI is not the only way a node adopts state it did not derive. A node
+   * that was down comes back, takes part in the next round, and ends up
+   * holding the network's revision directly - which is correct and wanted.
+   * But it wrote one umid, for the transaction it just took part in, and
+   * has nothing for the fifty before it. State jumps; history does not
+   * follow, and nothing anywhere reports a gap.
+   *
+   * Wiring the walk only to SPI missed exactly that case: SPI never fires,
+   * so the walk never ran, and a node could sit with correct state and an
+   * empty feed indefinitely.
+   *
+   * Cheap enough to do on every commit: one local read of the umid just
+   * written, then one held-check per stream it touched. Only a real hole
+   * costs anything more, and the walk itself is detached.
+   *
+   * @static
+   * @param {Host} host
+   * @param {string} umid the transaction just committed here
+   */
+  public static repairHistoryAfterCommit(host: Host, umid: string): void {
+    if (!umid) {
+      return;
+    }
+
+    void (async () => {
+      try {
+        // Deliberately NOT the local copy.
+        //
+        // `prev` is captured at commit time from the node's own :stream
+        // meta, so on a node that was behind it points at whatever that
+        // node last believed - the creation, say - rather than at the
+        // transaction the network actually superseded. That is exactly
+        // backwards on the only node that needs the chain, and reading the
+        // local document here made this trigger a no-op in precisely the
+        // case it was written for.
+        //
+        // A peer that was up has the right pointer, so take it from the
+        // majority copy. Same source of truth the walk itself uses.
+        const responses = await host.neighbourhood.knockAll(
+          `umid/${umid}`,
+          null,
+          true
+        );
+        const grouped: { [hash: string]: { count: number; doc: any } } = {};
+        for (let i = responses.length; i--; ) {
+          const response = responses[i];
+          if (!response?.streams) continue;
+          const hash = ActiveCrypto.Hash.getHash(JSON.stringify(response));
+          grouped[hash]
+            ? grouped[hash].count++
+            : (grouped[hash] = { count: 1, doc: response });
+        }
+        const hashes = Object.keys(grouped);
+        if (!hashes.length) {
+          return;
+        }
+        const doc =
+          grouped[hashes.sort((a, b) => grouped[b].count - grouped[a].count)[0]]
+            .doc;
+
+        const updated = doc?.streams?.updated;
+        if (!Array.isArray(updated) || !updated.length) {
+          return;
+        }
+
+        for (const entry of updated) {
+          const prev = entry?.prev;
+          const streamId = entry?.id;
+          if (!prev || !streamId) {
+            // A creation has no prev, and nothing to walk behind it.
+            continue;
+          }
+
+          // The common case by far: we have the one before, so there is no
+          // gap and this costs a single local read.
+          try {
+            const held = await host.dbConnection.get(`${prev}:umid`);
+            if (held && held._id) {
+              continue;
+            }
+          } catch {
+            // Missing - which is the whole point
+          }
+
+          const walk = await Endpoints.walkUmidHistory(host, streamId, prev);
+          if (walk.recovered.length) {
+            ActiveLogger.warn(
+              `SPI WALK (post-commit) ${streamId} recovered ${walk.recovered.length} umid(s), stopped: ${walk.stoppedAt}`
+            );
+          }
+        }
+      } catch (error) {
+        // Detached from the transaction path - must never surface into it
+        ActiveLogger.error(error, `SPI WALK (post-commit) failed for ${umid}`);
+      }
+    })();
+  }
+
+  /**
    * Repair a stream's umid history without holding anything up.
    *
    * Started, never awaited. The transaction that triggered SPI has a client

--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -408,7 +408,7 @@ export class Endpoints {
                                   // rather than a replacement for it - which is
                                   // the difference between this and an emit
                                   // that vanishes silently.
-                                  for (const streamId of repairedStreams) {
+                                  for (const streamId of Array.from(repairedStreams)) {
                                     Endpoints.repairHistoryInBackground(host, streamId, "#1");
                                   }
 
@@ -1384,7 +1384,7 @@ export class Endpoints {
                           // ones nothing recovered before: state converged
                           // while the umid and its events never arrived.
                           // Same reasoning as the origin path - not awaited.
-                          for (const streamId of repairedStreamsNonOrigin) {
+                          for (const streamId of Array.from(repairedStreamsNonOrigin)) {
                             Endpoints.repairHistoryInBackground(host, streamId, "#2");
                           }
 

--- a/packages/network/src/network/host.ts
+++ b/packages/network/src/network/host.ts
@@ -1217,6 +1217,14 @@ export class Host extends Home {
           if (this.hybridHosts.length) {
             this.processHybridNodes(pending.entry, m.data.entry?.$streams);
           }
+
+          // The client has its answer (resolve above), so this costs it
+          // nothing. A node that was behind can adopt the network's state
+          // through an ordinary commit without SPI ever running - correct,
+          // and wanted - but it then holds one umid and none of the history
+          // behind it. Check for that gap here rather than only on the SPI
+          // path, which this case never touches.
+          Endpoints.repairHistoryAfterCommit(this, pending.entry.$umid);
           break;
         case "broadcast":
           this.broadcast(m.data.umid, m.data.early);

--- a/packages/protocol/src/protocol/streamUpdater.ts
+++ b/packages/protocol/src/protocol/streamUpdater.ts
@@ -308,8 +308,26 @@ export class StreamUpdater {
         });
       } else {
         // Add to updated stream reference
+        //
+        // `prev` is the umid this transaction replaces on this stream,
+        // captured here because meta.umid is overwritten further down. One
+        // field per stream this transaction touched - bounded by $i u $o,
+        // never by how long the stream has existed.
+        //
+        // That bound is the point. meta.txs tried to keep the history as a
+        // list and grew without limit on any stream updated often, costing
+        // space, memory and speed at once. A backward pointer costs the
+        // same on a stream updated once as on one updated a million times,
+        // and chaining them gives the same walk a list would have: one hop
+        // per fetch, and only the hops actually needed.
+        //
+        // A node that missed transactions can walk from the network's
+        // current umid back through prev until it reaches one it already
+        // holds. Creations carry no prev, so a walk terminates naturally at
+        // the start of the stream rather than needing a sentinel.
         this.refStreams.updated.push({
           id: this.shared.filterPrefix(this.streams[i].state._id as string),
+          prev: this.streams[i].meta?.umid,
         });
 
         // meta.umid was previously left untouched on every update after

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -209,7 +209,7 @@ async function main(): Promise<boolean> {
 
     await runContractDivergenceTest(report, nodes, identity, NAMESPACE);
 
-    await runNodeRecoveryTests(report, harness, nodes, identity, NAMESPACE, returnerId);
+    await runNodeRecoveryTests(report, harness, nodes, identity, NAMESPACE, returnerId, emitterId);
 
     return report.summary();
   } finally {
@@ -1376,7 +1376,8 @@ async function runNodeRecoveryTests(
   nodes: NetworkNode[],
   identity: Identity,
   namespace: string,
-  returnerId: string
+  returnerId: string,
+  emitterId: string
 ): Promise<void> {
   const downNode = nodes[1];
   const originNode = nodes[0];
@@ -1506,6 +1507,111 @@ async function runNodeRecoveryTests(
           (held < missed.length
             ? ` - the rest are backfilled only by a full activerestore, not by SPI`
             : "")
+      );
+    }
+  }
+
+  // A long gap, with events - the shape of a node that was down for a
+  // while rather than one that dropped a round.
+  //
+  // Each umid records the umid it replaced, per stream, so the history is
+  // a linked list SPI can walk backwards one hop at a time. This is the
+  // check that the chain actually holds across a real run: fifty
+  // transactions, every one raising an event, none of which this node saw.
+  //
+  // Measured rather than asserted at a number. A partial walk is a real
+  // outcome (a peer may not hold an old umid, and the walk caps at 100),
+  // and reporting what came back is more use than failing on an arbitrary
+  // threshold - the pass condition is that state converges and that
+  // whatever history IS recovered brought its events with it, because a
+  // umid without its events is the fault this was built to fix.
+  const LONG_GAP = 50;
+  report.phase(`Node recovery: a ${LONG_GAP}-transaction gap, with events`);
+  {
+    const start = Date.now();
+    const subject = await onboard(originNode.baseUrl);
+    await waitForConvergence(nodes, subject.streamId, 10000);
+
+    await harness.killNode(downNode.index);
+
+    // Sequential: they all touch the same stream, so each depends on the
+    // revision the last one produced.
+    const missedUmids: string[] = [];
+    for (let i = 0; i < LONG_GAP; i++) {
+      const res: any = await runContract(
+        originNode.baseUrl,
+        subject,
+        namespace,
+        emitterId,
+        { message: `gap-${i}`, correlationId: `gap-${i}-${Date.now()}` }
+      ).catch(() => undefined);
+      if (res?.$umid) missedUmids.push(res.$umid);
+    }
+
+    await harness.restartNode(downNode.index);
+    await new Promise((r) => setTimeout(r, 4000));
+
+    // Something for the returned node to notice on.
+    await runContract(originNode.baseUrl, subject, namespace, emitterId, {
+      message: "gap-trigger",
+      correlationId: `gap-trigger-${Date.now()}`,
+    }).catch(() => undefined);
+
+    const { byNode, converged } = await waitForConvergence(nodes, subject.streamId, 30000);
+
+    // The walk is asynchronous - give it room, then count.
+    let heldUmids = 0;
+    let heldEvents = 0;
+    let expectedEvents = 0;
+    const deadline = Date.now() + 30000;
+    while (Date.now() < deadline) {
+      heldUmids = 0;
+      heldEvents = 0;
+      expectedEvents = 0;
+      for (const umid of missedUmids) {
+        let doc: any;
+        try {
+          doc = await storageGet(downNode.storageUrl, `${umid}:umid`);
+        } catch {
+          continue;
+        }
+        if (!doc?._id) continue;
+        heldUmids++;
+        for (const event of doc.events || []) {
+          if (!event?._id) continue;
+          expectedEvents++;
+          try {
+            const ev = await storageGet(downNode.storageUrl, event._id, "activeledgerevents");
+            if (ev?._id) heldEvents++;
+          } catch {
+            // not yet
+          }
+        }
+      }
+      if (heldUmids >= missedUmids.length && heldEvents >= expectedEvents) break;
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+
+    // Every umid recovered must have brought its events. That is the
+    // property; how far back the walk got is reported, not asserted.
+    const eventsIntact = expectedEvents === 0 || heldEvents === expectedEvents;
+    const ok = converged && eventsIntact;
+
+    report.record("recovers-a-long-gap", ok, Date.now() - start);
+    if (!converged) {
+      report.fail(
+        `State did not converge after a ${LONG_GAP}-transaction gap: ${byNode
+          .map((n) => `${n.port}=${n.rev}`)
+          .join(", ")}`
+      );
+    } else if (!eventsIntact) {
+      report.fail(
+        `Recovered ${heldUmids}/${missedUmids.length} umids but only ${heldEvents}/${expectedEvents} of their events - a umid without its events is the fault this exists to fix`
+      );
+    } else {
+      report.ok(
+        `State converged on ${byNode[0].rev}; node ${downNode.port} recovered ` +
+          `${heldUmids}/${missedUmids.length} missed umids and all ${heldEvents} of their events`
       );
     }
   }

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -1645,6 +1645,106 @@ async function runNodeRecoveryTests(
     }
   }
 
+  // A DELIBERATELY BROKEN chain, on a live network.
+  //
+  // The unit tests prove every layer of the repair contains its own
+  // failures. They cannot prove that a real node survives one, and that is
+  // the property that actually matters: history repair is the least
+  // important thing a node does, and it must never be worth a node. Node
+  // treats an unhandled rejection as fatal, so a bug here could take down a
+  // node that was otherwise perfectly healthy.
+  //
+  // So: give a returning node a chain it cannot walk - a mid-chain umid
+  // replaced with nonsense on every peer, so the fetch returns junk rather
+  // than failing cleanly - then check the node is still a working member of
+  // the network afterwards.
+  report.phase("Node recovery: a broken history chain must not harm the node");
+  {
+    const start = Date.now();
+    const driver = nodes[0];
+    const victim = await onboard(driver.baseUrl);
+    const bystander = await onboard(driver.baseUrl);
+    await waitForConvergence(nodes, victim.streamId, 10000);
+    await waitForConvergence(nodes, bystander.streamId, 10000);
+
+    await harness.killNode(downNode.index);
+
+    const missed: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      const res: any = await runContract(driver.baseUrl, victim, namespace, emitterId, {
+        message: `broken-${i}`,
+        correlationId: `broken-${i}-${Date.now()}`,
+      }).catch(() => undefined);
+      if (res?.$umid) missed.push(res.$umid);
+    }
+
+    // Poison the middle of the chain on every node that is up, so the walk
+    // gets a malformed document back rather than a clean "not found".
+    const poisoned = missed[Math.floor(missed.length / 2)];
+    if (poisoned) {
+      for (const node of nodes) {
+        if (node.index === downNode.index) continue;
+        await storagePut(node.storageUrl, `${poisoned}:umid`, {
+          _id: `${poisoned}:umid`,
+          umid: "not-an-object",
+          streams: "not-an-array",
+          events: { nope: true },
+        }).catch(() => undefined);
+      }
+    }
+
+    await harness.restartNode(downNode.index);
+    await new Promise((r) => setTimeout(r, 4000));
+    await runContract(driver.baseUrl, victim, namespace, emitterId, {
+      message: "broken-trigger",
+      correlationId: `broken-trigger-${Date.now()}`,
+    }).catch(() => undefined);
+
+    // Let the walk run into the poison and give up
+    await new Promise((r) => setTimeout(r, 8000));
+
+    // 1. Is the node still there at all?
+    let alive = false;
+    try {
+      const status: any = await requestJsonWithStatus(`${downNode.baseUrl}/a/status`, "GET");
+      alive = status.statusCode === 200;
+    } catch {
+      alive = false;
+    }
+
+    // 2. Is it still a working consensus member? A transaction on an
+    //    unrelated stream has to commit with it taking part.
+    const after: any = await runContract(driver.baseUrl, bystander, namespace, returnerId, {
+      message: "after-broken-chain",
+    }).catch(() => undefined);
+    const stillCommitting = !!after && !after.$summary?.errors;
+
+    // 3. Did the stream it was actually repairing still converge? State is
+    //    what matters; the history behind it is allowed to be incomplete.
+    const conv = await waitForConvergence(nodes, victim.streamId, 20000);
+
+    const ok = alive && stillCommitting && conv.converged;
+    report.record("broken-chain-does-not-harm-the-node", ok, Date.now() - start);
+    if (!alive) {
+      report.fail(`Node ${downNode.port} is not responding - a broken history chain took it down`);
+    } else if (!stillCommitting) {
+      report.fail(
+        `Node ${downNode.port} is up but no longer committing: ${JSON.stringify(after?.$summary)}`
+      );
+    } else if (!conv.converged) {
+      report.fail(
+        `State did not converge after a broken chain: ${conv.byNode
+          .map((n) => `${n.port}=${n.rev}`)
+          .join(", ")}`
+      );
+    } else {
+      report.ok(
+        `Poisoned the chain at ${poisoned?.slice(0, 12) || "?"} - node ${downNode.port} stayed up, ` +
+          `kept committing, and its state still converged on ${conv.byNode[0].rev}`
+      );
+    }
+  }
+
   // A long gap, with events - the shape of a node that was down for a
   // while rather than one that dropped a round.
   //

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -1551,6 +1551,7 @@ async function runNodeRecoveryTests(
     await harness.restartNode(downNode.index);
     await new Promise((r) => setTimeout(r, 4000));
 
+
     // Something for the returned node to notice on.
     await runContract(originNode.baseUrl, subject, namespace, emitterId, {
       message: "gap-trigger",
@@ -1558,6 +1559,8 @@ async function runNodeRecoveryTests(
     }).catch(() => undefined);
 
     const { byNode, converged } = await waitForConvergence(nodes, subject.streamId, 30000);
+    report.ok(
+    );
 
     // The walk is asynchronous - give it room, then count.
     let heldUmids = 0;

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -1511,84 +1511,74 @@ async function runNodeRecoveryTests(
     }
   }
 
-  // TWO nodes down at once, each behind on its OWN stream.
+  // ONE node down, behind on TWO streams at once.
   //
-  // The single-node case proves the walk works. This proves it stays
-  // correct when two of them run at the same time on the same network,
-  // which is the shape that would actually be seen after a rack or a
-  // network partition - and the shape where a shared in-flight guard, a
-  // shared cooldown, or a chain read from the wrong node would show up as
-  // one node recovering another's history, or neither recovering its own.
+  // Two nodes each missing their own stream reads like the harder test and
+  // is actually the easier one: nodes are separate processes, so their
+  // walks cannot collide by construction. The real concurrency risk is two
+  // walks on the SAME node - they share the in-flight guard, the cooldown
+  // map, one event loop and one storage engine. That is where a shared-state
+  // bug would show up, and it costs one outage rather than two.
   //
-  // Each node gets its own stream so the two walks must stay independent:
-  // if they cross, the counts below cannot both be right.
+  // Interleaved so neither stream is idle while the other moves, and both
+  // triggered together so the walks genuinely overlap rather than queueing.
   const PARALLEL_GAP = 50;
-  report.phase(`Node recovery: two nodes, two streams, ${PARALLEL_GAP} missed each, in parallel`);
+  report.phase(`Node recovery: one node, two streams, ${PARALLEL_GAP} missed on each`);
   {
     const start = Date.now();
-    const nodeA = nodes[1];
-    const nodeB = nodes[2];
     const driver = nodes[0];
-
     const streamA = await onboard(driver.baseUrl);
     const streamB = await onboard(driver.baseUrl);
     await waitForConvergence(nodes, streamA.streamId, 10000);
     await waitForConvergence(nodes, streamB.streamId, 10000);
 
-    // Staggered, never simultaneous. Two of four nodes down leaves the
-    // network short of what consensus needs, so the transactions simply do
-    // not commit and the test measures nothing - the first version of this
-    // stalled for exactly that reason. Taking one node at a time keeps
-    // three up throughout.
-    //
-    // The walks still overlap, which is the point: node A is restarted and
-    // its repair started BEFORE node B is touched, so by the time B is
-    // walking, A still is.
-    const gapFor = async (
-      node: NetworkNode,
-      identity: Identity,
-      tag: string
-    ): Promise<string[]> => {
-      const missed: string[] = [];
-      await harness.killNode(node.index);
-      for (let i = 0; i < PARALLEL_GAP; i++) {
-        const res: any = await runContract(driver.baseUrl, identity, namespace, emitterId, {
-          message: `${tag}-${i}`,
-          correlationId: `${tag}-${i}-${Date.now()}`,
-        }).catch(() => undefined);
-        if (res?.$umid) missed.push(res.$umid);
-      }
-      await harness.restartNode(node.index);
-      return missed;
-    };
+    // Only one node leaves, so the network keeps three and consensus holds
+    // throughout. An earlier version took two of four down and simply
+    // stalled - nothing could commit, so the test measured nothing.
+    await harness.killNode(downNode.index);
 
-    const missedA = await gapFor(nodeA, streamA, "par-a");
-    await new Promise((r) => setTimeout(r, 4000));
-    // Kick A's recovery off, then immediately go and break B - so A is
-    // still walking while B starts.
-    await runContract(driver.baseUrl, streamA, namespace, emitterId, {
-      message: "par-a-trigger",
-      correlationId: `par-a-trigger-${Date.now()}`,
-    }).catch(() => undefined);
+    const missedA: string[] = [];
+    const missedB: string[] = [];
+    for (let i = 0; i < PARALLEL_GAP; i++) {
+      const a: any = await runContract(driver.baseUrl, streamA, namespace, emitterId, {
+        message: `par-a-${i}`,
+        correlationId: `par-a-${i}-${Date.now()}`,
+      }).catch(() => undefined);
+      if (a?.$umid) missedA.push(a.$umid);
 
-    const missedB = await gapFor(nodeB, streamB, "par-b");
+      const b: any = await runContract(driver.baseUrl, streamB, namespace, emitterId, {
+        message: `par-b-${i}`,
+        correlationId: `par-b-${i}-${Date.now()}`,
+      }).catch(() => undefined);
+      if (b?.$umid) missedB.push(b.$umid);
+    }
+
+    await harness.restartNode(downNode.index);
     await new Promise((r) => setTimeout(r, 4000));
-    await runContract(driver.baseUrl, streamB, namespace, emitterId, {
-      message: "par-b-trigger",
-      correlationId: `par-b-trigger-${Date.now()}`,
-    }).catch(() => undefined);
+
+    // Both triggers back to back, so the node is walking two chains at once
+    await Promise.all([
+      runContract(driver.baseUrl, streamA, namespace, emitterId, {
+        message: "par-a-trigger",
+        correlationId: `par-a-trigger-${Date.now()}`,
+      }).catch(() => undefined),
+      runContract(driver.baseUrl, streamB, namespace, emitterId, {
+        message: "par-b-trigger",
+        correlationId: `par-b-trigger-${Date.now()}`,
+      }).catch(() => undefined),
+    ]);
 
     const convA = await waitForConvergence(nodes, streamA.streamId, 30000);
     const convB = await waitForConvergence(nodes, streamB.streamId, 30000);
 
-    const countFor = async (node: NetworkNode, umids: string[]) => {
+    const countFor = async (umids: string[]) => {
       let held = 0;
       let events = 0;
       let expected = 0;
       for (const umid of umids) {
         let doc: any;
         try {
-          doc = await storageGet(node.storageUrl, `${umid}:umid`);
+          doc = await storageGet(downNode.storageUrl, `${umid}:umid`);
         } catch {
           continue;
         }
@@ -1598,7 +1588,7 @@ async function runNodeRecoveryTests(
           if (!event?._id) continue;
           expected++;
           try {
-            const ev = await storageGet(node.storageUrl, event._id, "activeledgerevents");
+            const ev = await storageGet(downNode.storageUrl, event._id, "activeledgerevents");
             if (ev?._id) events++;
           } catch {
             // not yet
@@ -1610,52 +1600,47 @@ async function runNodeRecoveryTests(
 
     let a = { held: 0, events: 0, expected: 0 };
     let b = { held: 0, events: 0, expected: 0 };
-    const deadline = Date.now() + 45000;
+    const deadline = Date.now() + 60000;
     while (Date.now() < deadline) {
-      a = await countFor(nodeA, missedA);
-      b = await countFor(nodeB, missedB);
+      a = await countFor(missedA);
+      b = await countFor(missedB);
       if (a.held >= missedA.length && b.held >= missedB.length) break;
       await new Promise((r) => setTimeout(r, 2000));
     }
 
-    // There is deliberately NO cross-contamination check here.
-    //
-    // An earlier version counted how many of stream B's umids node A held,
-    // expecting zero, and reported "10 (want 0)" while passing - because it
-    // was never wired into the pass condition. Just as well: the number was
-    // correct and the expectation was nonsense. Node B was UP during node
-    // A's gap, so it committed every one of stream A's transactions at the
-    // time. Every node legitimately holds every umid; that is what
-    // consensus means.
-    //
-    // So a walk following the wrong stream's chain is indistinguishable
-    // from normal commits, and cannot be detected this way at all. What IS
-    // meaningful is that each node recovered its own missed set in full,
-    // which is what the counts below assert. Left as a comment rather than
-    // deleted quietly, because the check looked reasonable and was not.
+    // No cross-stream check here, deliberately. An earlier version counted
+    // how many of stream B's umids this node held while repairing A and
+    // expected zero - it reported 10 and passed only because it was never
+    // in the pass condition. The count was right and the expectation was
+    // nonsense: every node holds every umid, which is what consensus means.
+    // What matters is that BOTH chains came back in full, with their events.
     const eventsIntact =
       (a.expected === 0 || a.events === a.expected) &&
       (b.expected === 0 || b.events === b.expected);
-    const ok = convA.converged && convB.converged && eventsIntact;
+    const bothComplete = a.held === missedA.length && b.held === missedB.length;
+    const ok = convA.converged && convB.converged && eventsIntact && bothComplete;
 
-    report.record("two-nodes-recover-in-parallel", ok, Date.now() - start);
+    report.record("two-streams-recover-in-parallel", ok, Date.now() - start);
     if (!convA.converged || !convB.converged) {
       report.fail(
         `State did not converge - A:${convA.byNode.map((n) => n.rev).join("/")} B:${convB.byNode
           .map((n) => n.rev)
           .join("/")}`
       );
+    } else if (!bothComplete) {
+      report.fail(
+        `One chain lagged the other - A ${a.held}/${missedA.length}, B ${b.held}/${missedB.length}. ` +
+          `Two walks on one node must not starve each other`
+      );
     } else if (!eventsIntact) {
       report.fail(
         `Umids recovered without their events - A ${a.events}/${a.expected}, B ${b.events}/${b.expected}`
       );
     } else {
-      const bothComplete =
-        a.held === missedA.length && b.held === missedB.length;
       report.ok(
-        `Node ${nodeA.port}: ${a.held}/${missedA.length} umids, ${a.events} events. ` +
-          `Node ${nodeB.port}: ${b.held}/${missedB.length} umids, ${b.events} events. ` +
-          `${bothComplete ? "Both walks completed independently." : "Partial - see counts."}`
+        `Node ${downNode.port} walked both chains at once: ` +
+          `stream A ${a.held}/${missedA.length} umids + ${a.events} events, ` +
+          `stream B ${b.held}/${missedB.length} umids + ${b.events} events`
       );
     }
   }

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -1505,7 +1505,7 @@ async function runNodeRecoveryTests(
       report.ok(
         `History: node ${downNode.port} holds ${held}/${missed.length} of the umids it missed` +
           (held < missed.length
-            ? ` - the rest are backfilled only by a full activerestore, not by SPI`
+            ? ` - the rest are behind a broken chain or past the walk limit, and need a full activerestore`
             : "")
       );
     }

--- a/tests/network/run.ts
+++ b/tests/network/run.ts
@@ -1511,6 +1511,155 @@ async function runNodeRecoveryTests(
     }
   }
 
+  // TWO nodes down at once, each behind on its OWN stream.
+  //
+  // The single-node case proves the walk works. This proves it stays
+  // correct when two of them run at the same time on the same network,
+  // which is the shape that would actually be seen after a rack or a
+  // network partition - and the shape where a shared in-flight guard, a
+  // shared cooldown, or a chain read from the wrong node would show up as
+  // one node recovering another's history, or neither recovering its own.
+  //
+  // Each node gets its own stream so the two walks must stay independent:
+  // if they cross, the counts below cannot both be right.
+  const PARALLEL_GAP = 50;
+  report.phase(`Node recovery: two nodes, two streams, ${PARALLEL_GAP} missed each, in parallel`);
+  {
+    const start = Date.now();
+    const nodeA = nodes[1];
+    const nodeB = nodes[2];
+    const driver = nodes[0];
+
+    const streamA = await onboard(driver.baseUrl);
+    const streamB = await onboard(driver.baseUrl);
+    await waitForConvergence(nodes, streamA.streamId, 10000);
+    await waitForConvergence(nodes, streamB.streamId, 10000);
+
+    // Staggered, never simultaneous. Two of four nodes down leaves the
+    // network short of what consensus needs, so the transactions simply do
+    // not commit and the test measures nothing - the first version of this
+    // stalled for exactly that reason. Taking one node at a time keeps
+    // three up throughout.
+    //
+    // The walks still overlap, which is the point: node A is restarted and
+    // its repair started BEFORE node B is touched, so by the time B is
+    // walking, A still is.
+    const gapFor = async (
+      node: NetworkNode,
+      identity: Identity,
+      tag: string
+    ): Promise<string[]> => {
+      const missed: string[] = [];
+      await harness.killNode(node.index);
+      for (let i = 0; i < PARALLEL_GAP; i++) {
+        const res: any = await runContract(driver.baseUrl, identity, namespace, emitterId, {
+          message: `${tag}-${i}`,
+          correlationId: `${tag}-${i}-${Date.now()}`,
+        }).catch(() => undefined);
+        if (res?.$umid) missed.push(res.$umid);
+      }
+      await harness.restartNode(node.index);
+      return missed;
+    };
+
+    const missedA = await gapFor(nodeA, streamA, "par-a");
+    await new Promise((r) => setTimeout(r, 4000));
+    // Kick A's recovery off, then immediately go and break B - so A is
+    // still walking while B starts.
+    await runContract(driver.baseUrl, streamA, namespace, emitterId, {
+      message: "par-a-trigger",
+      correlationId: `par-a-trigger-${Date.now()}`,
+    }).catch(() => undefined);
+
+    const missedB = await gapFor(nodeB, streamB, "par-b");
+    await new Promise((r) => setTimeout(r, 4000));
+    await runContract(driver.baseUrl, streamB, namespace, emitterId, {
+      message: "par-b-trigger",
+      correlationId: `par-b-trigger-${Date.now()}`,
+    }).catch(() => undefined);
+
+    const convA = await waitForConvergence(nodes, streamA.streamId, 30000);
+    const convB = await waitForConvergence(nodes, streamB.streamId, 30000);
+
+    const countFor = async (node: NetworkNode, umids: string[]) => {
+      let held = 0;
+      let events = 0;
+      let expected = 0;
+      for (const umid of umids) {
+        let doc: any;
+        try {
+          doc = await storageGet(node.storageUrl, `${umid}:umid`);
+        } catch {
+          continue;
+        }
+        if (!doc?._id) continue;
+        held++;
+        for (const event of doc.events || []) {
+          if (!event?._id) continue;
+          expected++;
+          try {
+            const ev = await storageGet(node.storageUrl, event._id, "activeledgerevents");
+            if (ev?._id) events++;
+          } catch {
+            // not yet
+          }
+        }
+      }
+      return { held, events, expected };
+    };
+
+    let a = { held: 0, events: 0, expected: 0 };
+    let b = { held: 0, events: 0, expected: 0 };
+    const deadline = Date.now() + 45000;
+    while (Date.now() < deadline) {
+      a = await countFor(nodeA, missedA);
+      b = await countFor(nodeB, missedB);
+      if (a.held >= missedA.length && b.held >= missedB.length) break;
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+
+    // There is deliberately NO cross-contamination check here.
+    //
+    // An earlier version counted how many of stream B's umids node A held,
+    // expecting zero, and reported "10 (want 0)" while passing - because it
+    // was never wired into the pass condition. Just as well: the number was
+    // correct and the expectation was nonsense. Node B was UP during node
+    // A's gap, so it committed every one of stream A's transactions at the
+    // time. Every node legitimately holds every umid; that is what
+    // consensus means.
+    //
+    // So a walk following the wrong stream's chain is indistinguishable
+    // from normal commits, and cannot be detected this way at all. What IS
+    // meaningful is that each node recovered its own missed set in full,
+    // which is what the counts below assert. Left as a comment rather than
+    // deleted quietly, because the check looked reasonable and was not.
+    const eventsIntact =
+      (a.expected === 0 || a.events === a.expected) &&
+      (b.expected === 0 || b.events === b.expected);
+    const ok = convA.converged && convB.converged && eventsIntact;
+
+    report.record("two-nodes-recover-in-parallel", ok, Date.now() - start);
+    if (!convA.converged || !convB.converged) {
+      report.fail(
+        `State did not converge - A:${convA.byNode.map((n) => n.rev).join("/")} B:${convB.byNode
+          .map((n) => n.rev)
+          .join("/")}`
+      );
+    } else if (!eventsIntact) {
+      report.fail(
+        `Umids recovered without their events - A ${a.events}/${a.expected}, B ${b.events}/${b.expected}`
+      );
+    } else {
+      const bothComplete =
+        a.held === missedA.length && b.held === missedB.length;
+      report.ok(
+        `Node ${nodeA.port}: ${a.held}/${missedA.length} umids, ${a.events} events. ` +
+          `Node ${nodeB.port}: ${b.held}/${missedB.length} umids, ${b.events} events. ` +
+          `${bothComplete ? "Both walks completed independently." : "Partial - see counts."}`
+      );
+    }
+  }
+
   // A long gap, with events - the shape of a node that was down for a
   // while rather than one that dropped a round.
   //

--- a/tests/spi-umid-walk.test.ts
+++ b/tests/spi-umid-walk.test.ts
@@ -1,0 +1,335 @@
+import { expect } from "chai";
+import "mocha";
+import { Endpoints } from "../packages/network/src/network/endpoints";
+
+/**
+ * Walking a stream's umid history backwards.
+ *
+ * SPI can adopt a stream's current revision, but that leaves a node with
+ * correct state and no record of how it got there. The most recent umid is
+ * recoverable because the :stream meta names it; everything before that was
+ * unreachable, because nothing could enumerate what had been skipped.
+ *
+ * The fix is a backward pointer rather than a list. Each umid records the
+ * umid it replaced, per stream, so the history is a linked list:
+ *
+ *   :stream meta -> U0 --prev--> U1 --prev--> U2 -> ... -> creation
+ *
+ * A list of transactions per stream was tried before (meta.txs) and
+ * abandoned because it grew without limit on any busy stream, costing
+ * space, memory and speed at once. A pointer costs one field per stream
+ * per transaction however long the history is, and a walk fetches only the
+ * hops actually missing.
+ *
+ * These tests drive the walk against a fake network so the termination
+ * conditions can be checked exactly - the interesting behaviour is all in
+ * when it STOPS.
+ */
+
+const STREAM = "3f7a1c9e5b2d4a6c8e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f";
+
+/**
+ * A network holding a umid chain, and a node holding some prefix of it.
+ *
+ * `chain` is newest-first: chain[0] replaced chain[1], and so on.
+ */
+function fakeHost(chain: string[], held: string[] = [], opts: any = {}) {
+  const local = new Set(held.map((u) => `${u}:umid`));
+  const adopted: string[] = [];
+  const replayed: string[] = [];
+
+  const docFor = (umid: string) => {
+    const index = chain.indexOf(umid);
+    if (index === -1) return undefined;
+    const prev = chain[index + 1];
+    return {
+      _id: `${umid}:umid`,
+      umid: { $umid: umid },
+      // One event per transaction, id'd the way EventEngine does, so a
+      // replay can be counted and checked for duplicates.
+      events: [{ _id: `event:1,${umid}`, name: "Moved", data: { umid } }],
+      streams: prev
+        ? { new: [], updated: [{ id: STREAM, prev }] }
+        : // The oldest entry is the creation - no prev, which is what makes
+          // the start of a stream a natural terminator.
+          { new: [{ id: STREAM, name: "created" }], updated: [] },
+    };
+  };
+
+  return {
+    adopted,
+    replayed,
+    host: {
+      dbConnection: {
+        get: async (id: string) => {
+          if (!local.has(id)) throw new Error("not found");
+          return docFor(id.replace(":umid", ""));
+        },
+        bulkDocs: async (docs: any[]) => {
+          if (opts.writeFails) return false;
+          for (const doc of docs) {
+            local.add(doc._id);
+            adopted.push(doc._id.replace(":umid", ""));
+          }
+          return { ok: true };
+        },
+      },
+      dbEventConnection: {
+        post: async (doc: any) => {
+          replayed.push(doc._id);
+          return { ok: true };
+        },
+      },
+      neighbourhood: {
+        knockAll: async (endpoint: string) => {
+          const umid = endpoint.replace("umid/", "");
+          if (opts.unreachable?.includes(umid)) return [];
+          const doc = docFor(umid);
+          // Two nodes agreeing, as a real sample would return
+          return doc ? [doc, doc] : [];
+        },
+      },
+    } as any,
+  };
+}
+
+describe("Endpoints.walkUmidHistory - recovering a stream's missed history", () => {
+  it("walks back through every umid the node is missing", async () => {
+    // Node holds nothing; the network has four transactions plus a creation
+    const chain = ["u4", "u3", "u2", "u1", "created"];
+    const { host, adopted } = fakeHost(chain, []);
+
+    const result = await Endpoints.walkUmidHistory(host, STREAM, "u4");
+
+    expect(result.recovered).to.deep.equal(["u4", "u3", "u2", "u1", "created"]);
+    expect(adopted).to.deep.equal(["u4", "u3", "u2", "u1", "created"]);
+    expect(result.stoppedAt).to.equal("start of stream");
+  });
+
+  it("stops at the first umid it already holds", async () => {
+    // The common case: behind by two, everything older already present.
+    const chain = ["u4", "u3", "u2", "u1", "created"];
+    const { host, adopted } = fakeHost(chain, ["u2", "u1", "created"]);
+
+    const result = await Endpoints.walkUmidHistory(host, STREAM, "u4");
+
+    expect(result.recovered).to.deep.equal(["u4", "u3"]);
+    expect(adopted).to.deep.equal(["u4", "u3"]);
+    expect(result.stoppedAt).to.contain("already held");
+  });
+
+  it("does nothing at all when the node is already current", async () => {
+    const chain = ["u2", "u1", "created"];
+    const { host, adopted } = fakeHost(chain, ["u2", "u1", "created"]);
+
+    const result = await Endpoints.walkUmidHistory(host, STREAM, "u2");
+
+    expect(result.recovered).to.have.length(0);
+    expect(adopted).to.have.length(0);
+    expect(result.stoppedAt).to.contain("already held");
+  });
+
+  it("stops at the cap rather than grinding through an unbounded chain", async () => {
+    // A node this far behind wants a full restore, not 500 sequential
+    // network fetches holding the SPI path open.
+    const chain = Array.from({ length: 250 }, (_, i) => `u${i}`);
+    const { host } = fakeHost(chain, []);
+
+    const result = await Endpoints.walkUmidHistory(host, STREAM, "u0");
+
+    expect(result.recovered).to.have.length(100);
+    expect(result.stoppedAt).to.equal("limit reached");
+  });
+
+  it("stops cleanly when a umid cannot be recovered from anyone", async () => {
+    // A broken chain must not look like a completed walk.
+    const chain = ["u3", "u2", "u1", "created"];
+    const { host, adopted } = fakeHost(chain, [], { unreachable: ["u2"] });
+
+    const result = await Endpoints.walkUmidHistory(host, STREAM, "u3");
+
+    expect(result.recovered).to.deep.equal(["u3"]);
+    expect(adopted).to.deep.equal(["u3"]);
+    expect(result.stoppedAt).to.contain("could not recover u2");
+  });
+
+  it("reports a write failure rather than continuing past it", async () => {
+    const chain = ["u2", "u1", "created"];
+    const { host } = fakeHost(chain, [], { writeFails: true });
+
+    const result = await Endpoints.walkUmidHistory(host, STREAM, "u2");
+
+    expect(result.recovered).to.have.length(0);
+    expect(result.stoppedAt).to.contain("could not recover");
+  });
+
+  it("refuses to spin if a chain ever loops back on itself", async () => {
+    // Should be impossible. If it happens something upstream is wrong, and
+    // spinning forever would hide it.
+    // The node holds neither, so the walk actually fetches and follows -
+    // an earlier version of this fixture pre-seeded "a" and the walk
+    // correctly stopped at "already held" before it could ever loop, which
+    // proved nothing.
+    const store = new Map<string, any>();
+    const docFor = (umid: string) => ({
+      _id: `${umid}:umid`,
+      umid: { $umid: umid },
+      streams: {
+        new: [],
+        updated: [{ id: STREAM, prev: umid === "a" ? "b" : "a" }],
+      },
+    });
+    const looping: any = {
+      dbConnection: {
+        get: async (id: string) => {
+          if (!store.has(id)) throw new Error("not found");
+          return store.get(id);
+        },
+        bulkDocs: async (docs: any[]) => {
+          for (const doc of docs) store.set(doc._id, doc);
+          return { ok: true };
+        },
+      },
+      dbEventConnection: { post: async () => ({ ok: true }) },
+      neighbourhood: {
+        knockAll: async (endpoint: string) => {
+          const umid = endpoint.replace("umid/", "");
+          return [docFor(umid), docFor(umid)];
+        },
+      },
+    };
+
+    const result = await Endpoints.walkUmidHistory(looping, STREAM, "a");
+
+    expect(result.stoppedAt).to.equal("loop detected");
+  });
+
+  it("only follows the pointer for the stream being repaired", async () => {
+    // A transaction touches several streams and records a different prev
+    // for each. Following the wrong one would walk another stream's history
+    // and silently recover the wrong transactions.
+    const OTHER = "9999999999999999999999999999999999999999999999999999999999999999";
+    const store = new Map<string, any>();
+    const network: { [umid: string]: any } = {
+      top: {
+        _id: "top:umid",
+        umid: { $umid: "top" },
+        streams: {
+          new: [],
+          updated: [
+            { id: OTHER, prev: "wrong-branch" },
+            { id: STREAM, prev: "right-branch" },
+          ],
+        },
+      },
+      "right-branch": {
+        _id: "right-branch:umid",
+        umid: { $umid: "right-branch" },
+        streams: { new: [{ id: STREAM, name: "created" }], updated: [] },
+      },
+      "wrong-branch": {
+        _id: "wrong-branch:umid",
+        umid: { $umid: "wrong-branch" },
+        streams: { new: [{ id: OTHER, name: "created" }], updated: [] },
+      },
+    };
+
+    const multi: any = {
+      dbConnection: {
+        get: async (id: string) => {
+          if (!store.has(id)) throw new Error("not found");
+          return store.get(id);
+        },
+        bulkDocs: async (docs: any[]) => {
+          for (const doc of docs) store.set(doc._id, doc);
+          return { ok: true };
+        },
+      },
+      dbEventConnection: { post: async () => ({ ok: true }) },
+      neighbourhood: {
+        knockAll: async (endpoint: string) => {
+          const doc = network[endpoint.replace("umid/", "")];
+          return doc ? [doc, doc] : [];
+        },
+      },
+    };
+
+    const result = await Endpoints.walkUmidHistory(multi, STREAM, "top");
+
+    // right-branch, never wrong-branch
+    expect(result.recovered).to.deep.equal(["top", "right-branch"]);
+    expect(result.stoppedAt).to.equal("start of stream");
+  });
+
+  it("recovers a long gap in one walk, with every umid's events", async () => {
+    // Fifty missed transactions, which is the shape of a node that was down
+    // for a while rather than one that dropped a single round.
+    const chain = [...Array.from({ length: 50 }, (_, i) => `u${49 - i}`), "created"];
+    const { host, adopted, replayed } = fakeHost(chain, ["created"]);
+
+    const result = await Endpoints.walkUmidHistory(host, STREAM, "u49");
+
+    expect(result.recovered).to.have.length(50);
+    expect(adopted).to.have.length(50);
+    expect(result.stoppedAt).to.contain("already held");
+
+    // Every recovered umid replayed its event, exactly once each - plus
+    // one for the terminus, the already-held umid the walk stopped at.
+    // That extra pass is deliberate: a held umid can still be missing its
+    // events, and replaying is idempotent because ids are reused.
+    expect(replayed).to.have.length(51);
+    expect(new Set(replayed).size).to.equal(51);
+    for (const umid of result.recovered) {
+      expect(replayed).to.contain(`event:1,${umid}`);
+    }
+    expect(replayed, "the terminus replays too").to.contain("event:1,created");
+  });
+
+  it("recovers in order, newest first, so a partial walk leaves the newest present", async () => {
+    // If a walk is cut short the node should hold the MOST recent history,
+    // not a random middle slice - that is what a feed consumer needs.
+    const chain = ["u5", "u4", "u3", "u2", "u1", "created"];
+    const { host } = fakeHost(chain, [], { unreachable: ["u2"] });
+
+    const result = await Endpoints.walkUmidHistory(host, STREAM, "u5");
+
+    expect(result.recovered).to.deep.equal(["u5", "u4", "u3"]);
+  });
+
+  it("stops at the first held umid even when older ones are missing", async () => {
+    // Deliberate, and worth stating: the walk assumes history below a held
+    // umid is intact, because a node only gains umids in order. A hole
+    // underneath one it holds is not something this repairs - that is what
+    // a full restore is for.
+    const chain = ["u4", "u3", "u2", "u1", "created"];
+    const { host } = fakeHost(chain, ["u2"]); // holds u2, but not u1/created
+
+    const result = await Endpoints.walkUmidHistory(host, STREAM, "u4");
+
+    expect(result.recovered).to.deep.equal(["u4", "u3"]);
+    expect(result.stoppedAt).to.contain("already held");
+  });
+
+  it("recovers exactly the cap when the gap is exactly the cap", async () => {
+    const chain = [...Array.from({ length: 100 }, (_, i) => `u${99 - i}`), "created"];
+    const { host } = fakeHost(chain, ["created"]);
+
+    const result = await Endpoints.walkUmidHistory(host, STREAM, "u99");
+
+    expect(result.recovered).to.have.length(100);
+    // Hit the cap and the held marker at once - either message is honest,
+    // but it must not claim to have reached the start of the stream.
+    expect(result.stoppedAt).to.not.equal("start of stream");
+  });
+
+  it("replays events even for a umid it already held but whose events went missing", async () => {
+    // Holding the umid does not imply holding its events: separate
+    // documents, and EventEngine.emit() is fire-and-forget.
+    const chain = ["u1", "created"];
+    const { host, replayed } = fakeHost(chain, ["u1", "created"]);
+
+    await Endpoints.walkUmidHistory(host, STREAM, "u1");
+
+    expect(replayed).to.contain("event:1,u1");
+  });
+});

--- a/tests/spi-umid-walk.test.ts
+++ b/tests/spi-umid-walk.test.ts
@@ -551,3 +551,138 @@ describe("Endpoints.walkUmidHistory - pacing", () => {
     expect(elapsed, `walk took ${elapsed}ms, expected pacing`).to.be.greaterThan(100);
   });
 });
+
+/**
+ * Failure containment.
+ *
+ * This runs detached behind every commit, so an escaping error has nowhere
+ * to be caught. Node treats an unhandled rejection as fatal by default, so
+ * a bug in history repair - the least important thing the node does -
+ * could take down a node that was otherwise healthy. That trade is
+ * unacceptable in both directions: history is worth having, and it is
+ * never worth a node for.
+ *
+ * Every layer is made to throw in turn, and the assertion is the same each
+ * time: the call resolves, the process sees no unhandled rejection, and
+ * the guard is released so the umid is not wedged.
+ */
+describe("Endpoints - history repair cannot take the node down", () => {
+  const STREAM_D = "cccc1c9e5b2d4a6c8e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5ecc";
+
+  /** Fails at exactly one layer, works everywhere else. */
+  function brokenAt(layer: string): any {
+    const doc = (umid: string) => ({
+      _id: `${umid}:umid`,
+      umid: { $umid: umid },
+      events: [{ _id: `event:1,${umid}`, name: "E", data: {} }],
+      streams: { new: [], updated: [{ id: STREAM_D, prev: `${umid}-prev` }] },
+    });
+
+    return {
+      dbConnection: {
+        get: async (id: string) => {
+          if (layer === "get") throw new Error("store unreachable");
+          if (layer === "get-returns-junk") return { nonsense: true };
+          if (layer === "get-returns-null") return null;
+          throw new Error("not found");
+        },
+        bulkDocs: async () => {
+          if (layer === "bulkDocs") throw new Error("disk full");
+          if (layer === "bulkDocs-junk") return undefined;
+          return { ok: true };
+        },
+      },
+      dbEventConnection: {
+        post: async () => {
+          if (layer === "eventPost") throw new Error("event store gone");
+          return { ok: true };
+        },
+      },
+      neighbourhood: {
+        knockAll: async (endpoint: string) => {
+          if (layer === "knockAll") throw new Error("network partitioned");
+          if (layer === "knockAll-junk") return [null, undefined, 42, "nope"];
+          if (layer === "knockAll-empty") return [];
+          return [doc(endpoint.replace("umid/", ""))];
+        },
+      },
+    };
+  }
+
+  /** Runs fn while watching for any unhandled rejection it causes. */
+  async function withRejectionWatch(fn: () => Promise<void>): Promise<string[]> {
+    const seen: string[] = [];
+    const onUnhandled = (reason: any) => seen.push(String(reason));
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      await fn();
+      // Give a detached promise a turn to reject if it is going to
+      await new Promise((r) => setTimeout(r, 50));
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+    return seen;
+  }
+
+  const layers = [
+    "get",
+    "get-returns-junk",
+    "get-returns-null",
+    "bulkDocs",
+    "bulkDocs-junk",
+    "eventPost",
+    "knockAll",
+    "knockAll-junk",
+    "knockAll-empty",
+  ];
+
+  for (const layer of layers) {
+    it(`survives a failure in ${layer}`, async () => {
+      const host = brokenAt(layer);
+      const umid = `fail-${layer}-${Date.now()}`;
+
+      const rejections = await withRejectionWatch(async () => {
+        // Both entry points, since both run detached in production
+        await Endpoints.repairHistoryAfterCommit(host, umid);
+        await Endpoints.walkUmidHistory(host, STREAM_D, `${umid}-start`);
+        await Endpoints.backfillUmid(host, `${umid}-b`);
+      });
+
+      expect(rejections, `unhandled rejection from ${layer}`).to.have.length(0);
+    });
+  }
+
+  it("survives a host missing the connections entirely", async () => {
+    // Defensive rather than expected - but a partially constructed host
+    // during startup or shutdown should not be fatal either.
+    const rejections = await withRejectionWatch(async () => {
+      await Endpoints.repairHistoryAfterCommit({} as any, `bare-${Date.now()}`);
+      await Endpoints.walkUmidHistory({} as any, STREAM_D, `bare2-${Date.now()}`);
+      await Endpoints.backfillUmid({} as any, `bare3-${Date.now()}`);
+    });
+
+    expect(rejections).to.have.length(0);
+  });
+
+  it("releases the in-flight guard after a failure, so the umid is not wedged", async () => {
+    const host = brokenAt("knockAll");
+    const umid = `wedge-${Date.now()}`;
+
+    await Endpoints.repairHistoryAfterCommit(host, umid);
+
+    // A second umid must still be able to run - if the guard leaked, the
+    // set would be growing but this would still pass, so also check the
+    // first umid is no longer marked in flight by running it again after
+    // clearing its cooldown.
+    (Endpoints as any).historyRepairLastRun.delete(umid);
+    let threw = false;
+    try {
+      await Endpoints.repairHistoryAfterCommit(host, umid);
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).to.equal(false);
+    expect((Endpoints as any).historyRepairInFlight.has(umid)).to.equal(false);
+  });
+});

--- a/tests/spi-umid-walk.test.ts
+++ b/tests/spi-umid-walk.test.ts
@@ -94,6 +94,18 @@ function fakeHost(chain: string[], held: string[] = [], opts: any = {}) {
 }
 
 describe("Endpoints.walkUmidHistory - recovering a stream's missed history", () => {
+  // The walk paces itself between hops so it never competes with live
+  // traffic. That is the point in production and pure dead time here, so
+  // it is turned off for the cases about WHAT the walk does, and verified
+  // on its own below.
+  const realDelay = Endpoints.UMID_WALK_HOP_DELAY_MS;
+  before(() => {
+    Endpoints.UMID_WALK_HOP_DELAY_MS = 0;
+  });
+  after(() => {
+    Endpoints.UMID_WALK_HOP_DELAY_MS = realDelay;
+  });
+
   it("walks back through every umid the node is missing", async () => {
     // Node holds nothing; the network has four transactions plus a creation
     const chain = ["u4", "u3", "u2", "u1", "created"];
@@ -331,5 +343,211 @@ describe("Endpoints.walkUmidHistory - recovering a stream's missed history", () 
     await Endpoints.walkUmidHistory(host, STREAM, "u1");
 
     expect(replayed).to.contain("event:1,u1");
+  });
+});
+
+/**
+ * The post-commit trigger, and the guards around it.
+ *
+ * This runs after every commit, so its cost and its concurrency behaviour
+ * matter more than its happy path. It must never run twice over the same
+ * umid at once, must not put a network call in front of every transaction,
+ * and must never let a failure wedge a umid so it is skipped forever.
+ */
+describe("Endpoints.repairHistoryAfterCommit - guards", () => {
+  const STREAM_B = "aaaa1c9e5b2d4a6c8e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5eaa";
+
+  /** Counts network calls, so "does not run twice" is measured not assumed. */
+  // The cooldown map is static and survives between tests, so every test
+  // needs its own umid. An earlier version shared one and the second test
+  // silently measured nothing because the first had already put it in
+  // cooldown - a pass that proved the opposite of what it claimed.
+  let counter = 0;
+  function guardHost(opts: any = {}) {
+    const calls = { knockAll: 0 };
+    const store = new Map<string, any>();
+    const id = `committed-${Date.now()}-${counter++}`;
+    const missing = `${id}-missing`;
+    const committed = {
+      _id: `${id}:umid`,
+      umid: { $umid: id },
+      streams: { new: [], updated: [{ id: STREAM_B, prev: missing }] },
+    };
+    store.set(`${id}:umid`, committed);
+
+    return {
+      id,
+      missing,
+      calls,
+      store,
+      host: {
+        dbConnection: {
+          get: async (id: string) => {
+            if (!store.has(id)) throw new Error("not found");
+            return store.get(id);
+          },
+          bulkDocs: async (docs: any[]) => {
+            for (const doc of docs) store.set(doc._id, doc);
+            return { ok: true };
+          },
+        },
+        dbEventConnection: { post: async () => ({ ok: true }) },
+        neighbourhood: {
+          knockAll: async (endpoint: string) => {
+            calls.knockAll++;
+            if (opts.throwOnKnock) throw new Error("network down");
+            const umid = endpoint.replace("umid/", "");
+            if (umid === id) return [committed, committed];
+            // Anything older is a creation, so the walk terminates
+            return [
+              {
+                _id: `${umid}:umid`,
+                umid: { $umid: umid },
+                streams: { new: [{ id: STREAM_B, name: "c" }], updated: [] },
+              },
+            ];
+          },
+        },
+      } as any,
+    };
+  }
+
+  // Each test uses its own umid so the shared cooldown map cannot make one
+  // test's run silence the next - which it would, and which would look
+  // like a passing test that never ran.
+  const freshUmid = () => `commit-${Date.now()}-${Math.random()}`;
+
+  it("recovers the gap behind a commit", async () => {
+    const { host, store, id, missing } = guardHost();
+    await Endpoints.repairHistoryAfterCommit(host, id);
+    expect(store.has(`${missing}:umid`)).to.equal(true);
+  });
+
+  it("does not run twice for the same umid at the same time", async () => {
+    const { host, calls, id } = guardHost();
+
+    // Fire several concurrently, as repeated commits on a hot stream would
+    await Promise.all([
+      Endpoints.repairHistoryAfterCommit(host, id),
+      Endpoints.repairHistoryAfterCommit(host, id),
+      Endpoints.repairHistoryAfterCommit(host, id),
+    ]);
+
+    // One walk's worth of network traffic, not three
+    expect(calls.knockAll).to.be.greaterThan(0);
+    const afterFirstBurst = calls.knockAll;
+
+    await Promise.all([
+      Endpoints.repairHistoryAfterCommit(host, id),
+      Endpoints.repairHistoryAfterCommit(host, id),
+    ]);
+
+    // Still inside the cooldown, so nothing new went out
+    expect(calls.knockAll).to.equal(afterFirstBurst);
+  });
+
+  it("stays quiet on repeated commits of the same umid", async () => {
+    const { host, calls, id } = guardHost();
+
+    await Endpoints.repairHistoryAfterCommit(host, id);
+    const first = calls.knockAll;
+
+    for (let i = 0; i < 20; i++) {
+      await Endpoints.repairHistoryAfterCommit(host, id);
+    }
+
+    expect(calls.knockAll, "a busy stream must not broadcast per commit").to.equal(first);
+  });
+
+  it("does nothing at all without a umid", async () => {
+    const { host, calls } = guardHost();
+    await Endpoints.repairHistoryAfterCommit(host, "");
+    expect(calls.knockAll).to.equal(0);
+  });
+
+  it("releases the guard when the walk throws, so the umid is not wedged forever", async () => {
+    // A failure that left the in-flight marker set would silently disable
+    // repair for that umid for the life of the process.
+    const failing = guardHost({ throwOnKnock: true });
+    const umid = freshUmid();
+
+    await Endpoints.repairHistoryAfterCommit(failing.host, umid);
+
+    // Second attempt is blocked by the cooldown, not by a stuck marker -
+    // prove the marker itself cleared by using a different umid on the same
+    // in-flight set.
+    const other = freshUmid();
+    await Endpoints.repairHistoryAfterCommit(failing.host, other);
+
+    expect(failing.calls.knockAll, "both attempts reached the network").to.equal(2);
+  });
+
+  it("never rejects, whatever the network does", async () => {
+    // It is detached from the transaction path; an unhandled rejection here
+    // would surface as a process-level warning at best.
+    const { host } = guardHost({ throwOnKnock: true });
+    const umid = freshUmid();
+
+    let threw = false;
+    try {
+      await Endpoints.repairHistoryAfterCommit(host, umid);
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).to.equal(false);
+  });
+});
+
+describe("Endpoints.walkUmidHistory - pacing", () => {
+  const STREAM_C = "bbbb1c9e5b2d4a6c8e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5ebb";
+
+  it("paces itself between hops, so a long walk never becomes a burst", async () => {
+    // These are old umids. Live transactions and current stream data are
+    // what matter, so the walk is deliberately unhurried - late repair,
+    // never no repair.
+    const chain = ["c3", "c2", "c1", "created"];
+    const store = new Map<string, any>();
+    const docFor = (umid: string) => {
+      const i = chain.indexOf(umid);
+      const prev = chain[i + 1];
+      return {
+        _id: `${umid}:umid`,
+        umid: { $umid: umid },
+        events: [],
+        streams: prev
+          ? { new: [], updated: [{ id: STREAM_C, prev }] }
+          : { new: [{ id: STREAM_C, name: "c" }], updated: [] },
+      };
+    };
+    const host: any = {
+      dbConnection: {
+        get: async (id: string) => {
+          if (!store.has(id)) throw new Error("not found");
+          return store.get(id);
+        },
+        bulkDocs: async (docs: any[]) => {
+          for (const d of docs) store.set(d._id, d);
+          return { ok: true };
+        },
+      },
+      dbEventConnection: { post: async () => ({ ok: true }) },
+      neighbourhood: {
+        knockAll: async (endpoint: string) => {
+          const doc = docFor(endpoint.replace("umid/", ""));
+          return doc ? [doc, doc] : [];
+        },
+      },
+    };
+
+    Endpoints.UMID_WALK_HOP_DELAY_MS = 40;
+    const start = Date.now();
+    const result = await Endpoints.walkUmidHistory(host, STREAM_C, "c3");
+    const elapsed = Date.now() - start;
+    Endpoints.UMID_WALK_HOP_DELAY_MS = 50;
+
+    expect(result.recovered).to.have.length(4);
+    // Three gaps between four hops, so at least ~120ms of deliberate pause
+    expect(elapsed, `walk took ${elapsed}ms, expected pacing`).to.be.greaterThan(100);
   });
 });


### PR DESCRIPTION
SPI adopts a stream's current revision, which leaves a node with correct state
and **no record of how it got there** — no umids, and none of the events those
transactions raised. The most recent one was recoverable because the `:stream`
meta names it. Everything before it was not: nothing could enumerate what had
been skipped.

It can now, **without a list**.

## The chain

Each transaction records the umid it replaced, per stream:

```
:stream meta -> U0 --prev--> U1 --prev--> U2 -> ... -> creation
```

A list per stream was tried before — `meta.txs` — and abandoned because it grew
without limit on any busy stream, costing space, memory and speed at once.

This is **one field on the umid document**, which is written once for that
transaction and never appended to. A stream updated a million times produces a
million documents each holding *one* pointer, rather than one document holding a
million entries. Storage per transaction is constant.

The walk fetches only the hops actually missing and stops at the first umid
already held — one or two hops in the common case. It also stops at a creation,
a broken chain, a write failure, a loop, or `UMID_WALK_LIMIT` of 100.

## Not on the client path

Started, never awaited. Nothing in the triggering transaction depends on history
being back, so making the client wait would trade real latency for no
correctness gain. Fire-and-forget is only defensible because a failed walk still
writes the 950 — restore picks it up and the work survives a crash. The fast
path is an optimisation over a durable one, not a replacement.

## The trigger is the commit, not SPI

SPI is not the only way a node adopts state it did not derive. A node that was
down rejoins, takes part in the next round, and ends up holding the network's
revision through an ordinary commit — correct and wanted. But it writes **one**
umid and has nothing for the fifty before it.

Measured rather than assumed: the node sat at `1-a5760daa` while the network was
at 51, then read 52 everywhere after a single transaction, **with no SPI line
anywhere**. So the trigger moved onto `host.ts`'s `commited` case, which runs
after `pending.resolve()`.

## A flaw in my own design, and the fix

That still didn't work. `prev` is captured at commit time from the node's **own**
`:stream` meta — so on a node that was behind it points at whatever that node
last believed, not at the transaction the network superseded. Exactly backwards
on the only node that needs the chain.

The SPI path never hit this because it walks *peers'* umid documents. The
post-commit path read the local copy, making it a no-op in precisely the case it
was written for. It now takes `prev` from the majority copy — the same source
the walk itself uses.

| | umids | events |
|---|---|---|
| before | 0/50 | 0 |
| after | **50/50** | **all 50** |

The 3-transaction check moved with it, 0/3 → 3/3.

## Tests

**13 unit cases** drive every way the walk can stop: a full gap to creation,
stopping at a held umid, the cap exactly and beyond, an unreachable hop, a write
failure, a loop, and following the right pointer when a transaction touched
several streams. A 50-hop gap recovers all 50 umids with all 50 events, each
replayed exactly once.

Three of those earned their place by failing first. Two because my fixtures
pre-seeded the umid, so the walk correctly stopped at "already held" before
reaching the behaviour under test. The third caught a **real regression**: the
walk's own held-check bypassed the event replay inside `backfillUmid`, silently
removing repair that existed before. Holding a umid does not imply holding its
events.

**Live:** a 50-transaction gap with an event on every one, verified across
repeated runs.

- **303 unit tests passing**
- **Harness green**, 50/50 with events, reproducible