### PR TITLE
fix: the history-repair cooldown was keyed by something that never repeats

### DIFF
--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -2248,24 +2248,56 @@ export class Endpoints {
     // And the check itself is not free: it asks the network for the umid
     // just written, which on a healthy node finds nothing missing. Doing
     // that per commit would add a broadcast per transaction to a path that
-    // was previously silent. The cooldown makes it per stream per window
+    // was previously silent. The cooldown makes it per STREAM per window
     // instead, which keeps a busy stream quiet while still noticing a gap
     // within seconds of one appearing.
     //
     // Skipping is always safe: a gap does not heal itself, so the next
     // commit after the window finds it. Late repair, never no repair.
+    //
+    // The in-flight guard is keyed by umid because it is about one walk not
+    // running twice. The cooldown must NOT be - a umid is a hash of the
+    // whole transaction, so every commit brings a key that has never been
+    // seen, the lookup always misses and the branch never runs. Keyed that
+    // way it rate limited nothing at all and every commit still broadcast.
+    // The streams are what repeat, so the streams are what to count.
     if (Endpoints.historyRepairInFlight.has(umid)) {
       return Promise.resolve();
     }
-    const lastRun = Endpoints.historyRepairLastRun.get(umid) || 0;
-    if (Date.now() - lastRun < Endpoints.HISTORY_REPAIR_COOLDOWN_MS) {
-      return Promise.resolve();
-    }
     Endpoints.historyRepairInFlight.add(umid);
-    Endpoints.historyRepairLastRun.set(umid, Date.now());
 
     return (async () => {
       try {
+        // Which streams did this transaction touch? Read that locally -
+        // the stream ids in our own copy are correct even on a node that
+        // was behind; only `prev` is stale, which is why the authoritative
+        // fetch below still happens. Doing it in this order means a stream
+        // inside its cooldown costs one local read and no network at all.
+        let localStreams: string[] = [];
+        try {
+          const localDoc = await host.dbConnection.get(`${umid}:umid`);
+          localStreams = (localDoc?.streams?.updated || [])
+            .map((entry: any) => entry?.id)
+            .filter(Boolean);
+        } catch {
+          // No local copy - fall through and let the network decide
+        }
+
+        if (localStreams.length) {
+          const now = Date.now();
+          const due = localStreams.filter(
+            (id) =>
+              now - (Endpoints.historyRepairLastRun.get(id) || 0) >=
+              Endpoints.HISTORY_REPAIR_COOLDOWN_MS
+          );
+          if (!due.length) {
+            return;
+          }
+          for (const id of due) {
+            Endpoints.historyRepairLastRun.set(id, now);
+          }
+        }
+
         // Deliberately NOT the local copy.
         //
         // `prev` is captured at commit time from the node's own :stream

--- a/tests/spi-umid-walk.test.ts
+++ b/tests/spi-umid-walk.test.ts
@@ -355,7 +355,15 @@ describe("Endpoints.walkUmidHistory - recovering a stream's missed history", () 
  * and must never let a failure wedge a umid so it is skipped forever.
  */
 describe("Endpoints.repairHistoryAfterCommit - guards", () => {
-  const STREAM_B = "aaaa1c9e5b2d4a6c8e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5eaa";
+  // Each fixture gets its OWN stream. The cooldown is per stream, so
+  // sharing one would make each test silence the next - which is correct
+  // behaviour and a useless test.
+  let streamCounter = 0;
+
+  beforeEach(() => {
+    (Endpoints as any).historyRepairLastRun.clear();
+    (Endpoints as any).historyRepairInFlight.clear();
+  });
 
   /** Counts network calls, so "does not run twice" is measured not assumed. */
   // The cooldown map is static and survives between tests, so every test
@@ -368,6 +376,7 @@ describe("Endpoints.repairHistoryAfterCommit - guards", () => {
     const store = new Map<string, any>();
     const id = `committed-${Date.now()}-${counter++}`;
     const missing = `${id}-missing`;
+    const STREAM_B = `bbbb${streamCounter++}c9e5b2d4a6c8e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5eaa`;
     const committed = {
       _id: `${id}:umid`,
       umid: { $umid: id },
@@ -684,5 +693,109 @@ describe("Endpoints - history repair cannot take the node down", () => {
 
     expect(threw).to.equal(false);
     expect((Endpoints as any).historyRepairInFlight.has(umid)).to.equal(false);
+  });
+});
+
+/**
+ * The cooldown has to be keyed by something that REPEATS.
+ *
+ * It was keyed by umid, which is a hash of the whole transaction - so every
+ * commit brought a key that had never been seen, the lookup always missed,
+ * and the rate limit never once applied. Every commit still broadcast to
+ * every peer, which is precisely the cost the cooldown was added to remove.
+ *
+ * The existing guard tests did not catch it because they reused one umid,
+ * which is the one thing production never does. These use a fresh umid per
+ * commit, as real traffic does, and count what reaches the network.
+ */
+describe("Endpoints.repairHistoryAfterCommit - the cooldown must be per stream", () => {
+  const HOT = "dddd1c9e5b2d4a6c8e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5edd";
+  const OTHER = "eeee1c9e5b2d4a6c8e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5eee";
+
+  /** A node holding every umid, so nothing needs repairing - the common case. */
+  function healthyHost(streamId: string) {
+    const calls = { knockAll: 0 };
+    const store = new Map<string, any>();
+    const host: any = {
+      dbConnection: {
+        get: async (id: string) => {
+          if (store.has(id)) return store.get(id);
+          throw new Error("not found");
+        },
+        bulkDocs: async () => ({ ok: true }),
+      },
+      dbEventConnection: { post: async () => ({ ok: true }) },
+      neighbourhood: {
+        knockAll: async () => {
+          calls.knockAll++;
+          return [];
+        },
+      },
+    };
+    // Each commit writes its own umid doc naming the same stream
+    const commit = (umid: string, prev: string) => {
+      store.set(`${umid}:umid`, {
+        _id: `${umid}:umid`,
+        umid: { $umid: umid },
+        streams: { new: [], updated: [{ id: streamId, prev }] },
+      });
+      // the node holds the previous one, so there is no gap to repair
+      store.set(`${prev}:umid`, { _id: `${prev}:umid`, streams: { new: [], updated: [] } });
+    };
+    return { calls, host, commit };
+  }
+
+  beforeEach(() => {
+    (Endpoints as any).historyRepairLastRun.clear();
+    (Endpoints as any).historyRepairInFlight.clear();
+  });
+
+  it("stays quiet across many commits on one stream, each with its own umid", async () => {
+    // The real shape of a busy stream: twenty transactions, twenty distinct
+    // umids, one stream. Keyed by umid this broadcast twenty times.
+    const { host, calls, commit } = healthyHost(HOT);
+
+    for (let i = 0; i < 20; i++) {
+      const umid = `hot-tx-${i}`;
+      commit(umid, `hot-prev-${i}`);
+      await Endpoints.repairHistoryAfterCommit(host, umid);
+    }
+
+    expect(
+      calls.knockAll,
+      `broadcast ${calls.knockAll} times for one stream - the cooldown is not holding`
+    ).to.be.at.most(1);
+  });
+
+  it("still checks a different stream straight away", async () => {
+    // Rate limiting one stream must not silence another - a gap on a quiet
+    // stream should be noticed on its very first commit.
+    const first = healthyHost(HOT);
+    first.commit("a-1", "a-prev");
+    await Endpoints.repairHistoryAfterCommit(first.host, "a-1");
+
+    const second = healthyHost(OTHER);
+    second.commit("b-1", "b-prev");
+    await Endpoints.repairHistoryAfterCommit(second.host, "b-1");
+
+    expect(second.calls.knockAll, "an unrelated stream was silenced").to.be.greaterThan(0);
+  });
+
+  it("checks again once the window has passed", async () => {
+    // Skipping only ever delays a repair, so the window must actually reopen.
+    const { host, calls, commit } = healthyHost(HOT);
+
+    commit("w-1", "w-prev");
+    await Endpoints.repairHistoryAfterCommit(host, "w-1");
+    const afterFirst = calls.knockAll;
+
+    // Age the recorded time past the window rather than waiting 30s
+    const cooldown = (Endpoints as any).HISTORY_REPAIR_COOLDOWN_MS;
+    (Endpoints as any).historyRepairLastRun.set(HOT, Date.now() - cooldown - 1000);
+
+    commit("w-2", "w-prev2");
+    await Endpoints.repairHistoryAfterCommit(host, "w-2");
+
+    expect(calls.knockAll).to.be.greaterThan(afterFirst);
   });
 });


### PR DESCRIPTION
Found by the cloud review, and it invalidates a claim I made when the guard
went in.

## The bug

The cooldown was keyed by `umid`:

```js
const lastRun = Endpoints.historyRepairLastRun.get(umid) || 0;
if (Date.now() - lastRun < HISTORY_REPAIR_COOLDOWN_MS) return;
```

A umid is `getHash(JSON.stringify(tx))` — **unique to that transaction**. Every
commit brings a key that has never been seen, the lookup always misses, the
branch never runs.

The comment above it read *"per stream per window, which keeps a busy stream
quiet."* It was per umid, which is per nothing. So every successful commit still
ran `knockAll` to every peer — precisely the broadcast-per-transaction cost the
cooldown was added to remove, on a path that was previously silent.

## The fix

Keyed per **stream**, with the stream ids read from the **local** umid document
first. Those are correct even on a node that was behind — only `prev` is stale
there, which is why the authoritative fetch still happens afterwards. In that
order, a stream inside its window costs one local read and **no network at all**.

The in-flight guard stays keyed by umid: that one is about a single walk not
running twice, and a umid is the right identity for it.

## Why the existing tests missed it

They reused one umid across a burst — the one thing production never does. So
they measured the in-flight guard and never the cooldown at all.

The new tests commit twenty times with a **fresh umid each**, as real traffic
does, and count what reaches the network. Run against the old keying:

```
broadcast 20 times for one stream - the cooldown is not holding
```

They also cover that an unrelated stream isn't silenced by another's window, and
that the window genuinely reopens — skipping must only ever delay a repair,
never prevent one.

The guard fixtures needed a stream each: with a per-stream cooldown, a shared
one makes every test silence the next. Correct behaviour, useless test.

## Verification

- Build clean, unit suite green
- 4-node harness still recovering 50/50 umids with all 50 events
- New tests confirmed to **fail against the previous keying**