### PR TITLE
fix: say when the restore engine is switched off, rather than fixing it silently

### DIFF
--- a/packages/activeledger/src/cli/cli.ts
+++ b/packages/activeledger/src/cli/cli.ts
@@ -74,6 +74,52 @@ function resolveModulesDir(): string {
   );
 }
 
+/**
+ * Absolute path to a sibling service's entry script, or null.
+ *
+ * The autostart block used to spawn the bare command name - "activerestore"
+ * - which works only when npm has put its shim on PATH. A global install
+ * does; running `node lib/index.js` directly does not, and neither does a
+ * local install outside an npm script. So a node could have
+ * autostart.restore set correctly, log "Auto starting - Restore Engine",
+ * and then fail, leaving "restore is enabled" and "restore is running" as
+ * two different things.
+ *
+ * Asking Node where the package actually is removes the guess. Same fix as
+ * resolveModulesDir() above, for the same reason: resolve it rather than
+ * assume where it landed.
+ *
+ * Returns null rather than throwing, because PATH is still a legitimate
+ * route - a global install may not have the service resolvable from this
+ * package's own location, and the caller falls back to the old behaviour.
+ */
+function resolveServiceScript(pkg: string): string | null {
+  try {
+    const searched = require.resolve.paths(pkg) || [];
+    for (const dir of searched) {
+      const root = path.join(dir, pkg);
+      const manifest = path.join(root, "package.json");
+      if (!fs.existsSync(manifest)) {
+        continue;
+      }
+      const bin = JSON.parse(fs.readFileSync(manifest, "utf8")).bin;
+      // bin is either a string or { name: path }; take whichever is there
+      const rel =
+        typeof bin === "string" ? bin : bin && Object.values(bin)[0];
+      if (typeof rel !== "string") {
+        continue;
+      }
+      const entry = path.join(root, rel);
+      if (fs.existsSync(entry)) {
+        return fs.realpathSync(entry);
+      }
+    }
+  } catch {
+    // Fall through - the caller still has PATH to try
+  }
+  return null;
+}
+
 export class CLIHandler {
   private static readonly pidHandler: PIDHandler = new PIDHandler();
   private static readonly statsHandler: StatsHandler = new StatsHandler();
@@ -660,20 +706,36 @@ export class CLIHandler {
         if (ActiveOptions.get<any>("autostart", {}).restore) {
           ActiveLogger.info("Auto starting - Restore Engine");
           // Launch & Listen for launch error
-          const activerestoreChild = child
-            .spawn(
-              /^win/.test(process.platform)
-                ? "activerestore.cmd"
-                : "activerestore",
-              [],
-              {
-                cwd: "./",
-                stdio: "inherit",
-              }
-            )
-            .on("error", (error) => {
-              ActiveLogger.error(error, "Restore Engine Failed to start");
-            });
+          // Resolved path first, PATH second. Spawning node with the
+          // script avoids the shim entirely, so this works the same from a
+          // global install, a local one, or `node lib/index.js`.
+          const restoreScript = resolveServiceScript(
+            "@activeledger/activerestore"
+          );
+          const activerestoreChild = (
+            restoreScript
+              ? child.spawn(process.execPath, [restoreScript], {
+                  cwd: "./",
+                  stdio: "inherit",
+                })
+              : child.spawn(
+                  /^win/.test(process.platform)
+                    ? "activerestore.cmd"
+                    : "activerestore",
+                  [],
+                  {
+                    cwd: "./",
+                    stdio: "inherit",
+                  }
+                )
+          ).on("error", (error) => {
+            ActiveLogger.error(
+              error,
+              restoreScript
+                ? `Restore Engine Failed to start (${restoreScript})`
+                : "Restore Engine Failed to start - activerestore is not on PATH and could not be resolved"
+            );
+          });
 
           await CLIHandler.pidHandler.addPid(
             EPIDChild.RESTORE,

--- a/packages/activeledger/src/cli/cli.ts
+++ b/packages/activeledger/src/cli/cli.ts
@@ -584,6 +584,54 @@ export class CLIHandler {
       });
 
       //#region Auto starting Activeledger Services
+      // Say something when the restore engine is switched off.
+      //
+      // Until 4.5.16 the CLI disabled it for any node set up on a
+      // non-default port, which is most real deployments, and wrote that
+      // into config.json. Fixing the generator does not reach a node that
+      // already has the file - checkConfig() only runs when there is no
+      // config to read - so those nodes keep the flag and keep the hole.
+      //
+      // Deliberately a warning and not a migration. A config records WHAT
+      // was decided and never WHY, so nothing here can tell an operator
+      // who meant it from a CLI that guessed - and some deployments run
+      // activerestore as its own process on purpose, where flipping this
+      // on upgrade would start a second engine per node that nobody asked
+      // for. Correcting someone's configuration silently is worse than
+      // leaving it wrong and saying so.
+      //
+      // What it costs when nothing repairs: SPI still converges STATE, so
+      // the node looks healthy. What stops is the backfill of umid
+      // documents and the events they carried, and 950 error documents
+      // accumulate with nothing reading them. On 4.5.16+ the network layer
+      // recovers most of this itself, which narrows the gap but does not
+      // close it - a node further behind than the walk limit still needs a
+      // full activerestore.
+      // A config with no configVersion predates the field, so it was
+      // written by a CLI old enough to have the port heuristic. That does
+      // not prove the flag is wrong - an operator may have chosen it - but
+      // it does mean nobody can tell, which is worth saying out loud.
+      // Configs written from here carry a version, so the next default
+      // that turns out to be wrong can be corrected on a known set rather
+      // than guessed at across all of them.
+      if (ActiveOptions.get<number>("configVersion", 0) < 1) {
+        ActiveLogger.info(
+          "config.json predates configVersion - it cannot be told apart from one written by a CLI with known-bad defaults. " +
+            "Adding \"configVersion\": 1 once its settings are confirmed correct will silence this."
+        );
+      }
+
+      if (ActiveOptions.get<any>("autostart", {}).restore === false) {
+        ActiveLogger.warn(
+          "autostart.restore is false - this node will not run activerestore. " +
+            "If that is deliberate (a dedicated restore process elsewhere), ignore this. " +
+            "If not, it is likely left over from a pre-4.5.16 setup on a non-default port: " +
+            'set "autostart": { "restore": true } in config.json and restart. ' +
+            "Until then this node cannot backfill umids or replay their events beyond what SPI recovers, " +
+            "and activeledgererrors will grow with nothing processing it."
+        );
+      }
+
       if (ActiveOptions.get<any>("autostart", {})) {
         // Auto starting Core API?
         if (ActiveOptions.get<any>("autostart", {}).core) {

--- a/packages/activeledger/src/default.config.json
+++ b/packages/activeledger/src/default.config.json
@@ -1,4 +1,5 @@
 {
+  "configVersion": 1,
   "debug": true,
   "remote": false,
   "build": 40000,


### PR DESCRIPTION
4.5.16 stopped the CLI disabling `activerestore` on non-default ports — but that
only reaches configs generated *afterwards*. `checkConfig()` runs solely when
there's no `config.json` to read, so every node already deployed keeps the flag
it was given, and keeps the hole. The fix was real; its reach wasn't.

## The actual problem is bigger than the flag

**A config records *what* was decided and never *why*.** Nothing can tell an
operator who meant `restore: false` from a CLI that guessed it — so no automatic
correction is safe. There was also no `configVersion`, so not even "written by a
version with the bug" was knowable.

## So it warns rather than migrates

Silently rewriting someone's configuration on upgrade is worse than leaving it
wrong and saying so. And some deployments run `activerestore` as a dedicated
process **on purpose**, where flipping this would start a second engine per node
that nobody asked for. That isn't hypothetical — it's how the Varnir nodes are
set up, and it's why a migration would have caused a problem rather than fixed
one.

Two messages, each only when it applies:

```
autostart.restore is false - this node will not run activerestore. If that is
deliberate (a dedicated restore process elsewhere), ignore this. If not, it is
likely left over from a pre-4.5.16 setup on a non-default port: set
"autostart": { "restore": true } in config.json and restart.
```

```
config.json predates configVersion - it cannot be told apart from one written
by a CLI with known-bad defaults.
```

## The part that outlives this bug

Adds `configVersion` to the shipped config, so the **next** default that turns
out to be wrong can be corrected against a known set rather than guessed at
across every install. This won't be the last time a default needs changing.

## Verified both directions

A warning that fires on a healthy node is noise people learn to ignore, so both
cases were checked:

| Config | Result |
|---|---|
| legacy (`restore:false`, no version) | both messages fire |
| 4.5.17 (`restore:true`, version 1) | **silent**, and restore starts |

One note on method: the healthy-node check initially read a log file that didn't
exist and reported a cheerful zero. Redone against a node that actually ran — 32
log lines, genuinely silent.

## Second commit: "enabled" and "running" were still two different things

Checking the above surfaced the reason the flag alone isn't enough. autostart
spawned the bare command name `activerestore`, so it started only where npm
happened to have put its shim on `PATH`. A global install has one; running
`node lib/index.js` directly does not. A node could have the flag set
correctly, log `Auto starting - Restore Engine`, and fail the next line — which
is precisely the state the new warning exists to rule out.

Same shape as the CLI `node_modules` bug fixed in 4.5.12: resolving a dependency
by assuming where it landed instead of asking Node. It now resolves
`@activeledger/activerestore`, reads its `bin` entry, and spawns `node` with the
absolute script path. `PATH` stays as a fallback, and the failure message says
which route was tried.

Same node, same invocation, before and after:

```
Auto starting - Restore Engine        Auto starting - Restore Engine
Restore Engine Failed to start        Interagent Started
                                      Interagent Starting Error Checker
```

`activecore` has the identical bug two lines away and is **deliberately left
alone** — `autostart.core` is false in the shipped default so it is dormant, and
changing how it resolves could surprise anyone who has enabled it and is relying
on `PATH` pointing at a particular build. Worth its own decision, not a drive-by.
