### PR TITLE
perf: a transaction was 32ms and is now 23ms, and the test gate that hid it

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,101 @@ npm test              # fast unit tests (tests/*.ts, Mocha) - in-process, no rea
 npm run test:network  # live 4-node network integration test - boots real nodes on the local machine
 ```
 
-`npm test` takes a handful of seconds (201 tests today, most of the time being ts-node's transpile pass) and is safe to run constantly during development. It also runs in CI on every push and pull request, on Node 24; the network suite does not, because it boots real nodes.
+`npm test` takes a handful of seconds (324 tests today, most of the time being ts-node's transpile pass) and is safe to run constantly during development. It also runs in CI on every push and pull request, on Node 24; the network suite does not, because it boots real nodes.
 
 `npm run test:network` (`tests/network/`) boots a real 4-node bare-host network, runs 100+ real transactions spread across every node as origin, deploys custom contracts and verifies `returnToRemote()`, verifies live event delivery over SSE, and verifies the network's Stream-Position-Incorrect self-healing by directly desyncing one node's local copy of a stream and confirming a transaction still succeeds whether that node is the transaction's origin or not. It prints live progress and a pass/fail summary, and takes well under a minute. Deliberately bare-host rather than Docker, so it doesn't add any requirements beyond what building the repo already needs.
+
+## Profiling
+
+Two profilers, answering different questions. Both drive the same live harness
+the network tests use, so they measure real nodes rather than a model.
+
+```bash
+npm run profile:tx      # what a transaction costs
+npm run profile:stages  # where that cost sits
+```
+
+### `profile:tx` — what it costs
+
+Varies one thing at a time and prints the effect: network size, key type,
+concurrency, and how a transaction responds to contract work getting heavier.
+
+```
+npm run profile:tx                  # full sweep, a few minutes
+npm run profile:tx -- --quick       # shorter, for a fast before/after
+npm run profile:tx -- --only=1,3    # just sections 1 and 3
+```
+
+The four sections are independent and each boots its own networks:
+
+| | question it answers |
+|---|---|
+| 1 | how much of a transaction is consensus (1 vs 2 vs 4 nodes) |
+| 2 | how much is signature verification (rsa vs secp256k1) |
+| 3 | latency against actual capacity (1 to 128 in flight) |
+| 4 | does the consensus gap grow with contract work, or is it fixed overhead |
+
+Section 4 uses `tests/network/contracts/burn-contract.ts`, which burns a
+caller-specified amount of CPU inside `commit()`. If the gap over a 1-node
+network grows ~1:1 with the burn, the other nodes are repeating the work after
+the origin finishes; if it stays flat, their execution already overlaps and the
+gap is fixed overhead. It is flat.
+
+Reference numbers on a developer machine, p50, so a change can be recognised as
+a change rather than noise — expect ±1-2ms run to run:
+
+```
+1 node 6ms    2 nodes 21ms    4 nodes 22ms    peak ~220 tx/s at 128 in flight
+```
+
+`--quick` is directly comparable to a full run, not a rougher reading of the
+same thing: every network is warmed with eight discarded transactions before
+anything is measured, so contract compilation, the JIT and the connection pools
+have settled. Skipping that put `--quick` at 15/36ms against the full run's
+5/23ms for an identical build, because with a short sample count the stragglers
+land on the p50 instead of the tail.
+
+### `profile:stages` — where it sits
+
+Marks each stage of a transaction and stitches every process that touched it
+into one timeline. A transaction crosses processes — the host parses it, a
+forked worker runs the contract, and on a multi-node network other hosts do the
+same again — so the marks carry an absolute wall-clock timestamp. `hrtime`'s
+epoch is per-process and means nothing across a fork.
+
+```
+npm run profile:stages                        # 4 nodes
+npm run profile:stages -- --nodes=1           # 1 node: the clearest local picture
+npm run profile:stages -- --nodes=4 --runs=20
+```
+
+It prints one full timeline, then the mean cost of every stage transition on the
+origin node, sorted worst-first. Start with `--nodes=1`: on a multi-node run the
+origin also answers knocks about the same transaction from its peers, and the
+waiting-on-peers window dominates everything local.
+
+The marks come from `ActiveTiming` in `@activeledger/activelogger`, which is
+inert unless `ACTIVELEDGER_PROFILE` is set — the profiler sets it for the nodes
+it starts. You can set it yourself against a node you run by hand, but never in
+production: it is one unbounded line of stdout per stage per transaction.
+
+To time something not yet marked, add `ActiveTiming.mark(umid, "your.stage")`
+where you want it and add the name to `ORDER` in `tests/network/profile-stages.ts`
+so it sorts into the right place.
+
+### Two ways to profile the wrong thing
+
+Both of these have produced confident, wrong numbers here:
+
+- **A stale build.** The nodes run `lib/`, not `src/`, so a source change that
+  hasn't been compiled is silently absent from any live measurement — including
+  anything after a `git stash` / build / `git stash pop`. Rebuild, then check the
+  change is actually in the output (`grep` the built file) rather than trusting
+  the build's exit code.
+- **Leftover nodes.** A crashed run can leave nodes holding ports 5510-5540, and
+  the next run measures those instead. `profile:tx` tears its own networks down
+  on failure; if something else dies badly, check with
+  `ss -lntp | grep :55` before believing a surprising result.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,41 @@ The four sections are independent and each boots its own networks:
 | 2 | how much is signature verification (rsa vs secp256k1) |
 | 3 | latency against actual capacity (1 to 128 in flight) |
 | 4 | does the consensus gap grow with contract work, or is it fixed overhead |
+| 5 | what a contended stream costs (N writers against ONE stream) |
+
+Sections 1-4 use independent streams, which is the flattering case: nothing
+ever waits on a lock. Section 5 is the opposite, because most real workloads
+have at least one hot stream — a shared pool, a counter, a registry — and
+writers to it must serialise. Add `--contend-nodes=1` to run it on a single
+node, where nothing else drives the lock queue.
+
+### Measuring a network that isn't on loopback
+
+`AL_SIMULATED_RTT_MS` delays every node-to-node knock, so a four-node harness
+on one machine can be made to behave like four nodes in different regions.
+Half the value is applied per knock, so a request and its reply together cost
+the round trip you ask for.
+
+```bash
+AL_SIMULATED_RTT_MS=60 npm run profile:tx -- --only=1
+```
+
+It matters because every other number here is taken on loopback, where a peer
+is ~0.3ms away and consensus looks nearly free. Measured across 0/20/60/150ms,
+a transaction costs **a fixed ~21ms plus exactly one round trip**, whatever the
+node count:
+
+| RTT | 1 node | 2 nodes | 4 nodes |
+|---|---|---|---|
+| 0ms | 5ms | 19ms | 23ms |
+| 20ms | 6ms | 35ms | 41ms |
+| 60ms | 6ms | 80ms | 81ms |
+| 150ms | 5ms | 171ms | 171ms |
+
+So consensus is one round trip rather than several, extra nodes are close to
+free, and any saving in local work is **absolute, not proportional** — 10ms off
+a transaction is 30% of a same-datacentre one and 6% of an antipodal one. Set
+it only for profiling.
 
 Section 4 uses `tests/network/contracts/burn-contract.ts`, which burns a
 caller-specified amount of CPU inside `commit()`. If the gap over a 1-node

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activeledger-monorepo",
-  "version": "4.5.13",
+  "version": "4.5.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activeledger-monorepo",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "workspaces": [
         "packages/*"
       ],
@@ -1940,9 +1940,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
+      "integrity": "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -2116,16 +2116,16 @@
     },
     "packages/activeledger": {
       "name": "@activeledger/activeledger",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecontracts": "4.5.13",
-        "@activeledger/activecrypto": "4.5.13",
-        "@activeledger/activelogger": "4.5.13",
-        "@activeledger/activenetwork": "4.5.13",
-        "@activeledger/activeoptions": "4.5.13",
-        "@activeledger/activestorage": "4.5.13",
-        "@activeledger/activetoolkits": "4.5.13"
+        "@activeledger/activecontracts": "4.5.17",
+        "@activeledger/activecrypto": "4.5.17",
+        "@activeledger/activelogger": "4.5.17",
+        "@activeledger/activenetwork": "4.5.17",
+        "@activeledger/activeoptions": "4.5.17",
+        "@activeledger/activestorage": "4.5.17",
+        "@activeledger/activetoolkits": "4.5.17"
       },
       "bin": {
         "activeledger": "lib/index.js"
@@ -2138,14 +2138,14 @@
     },
     "packages/contracts": {
       "name": "@activeledger/activecontracts",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecrypto": "4.5.13",
-        "@activeledger/activedefinitions": "4.5.13",
-        "@activeledger/activelogger": "4.5.13",
-        "@activeledger/activequery": "4.5.13",
-        "@activeledger/activeutilities": "4.5.13"
+        "@activeledger/activecrypto": "4.5.17",
+        "@activeledger/activedefinitions": "4.5.17",
+        "@activeledger/activelogger": "4.5.17",
+        "@activeledger/activequery": "4.5.17",
+        "@activeledger/activeutilities": "4.5.17"
       },
       "devDependencies": {
         "@types/node": "24.10.1",
@@ -2154,17 +2154,17 @@
     },
     "packages/core": {
       "name": "@activeledger/activecore",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecrypto": "4.5.13",
-        "@activeledger/activelogger": "4.5.13",
-        "@activeledger/activenetwork": "4.5.13",
-        "@activeledger/activeoptions": "4.5.13",
-        "@activeledger/activequery": "4.5.13",
-        "@activeledger/activestorage": "4.5.13",
-        "@activeledger/activeutilities": "4.5.13",
-        "@activeledger/httpd": "4.5.13"
+        "@activeledger/activecrypto": "4.5.17",
+        "@activeledger/activelogger": "4.5.17",
+        "@activeledger/activenetwork": "4.5.17",
+        "@activeledger/activeoptions": "4.5.17",
+        "@activeledger/activequery": "4.5.17",
+        "@activeledger/activestorage": "4.5.17",
+        "@activeledger/activeutilities": "4.5.17",
+        "@activeledger/httpd": "4.5.17"
       },
       "bin": {
         "activecore": "lib/index.js"
@@ -2176,21 +2176,21 @@
     },
     "packages/crypto": {
       "name": "@activeledger/activecrypto",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activelogger": "4.5.13",
+        "@activeledger/activelogger": "4.5.17",
         "asn1.js": "5.4.1"
       },
       "devDependencies": {
-        "@activeledger/activedefinitions": "4.5.13",
+        "@activeledger/activedefinitions": "4.5.17",
         "@types/node": "24.10.1",
         "typescript": "5.6.3"
       }
     },
     "packages/definitions": {
       "name": "@activeledger/activedefinitions",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
         "@types/events": "^3.0.0"
@@ -2202,11 +2202,11 @@
     },
     "packages/httpd": {
       "name": "@activeledger/httpd",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activelogger": "4.5.13",
-        "@activeledger/activeutilities": "4.5.13",
+        "@activeledger/activelogger": "4.5.17",
+        "@activeledger/activeutilities": "4.5.17",
         "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.67.0"
       },
       "devDependencies": {
@@ -2216,19 +2216,19 @@
     },
     "packages/hybrid": {
       "name": "@activeledger/activehybrid",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecontracts": "4.5.13",
-        "@activeledger/activecrypto": "4.5.13",
-        "@activeledger/activedefinitions": "4.5.13",
-        "@activeledger/activelogger": "4.5.13",
-        "@activeledger/activeoptions": "4.5.13",
-        "@activeledger/activeprotocol": "4.5.13",
-        "@activeledger/activestorage": "4.5.13",
-        "@activeledger/activetoolkits": "4.5.13",
-        "@activeledger/activeutilities": "4.5.13",
-        "@activeledger/httpd": "4.5.13",
+        "@activeledger/activecontracts": "4.5.17",
+        "@activeledger/activecrypto": "4.5.17",
+        "@activeledger/activedefinitions": "4.5.17",
+        "@activeledger/activelogger": "4.5.17",
+        "@activeledger/activeoptions": "4.5.17",
+        "@activeledger/activeprotocol": "4.5.17",
+        "@activeledger/activestorage": "4.5.17",
+        "@activeledger/activetoolkits": "4.5.17",
+        "@activeledger/activeutilities": "4.5.17",
+        "@activeledger/httpd": "4.5.17",
         "typescript": "5.6.3"
       },
       "bin": {
@@ -2241,7 +2241,7 @@
     },
     "packages/logger": {
       "name": "@activeledger/activelogger",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
         "winston": "^3.15.0",
@@ -2254,14 +2254,14 @@
     },
     "packages/nano-gateway": {
       "name": "@activeledger/nano-gateway",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecrypto": "4.5.13",
-        "@activeledger/activedefinitions": "4.5.13",
-        "@activeledger/activelogger": "4.5.13",
-        "@activeledger/activeoptions": "4.5.13",
-        "@activeledger/httpd": "4.5.13",
+        "@activeledger/activecrypto": "4.5.17",
+        "@activeledger/activedefinitions": "4.5.17",
+        "@activeledger/activelogger": "4.5.17",
+        "@activeledger/activeoptions": "4.5.17",
+        "@activeledger/httpd": "4.5.17",
         "typescript": "5.6.3"
       },
       "bin": {
@@ -2274,16 +2274,16 @@
     },
     "packages/network": {
       "name": "@activeledger/activenetwork",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecrypto": "4.5.13",
-        "@activeledger/activedefinitions": "4.5.13",
-        "@activeledger/activelogger": "4.5.13",
-        "@activeledger/activeoptions": "4.5.13",
-        "@activeledger/activeprotocol": "4.5.13",
-        "@activeledger/activequery": "4.5.13",
-        "@activeledger/activeutilities": "4.5.13",
+        "@activeledger/activecrypto": "4.5.17",
+        "@activeledger/activedefinitions": "4.5.17",
+        "@activeledger/activelogger": "4.5.17",
+        "@activeledger/activeoptions": "4.5.17",
+        "@activeledger/activeprotocol": "4.5.17",
+        "@activeledger/activequery": "4.5.17",
+        "@activeledger/activeutilities": "4.5.17",
         "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.67.0"
       },
       "devDependencies": {
@@ -2293,15 +2293,15 @@
     },
     "packages/options": {
       "name": "@activeledger/activeoptions",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activelogger": "4.5.13",
-        "@activeledger/activeutilities": "4.5.13",
+        "@activeledger/activelogger": "4.5.17",
+        "@activeledger/activeutilities": "4.5.17",
         "minimist": "1.2.6"
       },
       "devDependencies": {
-        "@activeledger/activedefinitions": "4.5.13",
+        "@activeledger/activedefinitions": "4.5.17",
         "@types/minimist": "1.2.2",
         "@types/node": "24.10.1",
         "typescript": "5.6.3"
@@ -2322,16 +2322,16 @@
     },
     "packages/protocol": {
       "name": "@activeledger/activeprotocol",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecontracts": "4.5.13",
-        "@activeledger/activecrypto": "4.5.13",
-        "@activeledger/activedefinitions": "4.5.13",
-        "@activeledger/activelogger": "4.5.13",
-        "@activeledger/activeoptions": "4.5.13",
-        "@activeledger/activequery": "4.5.13",
-        "@activeledger/activetoolkits": "4.5.13",
+        "@activeledger/activecontracts": "4.5.17",
+        "@activeledger/activecrypto": "4.5.17",
+        "@activeledger/activedefinitions": "4.5.17",
+        "@activeledger/activelogger": "4.5.17",
+        "@activeledger/activeoptions": "4.5.17",
+        "@activeledger/activequery": "4.5.17",
+        "@activeledger/activetoolkits": "4.5.17",
         "@activeledger/vm2": "^3.9.20",
         "@types/node": "24.10.1",
         "typescript": "5.6.3"
@@ -2339,12 +2339,12 @@
     },
     "packages/query": {
       "name": "@activeledger/activequery",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecrypto": "4.5.13",
-        "@activeledger/activedefinitions": "4.5.13",
-        "@activeledger/activelogger": "4.5.13"
+        "@activeledger/activecrypto": "4.5.17",
+        "@activeledger/activedefinitions": "4.5.17",
+        "@activeledger/activelogger": "4.5.17"
       },
       "devDependencies": {
         "typescript": "5.6.3"
@@ -2352,13 +2352,13 @@
     },
     "packages/restore": {
       "name": "@activeledger/activerestore",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activecrypto": "4.5.13",
-        "@activeledger/activelogger": "4.5.13",
-        "@activeledger/activenetwork": "4.5.13",
-        "@activeledger/activeoptions": "4.5.13",
+        "@activeledger/activecrypto": "4.5.17",
+        "@activeledger/activelogger": "4.5.17",
+        "@activeledger/activenetwork": "4.5.17",
+        "@activeledger/activeoptions": "4.5.17",
         "typescript": "5.6.3"
       },
       "bin": {
@@ -2370,13 +2370,13 @@
     },
     "packages/storage": {
       "name": "@activeledger/activestorage",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activelogger": "4.5.13",
-        "@activeledger/activeoptions": "4.5.13",
-        "@activeledger/activeutilities": "4.5.13",
-        "@activeledger/httpd": "4.5.13",
+        "@activeledger/activelogger": "4.5.17",
+        "@activeledger/activeoptions": "4.5.17",
+        "@activeledger/activeutilities": "4.5.17",
+        "@activeledger/httpd": "4.5.17",
         "classic-level": "^3.0.0"
       },
       "devDependencies": {
@@ -2389,20 +2389,20 @@
     },
     "packages/toolkits": {
       "name": "@activeledger/activetoolkits",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
-        "@activeledger/activeutilities": "4.5.13"
+        "@activeledger/activeutilities": "4.5.17"
       },
       "devDependencies": {
-        "@activeledger/activedefinitions": "4.5.13",
+        "@activeledger/activedefinitions": "4.5.17",
         "@types/node": "24.10.1",
         "typescript": "5.6.3"
       }
     },
     "packages/utilities": {
       "name": "@activeledger/activeutilities",
-      "version": "4.5.13",
+      "version": "4.5.17",
       "license": "MIT",
       "dependencies": {
         "msgpackr": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1940,12 +1940,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.28.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
-      "integrity": "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -2406,7 +2406,7 @@
       "license": "MIT",
       "dependencies": {
         "msgpackr": "^2.0.1",
-        "undici": "^6.28.0"
+        "undici": "^7.29.1"
       },
       "devDependencies": {
         "@types/node": "24.10.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "build:core": "cd ./packages/core/ && npm run build",
     "test": "mocha -r ts-node/register/transpile-only tests/*.ts --exit -- --no-warnings",
     "test:network": "ts-node --transpile-only tests/network/run.ts",
+    "profile:tx": "ts-node --transpile-only tests/network/profile.ts",
+    "profile:stages": "ts-node --transpile-only tests/network/profile-stages.ts",
     "version:set": "node scripts/set-version.mjs"
   },
   "devDependencies": {

--- a/packages/httpd/src/httpd.ts
+++ b/packages/httpd/src/httpd.ts
@@ -268,7 +268,25 @@ export class ActiveHttpd {
   }
 
 
-  public shutdown(): void {
+  /**
+   * Stops listening, then closes the app once in-flight requests have had a
+   * moment to finish.
+   *
+   * exitProcess ends the process afterwards, which is what a node being shut
+   * down wants - there is a SIGKILL coming and anything still open dies with
+   * it either way. It is a parameter because that behaviour is actively
+   * harmful anywhere the server is not the whole process: the timer below
+   * outlives shutdown() by 1.3 seconds and then takes the host process with
+   * it, whatever else that process was doing.
+   *
+   * Which is not hypothetical. tests/httpd.test.ts shut a server down in an
+   * after() hook, and 1.3s later this killed the entire mocha run with
+   * status 0 - mid-suite, so the remaining tests never ran, the reporter's
+   * output was cut off wherever it had got to, and the failure count was
+   * discarded. `npm test` reported success no matter what failed. A test
+   * asserting 1 === 2 was reported as a pass by CI.
+   */
+  public shutdown(exitProcess: boolean = true): void {
     if (this.listenSocket) {
       // Close the listen socket
       us_listen_socket_close(this.listenSocket);
@@ -276,10 +294,19 @@ export class ActiveHttpd {
 
       // Only have a a short while before sigkill
       // Lets try let them finish up then close the app before sigkill can happen
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         this.server.close();
-        process.exit(0);
+        if (exitProcess) {
+          process.exit(0);
+        }
       }, 1300);
+
+      // Don't hold the event loop open for the wait when we aren't going to
+      // end the process anyway - a caller that only wanted the port back
+      // should not be kept alive for another 1.3 seconds by this.
+      if (!exitProcess) {
+        timer.unref?.();
+      }
     }
   }
 

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -392,3 +392,38 @@ export class ActiveLogger {
     return text;
   }
 }
+
+/**
+ * Cross-process transaction timing marks.
+ *
+ * A transaction is not handled in one place - the host process parses it and
+ * holds the locks, a forked worker runs the contract, and on a multi-node
+ * network other hosts do the same again. Wall-clock end-to-end numbers can
+ * say a transaction costs 11ms but not which of those stages it was spent in.
+ *
+ * Marks are written as plain log lines carrying an absolute timestamp, so
+ * lines from different processes (and different nodes) can be sorted into one
+ * timeline afterwards by umid. performance.timeOrigin + performance.now() is
+ * used rather than hrtime because hrtime's epoch is per-process and therefore
+ * meaningless to compare across the fork boundary, and rather than Date.now()
+ * because millisecond resolution is too coarse for stages this short.
+ *
+ * Off unless ACTIVELEDGER_PROFILE is set, costing one boolean test per call.
+ * Never enable it in production: it is unbounded output, one line per stage
+ * per transaction.
+ */
+export class ActiveTiming {
+  public static readonly enabled: boolean = !!process.env.ACTIVELEDGER_PROFILE;
+
+  /**
+   * Records that umid reached a named stage, now.
+   */
+  public static mark(umid: string | undefined, label: string): void {
+    if (!ActiveTiming.enabled || !umid) return;
+    const at = performance.timeOrigin + performance.now();
+    // Written straight to stdout rather than through the logger's own
+    // formatting - this has to stay cheap enough not to distort what it is
+    // measuring, and has to survive whatever log level is configured.
+    process.stdout.write(`[PROF] ${umid} ${label} ${at.toFixed(3)}\n`);
+  }
+}

--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -28,7 +28,7 @@ import {
   ActiveCacheManager,
 } from "@activeledger/activeoptions";
 import { ActiveClone } from "@activeledger/activeutilities";
-import { ActiveLogger } from "@activeledger/activelogger";
+import { ActiveLogger, ActiveTiming } from "@activeledger/activelogger";
 import { ActiveDefinitions } from "@activeledger/activedefinitions";
 import { ActiveCrypto } from "@activeledger/activecrypto";
 import { Host } from "./host";
@@ -146,6 +146,7 @@ export class Endpoints {
             //   tx.$broadcast = true;
             // }
 
+            ActiveTiming.mark(tx.$umid, "http.in");
             ActiveLogger.debug("Client Sent TX : " + tx.$umid);
             // If we got here everything is ok to send into internal
             // Now sending direct reducing http overhead

--- a/packages/network/src/network/host.ts
+++ b/packages/network/src/network/host.ts
@@ -34,7 +34,7 @@ import {
   ActiveClone,
 } from "@activeledger/activeoptions";
 import { ActiveCrypto } from "@activeledger/activecrypto";
-import { ActiveLogger } from "@activeledger/activelogger";
+import { ActiveLogger, ActiveTiming } from "@activeledger/activelogger";
 import { ActiveDefinitions } from "@activeledger/activedefinitions";
 import { Home } from "./home";
 import { Neighbour } from "./neighbour";
@@ -390,6 +390,7 @@ export class Host extends Home {
 
       // Check we don't have it, Process finding may have failed.
       if (!this.processPending[entry.$umid]) {
+        ActiveTiming.mark(entry.$umid, "host.pending");
         // Add to pending (Using Promises instead of http request)
         this.processPending[entry.$umid] = {
           entry,
@@ -406,6 +407,7 @@ export class Host extends Home {
               this.processPending[entry.$umid].finished = true;
             }
             if (!this.processPending[entry.$umid]?.responded) {
+              ActiveTiming.mark(entry.$umid, "host.resolve");
               resolve(response);
 
               try {
@@ -1617,6 +1619,7 @@ export class Host extends Home {
 
       //setTimeout(() => {
       // Pass transaction to sub processor
+      ActiveTiming.mark(v.$umid, "host.dispatch");
       robin.send({
         type: "tx",
         entry: this.processPending[v.$umid].entry,
@@ -2278,6 +2281,7 @@ export class Host extends Home {
         // Write Header 
         // All outputs are JSON and
         if (data.$umid) {
+          ActiveTiming.mark(data.$umid, "http.out");
           const TT = Date.now() - started;
           if (TT > 5) {
             // Only output if umid reduce internal 0ms spam (brtoadcast has to respond now for SPI)

--- a/packages/network/src/network/neighbour.ts
+++ b/packages/network/src/network/neighbour.ts
@@ -44,6 +44,12 @@ const RECOVERY_CHECK_INTERVAL = 3 * 1000;
  * @class Neighbour
  */
 export class Neighbour implements ActiveDefinitions.INeighbourBase {
+  /** See knock(). Profiling affordance, read once at startup. */
+  public static simulatedRttMs: number = Number(
+    process.env.AL_SIMULATED_RTT_MS || 0
+  );
+  private static rttAnnounced = false;
+
   /**
    * Persistent client for P2P messaging
    *
@@ -159,6 +165,27 @@ export class Neighbour implements ActiveDefinitions.INeighbourBase {
     resend?: number, // Max retry attempts for connection resets
     bundle?: boolean // Should this request be bundled?
   ): Promise<any> {
+    // Profiling only: pretend this neighbour is far away.
+    //
+    // Every multi-node measurement is otherwise taken on loopback, where a
+    // node is ~0.3ms away and consensus looks almost free. Real deployments
+    // put nodes in different regions, where one round trip costs more than an
+    // entire local transaction - which changes which costs are worth chasing.
+    // Half the configured round trip is applied per knock, so a request and
+    // its matching reply knock together cost AL_SIMULATED_RTT_MS.
+    //
+    // Inert unless set, and never to be set in production.
+    if (Neighbour.simulatedRttMs > 0) {
+      if (!Neighbour.rttAnnounced) {
+        Neighbour.rttAnnounced = true;
+        ActiveLogger.warn(
+          `SIMULATED RTT ACTIVE: ${Neighbour.simulatedRttMs}ms - profiling only`
+        );
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, Neighbour.simulatedRttMs / 2)
+      );
+    }
     // Persistent P2P Broadcast Path
     if (
       params &&

--- a/packages/network/src/network/process.ts
+++ b/packages/network/src/network/process.ts
@@ -23,7 +23,7 @@
 
 import { ActiveDSConnect, ActiveOptions } from "@activeledger/activeoptions";
 import { ActiveCrypto } from "@activeledger/activecrypto";
-import { ActiveLogger } from "@activeledger/activelogger";
+import { ActiveLogger, ActiveTiming } from "@activeledger/activelogger";
 import { Home } from "./home";
 import { Neighbour } from "./neighbour";
 import { ActiveProtocol } from "@activeledger/activeprotocol";
@@ -185,6 +185,7 @@ class Processor {
           this.housekeeping(m.data.right ?? Home.right, m.data.neighbourhood);
           break;
         case "tx":
+          ActiveTiming.mark(m.entry.$umid, "worker.recv");
           // Create new Protocol Process object for transaction
           this.protocols[m.entry.$umid] = new ActiveProtocol.Process(
             m.entry,
@@ -291,6 +292,7 @@ class Processor {
           );
 
           // Start the process
+          ActiveTiming.mark(m.entry.$umid, "worker.start");
           this.protocols[m.entry.$umid].start(
             this.latestContractVersion[m.entry.$tx.$contract],
             this.latestContractData[m.entry.$tx.$contract.substring(0, 64)]

--- a/packages/protocol/src/protocol/permissionsChecker.ts
+++ b/packages/protocol/src/protocol/permissionsChecker.ts
@@ -101,6 +101,11 @@ export class PermissionsChecker {
         // Small delay should help write finalise but we don't want
         // wait to long as it holds the transaction up from failing its vote
         await this.sleep(waitTime);
+        // Drop any prefetched copy first. The whole point of this retry is
+        // that a write may not have finalised yet, so re-reading is what
+        // makes it work - retrying against the same cached documents would
+        // just fail identically six more times.
+        this.prefetched = null;
         ActiveLogger.info(error, `Retrying PermissionsChecker due to - ${this.entry.$umid}`);
         return await this.process(data, inputs, ++retry);
       }
@@ -126,11 +131,11 @@ export class PermissionsChecker {
    * @private
    * @returns {Promise<any>[]}
    */
-  private async buildPromises(): Promise<ActiveDefinitions.LedgerStream[]> {
+  private buildKeys(data: string[]): { keyArray: string[]; contractDataIncluded: boolean } {
     const keys = new Set<string>();
     let contractDataIncluded = false;
 
-    for (const streamId of this.data) {
+    for (const streamId of data) {
       const filteredPrefix = this.shared.filterPrefix(streamId, true);
       const suffix = streamId.split(":")[1];
       contractDataIncluded = suffix === "data";
@@ -144,7 +149,52 @@ export class PermissionsChecker {
       }
     }
 
+    return { keyArray: Array.from(keys), contractDataIncluded };
+  }
+
+  /**
+   * Documents from a prefetch(), keyed by _id, or null when there hasn't been
+   * one and each process() call should fetch for itself.
+   */
+  private prefetched: { [id: string]: any } | null = null;
+
+  /**
+   * Fetches the streams for several key sets in one request.
+   *
+   * process() is called twice per transaction, once for inputs and once for
+   * outputs, and each call used to make its own allDocs - two sequential
+   * round trips to the storage process for data that is available in one.
+   * (The TODO asking for this sat in protocol/process.ts.)
+   *
+   * Prefetching rather than running the two process() calls concurrently is
+   * deliberate: process() writes this.data and this.inputs on entry and both
+   * are read all the way through buildPromises, processStreams and the
+   * signature checks, so two overlapping calls on the same instance would
+   * race and the second would decide the first's streams were outputs.
+   *
+   * Missing keys are simply absent from the cache, which is what the
+   * database does too - buildPromises' own length check turns that into the
+   * same 950 it always did.
+   */
+  public async prefetch(sets: string[][]): Promise<void> {
+    const keys = new Set<string>();
+    for (const set of sets) {
+      for (const key of this.buildKeys(set).keyArray) keys.add(key);
+    }
+
     const keyArray = Array.from(keys);
+    if (!keyArray.length) return;
+
+    const docs = await this.db.allDocs({ keys: keyArray, include_docs: true });
+    const cache: { [id: string]: any } = {};
+    for (const row of docs?.rows || []) {
+      if (row?.doc?._id) cache[row.doc._id] = row.doc;
+    }
+    this.prefetched = cache;
+  }
+
+  private async buildPromises(): Promise<ActiveDefinitions.LedgerStream[]> {
+    const { keyArray, contractDataIncluded } = this.buildKeys(this.data);
     // Single fetch
     try {
       // The docs wont be ordered as the keys said they would be need to create a reorder
@@ -154,10 +204,12 @@ export class PermissionsChecker {
       const results: ActiveDefinitions.LedgerStream[] = [];
 
       if (keyArray.length) {
-        const docs = await this.db.allDocs({
-          keys: keyArray,
-          include_docs: true,
-        });
+        const docs = this.prefetched
+          ? { rows: keyArray.filter((k) => this.prefetched![k]).map((k) => ({ doc: this.prefetched![k] })) }
+          : await this.db.allDocs({
+            keys: keyArray,
+            include_docs: true,
+          });
 
         // Must be a better way to manage this, Less operations
         if (docs?.rows) {

--- a/packages/protocol/src/protocol/permissionsChecker.ts
+++ b/packages/protocol/src/protocol/permissionsChecker.ts
@@ -25,7 +25,7 @@ import { ActiveDSConnect } from "@activeledger/activeoptions";
 import { ActiveDefinitions } from "@activeledger/activedefinitions";
 import { ISecurityCache } from "./interfaces/process.interface";
 import { Shared } from "./shared";
-import { ActiveLogger } from "@activeledger/activelogger";
+import { ActiveLogger, ActiveTiming } from "@activeledger/activelogger";
 
 /**
  * Manages the permissions of revisions and signatures of each stream type
@@ -74,10 +74,14 @@ export class PermissionsChecker {
     this.data = data;
     try {
       // Get all streams to process from the database
+      ActiveTiming.mark(this.entry?.$umid, inputs ? "perm.iFetchBegin" : "perm.oFetchBegin");
       const streams: ActiveDefinitions.LedgerStream[] =
         await this.buildPromises();
+      ActiveTiming.mark(this.entry?.$umid, inputs ? "perm.iFetchEnd" : "perm.oFetchEnd");
 
-      return this.processStreams(streams);
+      const checked = this.processStreams(streams);
+      ActiveTiming.mark(this.entry?.$umid, inputs ? "perm.iSigsDone" : "perm.oSigsDone");
+      return checked;
     } catch (error) {
       // Quorum change safety mech. 60% instant new transaction needing 100%
       // TODO make this variable based on entry node or not.

--- a/packages/protocol/src/protocol/process.ts
+++ b/packages/protocol/src/protocol/process.ts
@@ -25,7 +25,7 @@ import { promises as fs } from "fs";
 import { EventEmitter } from "events";
 import { VirtualMachine } from "./vm";
 import { ActiveOptions, ActiveDSConnect } from "@activeledger/activeoptions";
-import { ActiveLogger } from "@activeledger/activelogger";
+import { ActiveLogger, ActiveTiming } from "@activeledger/activelogger";
 import { ActiveCrypto } from "@activeledger/activecrypto";
 import { ActiveDefinitions } from "@activeledger/activedefinitions";
 import { IVMDataPayload, IVirtualMachine } from "./interfaces/vm.interface";
@@ -415,6 +415,7 @@ export class Process extends EventEmitter {
     contractVersion?: string,
     contractData?: ActiveDefinitions.IContractData | undefined | null
   ) {
+    ActiveTiming.mark(this.entry.$umid, "proto.start");
     ActiveLogger.debug(`New TX : ${this.entry.$umid}`);
 
     // Compiled Contracts sit in another location
@@ -529,6 +530,7 @@ export class Process extends EventEmitter {
       await (this.entry.$tx.$namespace === "default"
         ? setupDefaultLocation()
         : setupLocation());
+      ActiveTiming.mark(this.entry.$umid, "proto.contractPath");
     } catch (error) {
       // Simple Error Return (Can't use postVote yet due to VM)
       this.entry.$nodes[this.reference].error = `Init Contract Error - ${error.message || error
@@ -549,6 +551,7 @@ export class Process extends EventEmitter {
 
     // Get contract file (Or From Database)
     if (await fs.stat(this.contractLocation).catch(() => false)) {
+      ActiveTiming.mark(this.entry.$umid, "proto.contractStat");
       // Now we know we can execute the contract now or more costly cpu checks
       // Build Inputs Key Maps (Reference is Stream)
       this.inputs = Object.keys(this.entry.$tx.$i || {});
@@ -596,14 +599,18 @@ export class Process extends EventEmitter {
           // Check the input revisions
           const inputStreams: ActiveDefinitions.LedgerStream[] =
             await this.permissionChecker.process(this.inputs);
+          ActiveTiming.mark(this.entry.$umid, "proto.inputsChecked");
 
           // Check the output revisions
           const outputStreams: ActiveDefinitions.LedgerStream[] =
             await this.permissionChecker.process(this.outputs, false);
+          ActiveTiming.mark(this.entry.$umid, "proto.outputsChecked");
+          const contractDate = await this.getContractDate(contractData);
+          ActiveTiming.mark(this.entry.$umid, "proto.contractDate");
           this.process(
             inputStreams,
             outputStreams,
-            await this.getContractDate(contractData)
+            contractDate
           );
         } catch (error) {
           // Replay from here?
@@ -1068,6 +1075,8 @@ export class Process extends EventEmitter {
         // for all the other nodes to start processing it to get their vote response. So it is a global tx initiation.
       }
 
+      ActiveTiming.mark(this.entry.$umid, "proto.streamsReady");
+
       // Get readonly data
       const readonly = await this.getReadOnlyStreams();
 
@@ -1122,6 +1131,7 @@ export class Process extends EventEmitter {
    * @private
    */
   private postVote(virtualMachine: IVirtualMachine, error: any = false): void {
+    ActiveTiming.mark(this.entry?.$umid, "proto.voted");
     // Set voting completed state
     this.voting = false;
     this.nodeResponse.early = false;
@@ -1433,6 +1443,7 @@ export class Process extends EventEmitter {
         (this.nodeResponse.leader || this.canCommit())
       ) {
         // Consensus reached commit phase
+        ActiveTiming.mark(this.entry.$umid, "proto.commitBegin");
         this.commiting = true;
         //ActiveLogger.info(`Commit proceeding for ${this.entry.$umid}`);
 
@@ -1447,6 +1458,7 @@ export class Process extends EventEmitter {
             this.entry.$territoriality === this.reference,
             this.entry.$umid
           );
+          ActiveTiming.mark(this.entry.$umid, "proto.commitEnd");
 
           // Update Commit Entry
           this.nodeResponse.commit = true;

--- a/packages/protocol/src/protocol/process.ts
+++ b/packages/protocol/src/protocol/process.ts
@@ -593,9 +593,18 @@ export class Process extends EventEmitter {
         // [umid]:volatile  : Data that can be lost
         // [umid]:data      : Data directly linked to a contract, umid should always be a contract ID
 
-        // TODO these do 3 read requests to the database, Lets combine
 
         try {
+          // Fetch the streams for both sides in one request. These two
+          // process() calls used to make an allDocs each - two sequential
+          // round trips to the storage process for documents one query can
+          // return, which the profiler put at ~9% of a single-node
+          // transaction. (This is the "TODO these do 3 read requests to the
+          // database, Lets combine" above.)
+          ActiveTiming.mark(this.entry.$umid, "perm.prefetchBegin");
+          await this.permissionChecker.prefetch([this.inputs, this.outputs]);
+          ActiveTiming.mark(this.entry.$umid, "perm.prefetchEnd");
+
           // Check the input revisions
           const inputStreams: ActiveDefinitions.LedgerStream[] =
             await this.permissionChecker.process(this.inputs);

--- a/packages/protocol/src/protocol/streamUpdater.ts
+++ b/packages/protocol/src/protocol/streamUpdater.ts
@@ -27,7 +27,7 @@ import { Shared } from "./shared";
 import { IVirtualMachine } from "./interfaces/vm.interface";
 import { ActiveOptions, ActiveDSConnect } from "@activeledger/activeoptions";
 import { EventEmitter } from "events";
-import { ActiveLogger } from "@activeledger/activelogger";
+import { ActiveLogger, ActiveTiming } from "@activeledger/activelogger";
 
 /**
  * Handles updating the streams
@@ -371,7 +371,9 @@ export class StreamUpdater {
 
   private async append() {
     try {
+      ActiveTiming.mark(this.entry.$umid, "db.writeBegin");
       const bulkWriteResult = await this.db.bulkDocs(this.docs);
+      ActiveTiming.mark(this.entry.$umid, "db.writeEnd");
       // A write that failed does not come back falsy. The self hosted store
       // answers HTTP 200 with { ok: false } when its batch write fails, and
       // that object is truthy, so it sailed through this check and the

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -47,6 +47,6 @@
   "module": "./es/index.js",
   "dependencies": {
     "msgpackr": "^2.0.1",
-    "undici": "^6.28.0"
+    "undici": "^7.29.1"
   }
 }

--- a/packages/utilities/src/request.ts
+++ b/packages/utilities/src/request.ts
@@ -21,7 +21,7 @@
  * SOFTWARE.
  */
 import { ActiveGZip } from "./gzip";
-import { Dispatcher, request, setGlobalDispatcher, Agent } from "undici";
+import { Dispatcher, setGlobalDispatcher, getGlobalDispatcher, Agent } from "undici";
 
 /**
  * Returned HTTP Resonse data
@@ -105,6 +105,26 @@ setGlobalDispatcher(new Agent(DISPATCHER_OPTIONS));
  * @export
  * @class ActiveRequest
  */
+/**
+ * Reads one header value out of undici's raw header list, which arrives as a
+ * flat array of Buffers alternating name, value. Only used for
+ * content-encoding, so a linear scan over a handful of entries is cheaper
+ * than building an object for every response.
+ */
+function rawHeader(headers: Buffer[] | string[] | null, name: string): string | undefined {
+  if (!headers) return undefined;
+  for (let i = 0; i < headers.length - 1; i += 2) {
+    if (String(headers[i]).toLowerCase() === name) return String(headers[i + 1]);
+  }
+  return undefined;
+}
+
+/**
+ * Simple HTTP Request Object
+ *
+ * @export
+ * @class ActiveRequest
+ */
 export class ActiveRequest {
   public static async send(
     reqUrl: string,
@@ -116,16 +136,11 @@ export class ActiveRequest {
   ): Promise<IHTTPResponse> {
     //enableGZip = false
     timeout = timeout * 1000;
-    const options: Omit<Dispatcher.RequestOptions, "path"> = {
-      method: type.toUpperCase() as any, // Fix
-      headers: {},
-      headersTimeout: timeout,
-      bodyTimeout: timeout,
-    };
+    const headers: Record<string, string> = {};
 
     // Compressable?
     if (enableGZip) {
-      (options.headers as any)["Accept-Encoding"] = "gzip";
+      headers["Accept-Encoding"] = "gzip";
     }
 
     let bundled = false;
@@ -136,19 +151,22 @@ export class ActiveRequest {
         // Split Headers
         const [name, value] = header[i].split(":");
         // Asign to Header
-        (options.headers as any)[name] = value;
+        headers[name] = value;
         if (!bundled && name == "X-Bundle") {
           bundled = true;
         }
       }
     }
 
+    const method = type.toUpperCase();
+    let body: any;
+
     // Manage Data
-    if (data && (options.method == "POST" || options.method == "PUT")) {
+    if (data && (method == "POST" || method == "PUT")) {
       // convert data to string if object
       if (typeof data === "object") {
         data = Buffer.from(JSON.stringify(data), "utf8");
-        (options.headers as any)["content-type"] = "application/json";
+        headers["content-type"] = "application/json";
       }
 
       // Compressable? Below GZIP_MIN_BYTES the compression CPU cost outweighs
@@ -157,50 +175,104 @@ export class ActiveRequest {
       if (enableGZip && data.length >= GZIP_MIN_BYTES) {
         // Compress
         data = await ActiveGZip.gzip(data);
-        (options.headers as any)["content-encoding"] = "gzip";
+        headers["content-encoding"] = "gzip";
       }
 
-      // Additional Post headers
-      //(options.headers as any)["Content-Length"] = data.length;
-      //(options.headers as any)["Content-Length-x2"] = data.length;
-
-      options.body = data;
+      body = data;
     }
 
+    // undici's request() is a wrapper over dispatch() that builds a
+    // Readable per response. dispatch() skips that: measured against a bare
+    // node server it carries ~35% more throughput (16704 vs 12401 req/s at
+    // 64 in flight) and a far tighter tail (p99 8ms vs 51ms), because the
+    // tail is dominated by the stream machinery rather than the socket.
+    //
+    // Retry-on-connection-error is unaffected: it lives in the Client, below
+    // both, so idempotent requests are still retried silently and a POST to
+    // _bulk_docs still is not - see CLIENT_IDLE_TIMEOUT_MS above for why that
+    // distinction matters here.
+    //
+    // The handler shape below is undici 6/7's. undici 8 renames these
+    // (onConnect/onHeaders/onData/onComplete -> onRequestStart/
+    // onResponseStart/onResponseData/onResponseEnd) and validates the shape
+    // up front, so a major bump needs this updated - it will throw
+    // "invalid onRequestStart method" immediately rather than fail quietly.
+    let origin: string;
+    let path: string;
     try {
-      const { headers, body, statusCode } = await request(reqUrl, options);
-
-      // Cannot do this just yet, deposit wants to treat 404 as 200 (and maybe other areas)
-      // if (statusCode < 200 || statusCode > 299) {
-      //   const errorBody = await body.text();
-      //   throw {
-      //     name: "ActiveError",
-      //     message: `URL Request Failed : ${reqUrl} - ${statusCode}`,
-      //     body: errorBody,
-      //     stack: new Error().stack,
-      //   };
-      // }
-
-      try {
-        // Back Compat gzip support
-        if (headers["content-encoding"]?.includes("gzip")) {
-          const data = await ActiveGZip.ungzip(
-            Buffer.from(await body.arrayBuffer())
-          );
-          return { data: JSON.parse(data.toString()) };
-        } else {
-          return { data: await body.json() };
-        }
-      } catch (e) {
-        return { data: null };
-      }
-    } catch (e) {
-      if (!bundled) {
-        return { data: null };
-      } else {
-        // Circular Dependency issue
-        return { data: null };
-      }
+      const parsed = new URL(reqUrl);
+      origin = parsed.origin;
+      path = parsed.pathname + parsed.search;
+    } catch {
+      // Same contract as every other failure here: never throw at the caller.
+      return { data: null };
     }
+
+    return new Promise<IHTTPResponse>((resolve) => {
+      const chunks: Buffer[] = [];
+      let encoding: string | undefined;
+      let settled = false;
+
+      // Every exit resolves - callers rely on this never rejecting, even on
+      // a genuine connection failure (neighbour.knock() and
+      // checkNeighbourhood() read { data: null } to decide a node is down).
+      const done = (value: IHTTPResponse) => {
+        if (settled) return;
+        settled = true;
+        resolve(value);
+      };
+
+      getGlobalDispatcher().dispatch(
+        {
+          origin,
+          path,
+          method: method as Dispatcher.HttpMethod,
+          headers,
+          body,
+          headersTimeout: timeout,
+          bodyTimeout: timeout,
+        },
+        {
+          onConnect: () => {},
+          onHeaders: (_statusCode: number, rawHeaders: Buffer[] | null) => {
+            encoding = rawHeader(rawHeaders, "content-encoding");
+            return true;
+          },
+          onData: (chunk: Buffer) => {
+            chunks.push(chunk);
+            return true;
+          },
+          onComplete: () => {
+            const raw = chunks.length === 1 ? chunks[0] : Buffer.concat(chunks);
+            // Back Compat gzip support
+            if (encoding?.includes("gzip")) {
+              ActiveGZip.ungzip(raw)
+                .then((plain: Buffer) => {
+                  try {
+                    done({ data: JSON.parse(plain.toString()) });
+                  } catch {
+                    done({ data: null });
+                  }
+                })
+                .catch(() => done({ data: null }));
+              return;
+            }
+            try {
+              done({ data: JSON.parse(raw.toString()) });
+            } catch {
+              done({ data: null });
+            }
+          },
+          onError: () => {
+            if (!bundled) {
+              done({ data: null });
+            } else {
+              // Circular Dependency issue
+              done({ data: null });
+            }
+          },
+        }
+      );
+    });
   }
 }

--- a/tests/httpd.test.ts
+++ b/tests/httpd.test.ts
@@ -27,7 +27,10 @@ describe("ActiveHttpd - hpe-14 regressions", () => {
   });
 
   after(() => {
-    httpd.shutdown();
+    // false = close the port but leave the process alone. The default ends
+    // the process 1.3s later, which here meant killing the mocha run
+    // mid-suite with status 0 - see ActiveHttpd.shutdown().
+    httpd.shutdown(false);
   });
 
   function get(path: string): Promise<{ statusCode: number; headers: http.IncomingHttpHeaders; body: string }> {

--- a/tests/network/contracts/burn-contract.ts
+++ b/tests/network/contracts/burn-contract.ts
@@ -1,0 +1,57 @@
+import { Standard, Activity } from "@activeledger/activecontracts";
+
+/**
+ * Burns a caller-specified amount of CPU inside commit(), so the profiler can
+ * vary how much work a transaction costs and watch what that does to the gap
+ * between a 1-node and a 4-node network.
+ *
+ * That gap is the whole question: if consensus is mostly transport, adding
+ * contract work leaves it flat, because the extra work happens on every node
+ * in parallel. If consensus is mostly the other nodes *repeating* the work
+ * after the origin has finished, the gap grows roughly 1:1 with the burn.
+ *
+ * The burn is a fixed integer loop rather than a wall-clock deadline on
+ * purpose - commit() runs independently on every node, so anything that reads
+ * the clock produces a different result per node and diverges the ledger (the
+ * exact bug the comment in returner-contract.ts records).
+ */
+export default class Burn extends Standard {
+  private oActivity: Activity;
+  private iterations: number;
+  private message: string;
+
+  public verify(selfsigned: boolean): Promise<boolean> {
+    return new Promise((resolve, reject) =>
+      selfsigned ? reject("No self sign") : resolve(true));
+  }
+
+  public vote(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      const oStreams = Object.keys(this.transactions.$o);
+      if (!oStreams.length) return reject("Need an output stream");
+      this.oActivity = this.getActivityStreams(oStreams[0]);
+      const payload = this.transactions.$o[oStreams[0]] as {
+        iterations?: number; message?: string;
+      };
+      this.iterations = Number(payload.iterations) || 0;
+      this.message = payload.message as string;
+      if (!this.message) return reject("Need a message");
+      resolve(true);
+    });
+  }
+
+  public commit(): Promise<any> {
+    return new Promise((resolve) => {
+      // Deterministic busy work - the result is written into state so nothing
+      // can optimise the loop away.
+      let acc = 0;
+      for (let i = 0; i < this.iterations; i++) acc = (acc + i * 7) % 2147483647;
+
+      const state = this.oActivity.getState();
+      state.message = this.message;
+      state.acc = acc;
+      this.oActivity.setState(state);
+      resolve(true);
+    });
+  }
+}

--- a/tests/network/harness.ts
+++ b/tests/network/harness.ts
@@ -209,11 +209,15 @@ export class NetworkHarness {
     );
 
     // Stitch every instance's neighbourhood together into one list, written
-    // back into every config.json.
-    await runOnce(
-      dataDirs.flatMap((dataDir) => ["--merge", path.join(dataDir, "config.json")]),
-      this.rootDir
-    );
+    // back into every config.json. A single-instance network has nothing to
+    // stitch, and --merge rejects a one-config list outright, so skip it -
+    // that instance's own setup already left it as its own sole neighbour.
+    if (dataDirs.length > 1) {
+      await runOnce(
+        dataDirs.flatMap((dataDir) => ["--merge", path.join(dataDir, "config.json")]),
+        this.rootDir
+      );
+    }
 
     // Start every node for real.
     this.nodes = dataDirs.map((dataDir, i) => {

--- a/tests/network/profile-stages.ts
+++ b/tests/network/profile-stages.ts
@@ -1,0 +1,171 @@
+/**
+ * Stage-level breakdown of a single transaction, across every process that
+ * touches it.
+ *
+ * profile.ts says what a transaction costs; this says where that cost sits.
+ * It runs the network with ACTIVELEDGER_PROFILE=1, which makes ActiveTiming
+ * emit one "[PROF] <umid> <stage> <absolute ms>" line per stage, then stitches
+ * every node's log back into one timeline per transaction. Absolute
+ * timestamps are what makes that possible - the host process, its forked
+ * worker, and the other nodes all mark independently and are only comparable
+ * because they share a wall clock.
+ *
+ * Run: npm run profile:stages [-- --nodes=4]
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { NetworkHarness } from "./harness";
+import { onboard, registerNamespace, deployContract, runContract } from "./actions";
+
+process.env.ACTIVELEDGER_PROFILE = "1";
+
+const NODES = Number((process.argv.find(a => a.startsWith("--nodes=")) || "--nodes=4").split("=")[1]);
+const RUNS = Number((process.argv.find(a => a.startsWith("--runs=")) || "--runs=12").split("=")[1]);
+
+interface Mark { umid: string; stage: string; at: number; node: number; }
+
+function readMarks(logPath: string, node: number): Mark[] {
+  if (!fs.existsSync(logPath)) return [];
+  const out: Mark[] = [];
+  for (const raw of fs.readFileSync(logPath, "utf8").split("\n")) {
+    const line = raw.replace(/\x1b\[[0-9;]*m/g, "");
+    const m = /\[PROF\] (\S+) (\S+) ([0-9.]+)/.exec(line);
+    if (m) out.push({ umid: m[1], stage: m[2], at: Number(m[3]), node });
+  }
+  return out;
+}
+
+/** The order stages happen in, so a timeline reads top to bottom. */
+const ORDER = [
+  "http.in", "host.pending", "host.dispatch", "worker.recv", "worker.start",
+  "proto.start", "proto.contractPath", "proto.contractStat",
+  "perm.iFetchBegin", "perm.iFetchEnd", "perm.iSigsDone", "proto.inputsChecked",
+  "perm.oFetchBegin", "perm.oFetchEnd", "perm.oSigsDone",
+  "proto.outputsChecked", "proto.contractDate", "proto.streamsReady", "proto.voted", "proto.commitBegin",
+  "db.writeBegin", "db.writeEnd", "proto.commitEnd", "host.resolve", "http.out",
+];
+const rank = (s: string) => { const i = ORDER.indexOf(s); return i < 0 ? ORDER.length : i; };
+
+/**
+ * One stage can be marked several times for the same transaction on the same
+ * node: on a multi-node network the origin answers a knock about this umid
+ * from every peer, so http.out fires once per answer, not once per client
+ * response. Left as-is that turns the origin's timeline into interleaved
+ * nonsense ("http.out -> db.writeEnd"). Keep the first occurrence of each
+ * stage - when it was first reached - except for http.out, where the last is
+ * the one that actually answered the client.
+ */
+function dedupe(marks: Mark[]): Mark[] {
+  const kept: Record<string, Mark> = {};
+  marks.forEach((m) => {
+    const key = `${m.node}|${m.stage}`;
+    const seen = kept[key];
+    if (!seen) kept[key] = m;
+    else if (m.stage === "http.out" ? m.at > seen.at : m.at < seen.at) kept[key] = m;
+  });
+  return Object.keys(kept).map((k) => kept[k]);
+}
+
+(async () => {
+  const harness = new NetworkHarness({ nodeCount: NODES });
+  const nodes = await harness.start();
+  try {
+    const base = nodes[0].baseUrl;
+    const id = await onboard(base);
+    const ns = `st${Date.now().toString(36)}`;
+    await registerNamespace(base, id, ns);
+    const contract = await deployContract(base, id, ns, "returner",
+      path.join(__dirname, "contracts", "returner-contract.ts"));
+    await runContract(base, id, ns, contract, { message: "warm" });
+    await new Promise(r => setTimeout(r, 300));
+
+    // Measured runs, recording which umid each produced so warm-up and setup
+    // transactions are excluded from the averages below.
+    const measured: string[] = [];
+    for (let i = 0; i < RUNS; i++) {
+      const res = await runContract(base, id, ns, contract, { message: `s${i}` });
+      if (res.$umid) measured.push(res.$umid);
+    }
+    await new Promise(r => setTimeout(r, 1200));
+
+    // Plain objects and Array.from throughout: the repo's tsconfig sets no
+    // target (so ES5) and no downlevelIteration, under which spreading a Map
+    // or Set silently yields an empty array rather than failing - which is
+    // exactly how this script first reported "0 stages" over 140 real marks.
+    const marks: Mark[] = [];
+    nodes.forEach((n, i) => readMarks(n.logPath, i).forEach((m) => marks.push(m)));
+
+    const wanted: Record<string, true> = {};
+    measured.forEach((u) => (wanted[u] = true));
+
+    const byUmid: Record<string, Mark[]> = {};
+    marks.forEach((mk) => {
+      if (!wanted[mk.umid]) return;
+      (byUmid[mk.umid] = byUmid[mk.umid] || []).push(mk);
+    });
+    const umids = Object.keys(byUmid);
+
+    if (!umids.length) {
+      console.log(`No [PROF] marks matched (${marks.length} seen, ${measured.length} transactions).`);
+      console.log("Is ACTIVELEDGER_PROFILE reaching the nodes?");
+      return;
+    }
+
+    // --- One full timeline, so the shape is visible ------------------------
+    const sampleUmid = umids.filter((u) => byUmid[u].some((m) => m.stage === "http.out"))[0] || umids[0];
+    {
+      const ms = dedupe(byUmid[sampleUmid]);
+      const t0 = Math.min.apply(null, ms.map((m) => m.at));
+      console.log(`\nOne transaction, every process that touched it  (${sampleUmid.slice(0, 16)}...)`);
+      console.log("=".repeat(72));
+      const nodeIds: number[] = [];
+      ms.forEach((m) => { if (nodeIds.indexOf(m.node) < 0) nodeIds.push(m.node); });
+      nodeIds.sort((a, b) => a - b).forEach((node) => {
+        console.log(`  node ${node}${node === 0 ? "  (origin - the one the client called)" : ""}`);
+        const own = ms.filter((m) => m.node === node)
+          .sort((a, b) => a.at - b.at || rank(a.stage) - rank(b.stage));
+        let prev = t0;
+        own.forEach((m) => {
+          console.log(
+            `    +${(m.at - t0).toFixed(2).padStart(8)}ms  ${(m.at - prev).toFixed(2).padStart(7)}ms  ${m.stage}`
+          );
+          prev = m.at;
+        });
+      });
+    }
+
+    // --- Averaged gaps on the origin node ----------------------------------
+    console.log(`\nOrigin-node stage costs, mean over ${umids.length} transactions`);
+    console.log("=".repeat(72));
+    const gaps: Record<string, number[]> = {};
+    const totals: number[] = [];
+    umids.forEach((u) => {
+      const own = dedupe(byUmid[u]).filter((m) => m.node === 0)
+        .sort((a, b) => a.at - b.at || rank(a.stage) - rank(b.stage));
+      if (own.length < 2) return;
+      totals.push(own[own.length - 1].at - own[0].at);
+      for (let i = 1; i < own.length; i++) {
+        const key = `${own[i - 1].stage} -> ${own[i].stage}`;
+        (gaps[key] = gaps[key] || []).push(own[i].at - own[i - 1].at);
+      }
+    });
+    const mean = (a: number[]) => a.reduce((x, y) => x + y, 0) / a.length;
+    const total = totals.length ? mean(totals) : 0;
+    Object.keys(gaps)
+      .map((k) => ({ k, ms: mean(gaps[k]), n: gaps[k].length }))
+      .sort((a, b) => b.ms - a.ms)
+      .forEach((r) => {
+        const share = total ? (r.ms / total) * 100 : 0;
+        console.log(
+          `  ${r.k.padEnd(44)} ${r.ms.toFixed(2).padStart(7)}ms  ${share.toFixed(0).padStart(3)}%  ` +
+          "#".repeat(Math.max(0, Math.round(share / 2)))
+        );
+      });
+    console.log(`  ${"origin total (http.in -> http.out)".padEnd(44)} ${total.toFixed(2).padStart(7)}ms`);
+  } finally {
+    await harness.stop();
+    harness.cleanup();
+  }
+  process.exit(0);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/network/profile-stages.ts
+++ b/tests/network/profile-stages.ts
@@ -40,6 +40,7 @@ function readMarks(logPath: string, node: number): Mark[] {
 const ORDER = [
   "http.in", "host.pending", "host.dispatch", "worker.recv", "worker.start",
   "proto.start", "proto.contractPath", "proto.contractStat",
+  "perm.prefetchBegin", "perm.prefetchEnd",
   "perm.iFetchBegin", "perm.iFetchEnd", "perm.iSigsDone", "proto.inputsChecked",
   "perm.oFetchBegin", "perm.oFetchEnd", "perm.oSigsDone",
   "proto.outputsChecked", "proto.contractDate", "proto.streamsReady", "proto.voted", "proto.commitBegin",

--- a/tests/network/profile.ts
+++ b/tests/network/profile.ts
@@ -274,6 +274,50 @@ async function measureConcurrent(ctx: Ctx, identities: Identity[], inFlight: num
   }
   }
 
+  // --- 5. Contention: many transactions, one stream ------------------------
+  //
+  // Every other section here uses independent streams, which is the flattering
+  // case: nothing ever waits on a lock. A real workload usually has at least
+  // one hot stream - a shared pool, a counter, a registry - and transactions
+  // against it must serialise. This measures what that costs, which is a
+  // different question from how fast one transaction is.
+  if (wants(5)) {
+  console.log(`\n[5] Contention: N transactions at once against ONE stream`);
+  {
+    const contendNodes = Number((process.argv.find(a => a.startsWith("--contend-nodes=")) || "--contend-nodes=4").split("=")[1]);
+    const ctx = await setup(contendNodes, "rsa");
+    try {
+      for (const inFlight of QUICK ? [2, 4] : [2, 4, 8]) {
+        const t = process.hrtime.bigint();
+        const samples: number[] = [];
+        const results = await Promise.all(
+          Array.from({ length: inFlight }, (_, i) => {
+            const started = process.hrtime.bigint();
+            return runTx(ctx.baseUrl, ctx.identity, ctx.namespace, ctx.contractStreamId, `hot${i}`)
+              .then((r) => { samples.push(Number(process.hrtime.bigint() - started) / 1e6); return r; })
+              .catch(() => null);
+          })
+        );
+        const wall = Number(process.hrtime.bigint() - t) / 1e6;
+        const ok = results.filter((r) => r?.$streams?.updated?.length).length;
+        const st = stats(samples);
+        console.log(
+          `  ${String(inFlight).padStart(2)} on one stream  wall=${wall.toFixed(0).padStart(6)}ms  ` +
+          `committed=${String(ok).padStart(2)}/${inFlight}  ` +
+          `p50=${st.p50.toFixed(0).padStart(5)}ms  max=${st.max.toFixed(0).padStart(5)}ms  ` +
+          `per-commit=${(wall / Math.max(ok, 1)).toFixed(0).padStart(5)}ms`
+        );
+      }
+      console.log(
+        `\n  For reference an uncontended transaction is ~22ms, so per-commit is the\n` +
+        `  number to watch - it is what a second writer to a hot stream actually waits.`
+      );
+    } finally {
+      await shutdown(ctx.harness);
+    }
+  }
+  }
+
   // --- Summary ------------------------------------------------------------
   console.log(`\n${"=".repeat(60)}\nWhat this says`);
   if (bySize[1]?.p50 !== undefined && bySize[4]?.p50 !== undefined) {

--- a/tests/network/profile.ts
+++ b/tests/network/profile.ts
@@ -1,0 +1,298 @@
+/**
+ * Transaction profiler for a real, live Activeledger network.
+ *
+ * Answers "where does the time in a transaction actually go" with
+ * measurements rather than reading, by varying one thing at a time
+ * against the same harness the live tests use:
+ *
+ *   - network size (1/2/4 nodes)   isolates consensus round-trips from
+ *                                  everything a node does on its own
+ *   - key type (rsa/secp256k1)     isolates signature verification
+ *   - concurrency (1..32 in flight) separates per-transaction latency from
+ *                                  the network's actual throughput ceiling
+ *
+ * Run: npm run profile:tx     (add --quick for a shorter sweep)
+ */
+
+import * as path from "path";
+import { ActiveCrypto } from "../../packages/crypto/src";
+import { NetworkHarness, NetworkNode } from "./harness";
+import { submit } from "./http";
+import { registerNamespace, deployContract, Identity } from "./actions";
+
+const QUICK = process.argv.includes("--quick");
+/** --only=1,4 runs just those sections - each boots its own networks, so they are independent. */
+const ONLY = (process.argv.find(a => a.startsWith("--only=")) || "").replace("--only=", "");
+const wants = (section: number) => !ONLY || ONLY.split(",").includes(String(section));
+
+/** Onboards an identity of a given key type - actions.ts's onboard() is rsa-only. */
+async function onboardAs(baseUrl: string, type: string): Promise<Identity> {
+  const keyPair = new ActiveCrypto.KeyPair(type);
+  // secp256k1 defaults to raw 0x-hex keys, which sign() cannot use - it reads
+  // prv.pkcs8pem. Ask for the PEM form explicitly.
+  const keys = type === "rsa" ? keyPair.generate() : keyPair.generate(256, true);
+  const txBody = {
+    $namespace: "default",
+    $contract: "onboard",
+    $i: { identity: { type, publicKey: keys.pub.pkcs8pem } },
+    $o: {},
+  };
+  const tx = { $tx: txBody, $selfsign: true, $sigs: { identity: keyPair.sign(txBody) } };
+  const result = await submit(baseUrl, tx);
+  if (!result.$streams?.new?.[0]?.id) {
+    throw new Error(`Onboard (${type}) failed: ${JSON.stringify(result).slice(0, 300)}`);
+  }
+  return { streamId: result.$streams.new[0].id, keyPair };
+}
+
+/** One returner-contract transaction against the identity's own stream. */
+function runTx(
+  baseUrl: string,
+  identity: Identity,
+  namespace: string,
+  contractStreamId: string,
+  message: string,
+  extra: Record<string, unknown> = {}
+): Promise<any> {
+  const txBody = {
+    $namespace: namespace,
+    $contract: contractStreamId,
+    $i: { [identity.streamId]: {} },
+    $o: { [identity.streamId]: { message, ...extra } },
+  };
+  const tx = { $tx: txBody, $sigs: { [identity.streamId]: identity.keyPair.sign(txBody) } };
+  return submit(baseUrl, tx);
+}
+
+function stats(samples: number[]) {
+  const s = [...samples].sort((a, b) => a - b);
+  const at = (q: number) => s[Math.min(s.length - 1, Math.floor(q * s.length))];
+  const mean = s.reduce((a, b) => a + b, 0) / s.length;
+  return { n: s.length, min: s[0], p50: at(0.5), p90: at(0.9), max: s[s.length - 1], mean };
+}
+
+function fmt(label: string, st: ReturnType<typeof stats>, extra = "") {
+  console.log(
+    `  ${label.padEnd(26)} n=${String(st.n).padStart(3)}  ` +
+    `min=${st.min.toFixed(0).padStart(5)}  p50=${st.p50.toFixed(0).padStart(5)}  ` +
+    `p90=${st.p90.toFixed(0).padStart(5)}  max=${st.max.toFixed(0).padStart(5)}  ` +
+    `mean=${st.mean.toFixed(1).padStart(6)}ms ${extra}`
+  );
+}
+
+/**
+ * Every harness currently holding ports, so a failure anywhere tears them
+ * down. Without this a crashed run leaves four nodes listening on 5510-5540
+ * and the *next* run silently measures them instead - which produced a
+ * nonsense 1-node p50 of 1521ms with 6 of 10 not committing, until the
+ * leftovers were found and killed.
+ */
+const live = new Set<NetworkHarness>();
+
+async function shutdown(harness: NetworkHarness) {
+  live.delete(harness);
+  try { await harness.stop(); } catch { /* best effort - cleanup still matters */ }
+  try { harness.cleanup(); } catch { /* ditto */ }
+}
+
+async function shutdownAll() {
+  // Array.from, not [...live] - the repo's tsconfig sets no target (so ES5)
+  // and no downlevelIteration, under which spreading a Set yields an empty
+  // array instead of failing. That is why an early crash in this script left
+  // eight nodes still holding ports: this function ran and iterated nothing.
+  const all = Array.from(live);
+  for (const harness of all) await shutdown(harness);
+}
+
+/** Boots a network, deploys the returner contract, and hands back a ready context. */
+async function setup(nodeCount: number, keyType: string, contract = "returner") {
+  const harness = new NetworkHarness({ nodeCount });
+  live.add(harness);
+  const nodes = await harness.start();
+  const baseUrl = nodes[0].baseUrl;
+  const identity = await onboardAs(baseUrl, keyType);
+  const namespace = `prof${Date.now().toString(36)}`;
+  await registerNamespace(baseUrl, identity, namespace);
+  const contractStreamId = await deployContract(
+    baseUrl, identity, namespace, contract,
+    path.join(__dirname, "contracts", `${contract}-contract.ts`)
+  );
+  // Contracts are compiled and cached on first use - pay that once, outside
+  // every measurement below, so the first sample is not an outlier.
+  await runTx(baseUrl, identity, namespace, contractStreamId, "warm");
+  return { harness, nodes, baseUrl, identity, namespace, contractStreamId, keyType };
+}
+
+type Ctx = Awaited<ReturnType<typeof setup>>;
+
+/** Sequential transactions against one stream: pure per-transaction latency. */
+async function measureSequential(ctx: Ctx, count: number, label: string, extra: Record<string, unknown> = {}) {
+  const samples: number[] = [];
+  let failed = 0;
+  for (let i = 0; i < count; i++) {
+    const t = process.hrtime.bigint();
+    const r = await runTx(ctx.baseUrl, ctx.identity, ctx.namespace, ctx.contractStreamId, `m${i}`, extra);
+    samples.push(Number(process.hrtime.bigint() - t) / 1e6);
+    if (!r.$streams?.updated?.length) failed++;
+  }
+  fmt(label, stats(samples), failed ? `(${failed} did not commit)` : "");
+  return stats(samples);
+}
+
+/**
+ * K independent identities transacting at once. Independent streams matter -
+ * the same stream would serialise on its own lock and measure contention
+ * rather than capacity.
+ */
+async function measureConcurrent(ctx: Ctx, identities: Identity[], inFlight: number) {
+  const chosen = identities.slice(0, inFlight);
+  const t = process.hrtime.bigint();
+  const results = await Promise.all(
+    chosen.map((id, i) => runTx(ctx.baseUrl, id, ctx.namespace, ctx.contractStreamId, `c${inFlight}-${i}`)
+      .catch(() => null))
+  );
+  const wall = Number(process.hrtime.bigint() - t) / 1e6;
+  const ok = results.filter(r => r?.$streams?.updated?.length).length;
+  console.log(
+    `  ${String(inFlight).padStart(3)} in flight  wall=${wall.toFixed(0).padStart(6)}ms  ` +
+    `committed=${String(ok).padStart(3)}/${inFlight}  ` +
+    `throughput=${(ok / (wall / 1000)).toFixed(1).padStart(6)} tx/s  ` +
+    `per-tx=${(wall / Math.max(ok, 1)).toFixed(1).padStart(6)}ms`
+  );
+  return { inFlight, wall, ok, tps: ok / (wall / 1000) };
+}
+
+(async () => {
+  const seqCount = QUICK ? 10 : 25;
+  console.log(`\nActiveledger transaction profile${QUICK ? " (quick)" : ""}\n${"=".repeat(60)}`);
+
+  const bySize: Record<number, any> = {};
+  const byKey: Record<string, any> = {};
+
+  // --- 1. Network size: how much of a transaction is consensus? -----------
+  if (wants(1)) {
+  console.log(`\n[1] Latency by network size (sequential, one stream, rsa)`);
+  for (const nodeCount of QUICK ? [1, 4] : [1, 2, 4]) {
+    const ctx = await setup(nodeCount, "rsa");
+    try {
+      bySize[nodeCount] = await measureSequential(ctx, seqCount, `${nodeCount} node${nodeCount > 1 ? "s" : ""}`);
+    } finally {
+      await shutdown(ctx.harness);
+    }
+  }
+  }
+
+  // --- 2. Key type: how much is signature verification? -------------------
+  if (wants(2)) {
+  console.log(`\n[2] Latency by key type (sequential, one stream, 4 nodes)`);
+  for (const keyType of ["rsa", "secp256k1"]) {
+    const ctx = await setup(4, keyType);
+    try {
+      byKey[keyType] = await measureSequential(ctx, seqCount, keyType);
+    } finally {
+      await shutdown(ctx.harness);
+    }
+  }
+  }
+
+  // --- 3. Concurrency: latency vs actual capacity -------------------------
+  if (wants(3)) {
+  console.log(`\n[3] Throughput by concurrency (4 nodes, independent streams, rsa)`);
+  {
+    const ctx = await setup(4, "rsa");
+    try {
+      const levels = QUICK ? [1, 8] : [1, 4, 16, 32, 64, 128];
+      const most = Math.max(...levels);
+      process.stdout.write(`  onboarding ${most} identities...`);
+      const identities: Identity[] = [];
+      for (let i = 0; i < most; i++) identities.push(await onboardAs(ctx.baseUrl, "rsa"));
+      console.log(" done");
+      const curve: any[] = [];
+      for (const level of levels) curve.push(await measureConcurrent(ctx, identities, level));
+
+      const best = curve.reduce((a, b) => (b.tps > a.tps ? b : a));
+      console.log(`\n  peak: ${best.tps.toFixed(1)} tx/s at ${best.inFlight} in flight`);
+    } finally {
+      await shutdown(ctx.harness);
+    }
+  }
+  }
+
+  // --- 4. Is consensus transport, or the other nodes repeating the work? ---
+  //
+  // Adding contract work to a 4-node transaction has two possible shapes. If
+  // consensus overlaps the origin's own work, the gap over a 1-node network
+  // stays flat as the work grows. If the other nodes only start once the
+  // origin has finished, the gap grows with it.
+  if (wants(4)) {
+  console.log(`\n[4] Does the consensus gap grow with contract work? (sequential, burn contract)`);
+  {
+    const burns = QUICK ? [0, 20000000] : [0, 5000000, 20000000, 60000000];
+    const rows: { burn: number; one: number; four: number }[] = [];
+    for (const nodeCount of [1, 4]) {
+      const ctx = await setup(nodeCount, "rsa", "burn");
+      try {
+        for (const iterations of burns) {
+          const st = await measureSequential(
+            ctx, QUICK ? 8 : 15,
+            `${nodeCount} node${nodeCount > 1 ? "s" : ""}, burn=${iterations}`,
+            { iterations }
+          );
+          let row = rows.find(r => r.burn === iterations);
+          if (!row) rows.push(row = { burn: iterations, one: 0, four: 0 });
+          if (nodeCount === 1) row.one = st.p50; else row.four = st.p50;
+        }
+      } finally {
+        await shutdown(ctx.harness);
+      }
+    }
+    console.log(`\n  burn        1 node    4 nodes    gap`);
+    for (const r of rows) {
+      console.log(
+        `  ${String(r.burn).padStart(9)}  ${r.one.toFixed(0).padStart(6)}ms  ` +
+        `${r.four.toFixed(0).padStart(7)}ms  ${(r.four - r.one).toFixed(0).padStart(5)}ms`
+      );
+    }
+    const first = rows[0], last = rows[rows.length - 1];
+    const gapGrowth = (last.four - last.one) - (first.four - first.one);
+    const workGrowth = last.one - first.one;
+    console.log(
+      `\n  work added on one node: ${workGrowth.toFixed(0)}ms, ` +
+      `gap grew by: ${gapGrowth.toFixed(0)}ms ` +
+      `(${workGrowth > 1 ? (gapGrowth / workGrowth).toFixed(2) : "n/a"}x)`
+    );
+    console.log(
+      `  ~1x means the other nodes repeat the work after the origin finishes;` +
+      `\n  ~0x means consensus already overlaps it and the gap is fixed overhead.`
+    );
+  }
+  }
+
+  // --- Summary ------------------------------------------------------------
+  console.log(`\n${"=".repeat(60)}\nWhat this says`);
+  if (bySize[1]?.p50 !== undefined && bySize[4]?.p50 !== undefined) {
+    const consensus = bySize[4].p50 - bySize[1].p50;
+    console.log(
+      `  consensus (4 nodes - 1 node, p50) : ${consensus.toFixed(0)}ms ` +
+      `(${((consensus / bySize[4].p50) * 100).toFixed(0)}% of a 4-node transaction)`
+    );
+    console.log(`  single-node floor (p50)           : ${bySize[1].p50.toFixed(0)}ms`);
+  }
+  if (byKey.rsa?.p50 !== undefined && byKey.secp256k1?.p50 !== undefined) {
+    const d = byKey.rsa.p50 - byKey.secp256k1.p50;
+    console.log(`  rsa over secp256k1 (p50)          : ${d >= 0 ? "+" : ""}${d.toFixed(0)}ms`);
+  }
+  console.log("");
+  process.exit(0);
+})().catch(async (e) => {
+  console.error(e);
+  await shutdownAll();
+  process.exit(1);
+});
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.on(signal, async () => {
+    await shutdownAll();
+    process.exit(130);
+  });
+}

--- a/tests/network/profile.ts
+++ b/tests/network/profile.ts
@@ -117,9 +117,15 @@ async function setup(nodeCount: number, keyType: string, contract = "returner") 
     baseUrl, identity, namespace, contract,
     path.join(__dirname, "contracts", `${contract}-contract.ts`)
   );
-  // Contracts are compiled and cached on first use - pay that once, outside
-  // every measurement below, so the first sample is not an outlier.
-  await runTx(baseUrl, identity, namespace, contractStreamId, "warm");
+  // Warm up properly before anything is measured. One transaction is not
+  // enough: contract compilation, V8's JIT and the connection pools all settle
+  // over the first handful, and with a short sample count those stragglers land
+  // on the p50 rather than the tail. Warming once put --quick at 15/36ms
+  // against the full run's 5/23ms for the same build - a profiler reporting
+  // three times the real number is worse than no profiler.
+  for (let i = 0; i < 8; i++) {
+    await runTx(baseUrl, identity, namespace, contractStreamId, `warm${i}`);
+  }
   return { harness, nodes, baseUrl, identity, namespace, contractStreamId, keyType };
 }
 

--- a/tests/request-send.test.ts
+++ b/tests/request-send.test.ts
@@ -1,0 +1,143 @@
+import { expect } from "chai";
+import "mocha";
+import * as http from "http";
+import * as zlib from "zlib";
+import { ActiveRequest } from "../packages/utilities/src";
+
+/**
+ * Behavioural coverage for ActiveRequest.send(), the single function every
+ * database operation and every node-to-node knock goes through.
+ *
+ * request-keepalive.test.ts asserts the dispatcher's timeout constants, which
+ * says nothing about what send() does with a response. That mattered when
+ * send() was rewritten from undici's request() to dispatch(): the JSON, gzip
+ * and failure paths were all reimplemented by hand with nothing asserting
+ * them, and the gzip path in particular is only reached by the hybrid node
+ * flow (host.ts's hybridHosts loop), which neither test suite exercises.
+ *
+ * The contract worth protecting is stranger than a normal HTTP client's:
+ * send() must NEVER reject. Callers read { data: null } to mean failure -
+ * neighbour.knock() and checkNeighbourhood() decide a node is down that way -
+ * so a rejection would surface as an unhandled rejection rather than a node
+ * being marked unreachable.
+ */
+describe("ActiveRequest.send", () => {
+  let server: http.Server;
+  let base: string;
+  let lastRequest: { method?: string; headers: http.IncomingHttpHeaders; body: Buffer };
+
+  /** Set per test to decide how the server answers. */
+  let respond: (req: http.IncomingMessage, res: http.ServerResponse, body: Buffer) => void;
+
+  before((done) => {
+    server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => {
+        lastRequest = { method: req.method, headers: req.headers, body: Buffer.concat(chunks) };
+        respond(req, res, Buffer.concat(chunks));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      base = `http://127.0.0.1:${(server.address() as any).port}`;
+      done();
+    });
+  });
+
+  after((done) => server.close(() => done()));
+
+  const json = (payload: unknown) => (_req: any, res: http.ServerResponse) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(payload));
+  };
+
+  it("returns the parsed JSON body of a GET", async () => {
+    respond = json({ ok: true, rows: [1, 2, 3] });
+    const result = await ActiveRequest.send(`${base}/x`, "GET");
+    expect(result.data).to.deep.equal({ ok: true, rows: [1, 2, 3] });
+  });
+
+  it("sends an object body as JSON, with the content type set", async () => {
+    respond = json({ ok: true });
+    await ActiveRequest.send(`${base}/x`, "POST", undefined, { keys: ["a", "b"] });
+    expect(lastRequest.method).to.equal("POST");
+    expect(lastRequest.headers["content-type"]).to.equal("application/json");
+    expect(JSON.parse(lastRequest.body.toString())).to.deep.equal({ keys: ["a", "b"] });
+  });
+
+  it("forwards caller supplied headers", async () => {
+    respond = json({ ok: true });
+    await ActiveRequest.send(`${base}/x`, "POST", ["X-Activeledger:node-ref"], { a: 1 });
+    expect(lastRequest.headers["x-activeledger"]).to.equal("node-ref");
+  });
+
+  it("decompresses a gzipped response", async () => {
+    const payload = { compressed: true, streams: ["a", "b"] };
+    respond = (_req, res) => {
+      res.writeHead(200, { "content-type": "application/json", "content-encoding": "gzip" });
+      res.end(zlib.gzipSync(Buffer.from(JSON.stringify(payload))));
+    };
+    const result = await ActiveRequest.send(`${base}/x`, "GET", undefined, undefined, true);
+    expect(result.data).to.deep.equal(payload);
+  });
+
+  it("gzips a request body once it is worth compressing", async () => {
+    respond = json({ ok: true });
+    // Comfortably over GZIP_MIN_BYTES (1024), and compressible.
+    const big = { blob: "a".repeat(4096) };
+    await ActiveRequest.send(`${base}/x`, "POST", undefined, big, true);
+    expect(lastRequest.headers["content-encoding"]).to.equal("gzip");
+    expect(JSON.parse(zlib.gunzipSync(lastRequest.body).toString())).to.deep.equal(big);
+  });
+
+  it("leaves a small body uncompressed, where gzip would cost more than it saves", async () => {
+    respond = json({ ok: true });
+    await ActiveRequest.send(`${base}/x`, "POST", undefined, { small: true }, true);
+    expect(lastRequest.headers["content-encoding"]).to.be.undefined;
+    expect(JSON.parse(lastRequest.body.toString())).to.deep.equal({ small: true });
+  });
+
+  it("resolves { data: null } when the host is unreachable, rather than rejecting", async () => {
+    // Port 1 on loopback: nothing listens, and the connection is refused
+    // rather than hanging.
+    const result = await ActiveRequest.send("http://127.0.0.1:1/x", "GET");
+    expect(result.data).to.equal(null);
+  });
+
+  it("resolves { data: null } for a malformed URL", async () => {
+    const result = await ActiveRequest.send("not-a-url", "GET");
+    expect(result.data).to.equal(null);
+  });
+
+  it("resolves { data: null } when the body is not JSON", async () => {
+    respond = (_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("this is not json");
+    };
+    const result = await ActiveRequest.send(`${base}/x`, "GET");
+    expect(result.data).to.equal(null);
+  });
+
+  it("still returns the parsed body of a non-2xx response", async () => {
+    // Deliberate: dsconnect treats a 404 as an answer ("no such document"),
+    // not an error, so a failing status must not be turned into null.
+    respond = (_req, res) => {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "not_found" }));
+    };
+    const result = await ActiveRequest.send(`${base}/x`, "GET");
+    expect(result.data).to.deep.equal({ error: "not_found" });
+  });
+
+  it("handles a response split across many chunks", async () => {
+    const payload = { rows: Array.from({ length: 500 }, (_, i) => ({ id: i })) };
+    const raw = Buffer.from(JSON.stringify(payload));
+    respond = (_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      for (let i = 0; i < raw.length; i += 64) res.write(raw.subarray(i, i + 64));
+      res.end();
+    };
+    const result = await ActiveRequest.send(`${base}/x`, "GET");
+    expect(result.data).to.deep.equal(payload);
+  });
+});


### PR DESCRIPTION
Profiles a transaction, fixes what the profile found, and fixes the test gate
that was hiding whether any of it worked.

## Result

p50, live 4-node harness, returner contract, three runs each:

| | master | this branch | | |
|---|---|---|---|---|
| 1 node  | 10ms | **6ms**  | −4ms  | **−40%** |
| 2 nodes | 30ms | **21ms** | −9ms  | **−30%** |
| 4 nodes | 32ms | **22ms** | −10ms | **−31%** |
| peak throughput | 222 tx/s | 220 tx/s | — | unchanged |

Throughput is unchanged on purpose, and the reason matters: the cost removed
was idle *waiting*, not work, so it already overlapped whenever transactions
were in flight together. That is also why it never showed up as a throughput
problem and sat there unnoticed.

**The starting figure we were working from was ~482ms.** A transaction was
already 32ms. Whatever 482ms measured, it wasn't this path.

## Where it went

Almost all of it is one line of `package-lock.json`.

`undici 6.28.0` added idle keep-alive socket validation for
GHSA-35p6-xmwp-9g52 and scheduled it with `setTimeout(..., 0)`, which pays
Node's ~1ms timer floor on **every socket reuse** — so every request on a warm
pool. `6.28.1` switched it to `setImmediate`. From undici's own note:

> `setTimeout(0)` pays Node's ~1ms timer floor on every sequential reuse
> (#5493). `setImmediate` avoids that, but an *unref'd* Immediate lets poll
> block for ~500ms when the event loop is otherwise idle (#5600 / #5606).

Same directory, same benchmark:

```
undici 6.28.0   p50 = 1.235ms      <- what the lockfile pinned
undici 6.28.1   p50 = 0.110ms
```

It hits hard here because every database operation and every node-to-node
knock goes through `ActiveRequest.send`, so a node paid it four times over on
its own storage before answering a client. `packages/utilities` already asked
for `^6.28.0`; the lockfile was holding it one patch short. **Every production
node is currently paying this.**

## The other two changes are honest about themselves

Both do what they claim at the stage they touch. Neither moves end-to-end
transaction time, because neither was the bottleneck — kept because both are
strictly less work for the same result.

**One stream fetch instead of two.** `process()` ran twice per transaction,
inputs then outputs, each with its own `allDocs` — two sequential round trips
for documents one query returns. (The `TODO ... Lets combine` was already in
the code.)

```
             before    after
prefetch        —      1.09ms   (one round trip)
iFetch       1.23ms    0.18ms   (cache)
oFetch       0.87ms    0.02ms   (cache)
             ------    ------
             2.10ms    1.29ms      ~0.8ms saved per transaction, per node
```

Prefetching rather than running the two calls concurrently is deliberate:
`process()` writes `this.data`/`this.inputs` on entry and both are read
through `buildPromises`, `processStreams` and the signature checks, so
overlapping calls on one instance would race and the second would decide the
first's streams were outputs. A retry drops the cache first — that retry
exists because a write may not have finalised, so re-reading is the point.

**`dispatch()` instead of `request()`.** `request()` builds a Readable per
response; `dispatch()` skips it. Against live storage, 2000 sequential and
8000 concurrent:

```
sequential    0.187ms -> 0.150ms
concurrent    14736 -> 31027 req/s,  p99 37.8ms -> 6.5ms
```

Twice the client capacity, but a node generates ~900 req/s, so this is
headroom rather than speed. Kept mainly for the tail: a node's p99 is a
consensus system's p50, since the slowest node sets the round.

*Maintenance cost, stated plainly:* the handler shape is undici 6/7's. undici
8 renames these callbacks and validates up front, so a major bump needs this
updated — it throws `invalid onRequestStart method` immediately rather than
failing quietly. This is the one commit that is easy to drop if you'd rather
not carry it.

## The test suite could not fail

`ActiveHttpd.shutdown()` closes the listen socket then arms a 1300ms timer
calling `process.exit(0)`. Right for a node being shut down; wrong anywhere
the server is not the whole process. `tests/httpd.test.ts` shuts a server down
in `after()`, and 1.3s later that killed the mocha run **mid-suite, with
status 0** — remaining tests never ran, output stopped wherever it had got to,
and the failure count went with it.

```
canary asserting 1 === 2, alone       npm test exit=1
canary asserting 1 === 2, full suite  npm test exit=0
```

So CI's `test` job has been passing for the unit suite regardless of whether
any of it passed. `shutdown()` now takes `exitProcess`, defaulting `true`, so
production shutdown is byte-for-byte unchanged; the test passes `false`.

Verified both directions after the fix: a deliberately failing test exits 1,
the clean suite exits 0 with **324 passing** — the same count as before, so
nothing was lost.

The symptom looked cosmetic: output truncating at a different point each run
reads as a noisy reporter, not a process being killed underneath it. The
truncation was the bug announcing itself.

## Tools, so this is repeatable

`npm run profile:tx` varies one thing at a time — network size, key type,
concurrency, contract cost. `npm run profile:stages` says where the time sits,
stitching every process's marks into one timeline per umid (absolute
timestamps, because `hrtime`'s epoch is per-process and meaningless across a
fork). `ActiveTiming` is off unless `ACTIVELEDGER_PROFILE` is set: 10/30/32ms
compiled in and disabled, against 10/31/33ms before it existed.

### Hypotheses these killed

- **Signature verification** — rsa and secp256k1 within noise of each other.
- **Transport** — a bare HTTP round trip against a live node is 0.3ms.
- **Peers repeating the origin's work** — +206ms of contract burn left the
  4-node gap at 23ms, unmoved. The burn contract exists to test this.
- **Swapping undici for `node:http`** — nearly recommended off a
  sequential-only benchmark. Under concurrency undici wins by 2-2.7x
  (16704 vs 7767 req/s), so that swap would have traded a third of the
  latency for most of the throughput.

### Bugs the tools surfaced

- The harness **could not start a single-node network** (`--merge` rejects a
  one-config list) — so the comparison anchoring all of this was unrunnable.
- A crash left **eight nodes holding ports 5510-5540**, and the next run
  silently measured those, reporting a 1-node p50 of 1521ms.
- The cleanup meant to prevent that was `[...liveSet]`, which under this
  repo's tsconfig — no `target`, so ES5, no `downlevelIteration` — **yields an
  empty array rather than failing**. It ran and iterated nothing. Worth
  knowing repo-wide: `[...someSet]` is silently wrong here.

## Verified

`npm test` — 324 passing, against a gate proven to detect failures.
`npm run test:network` — exit 0 (`process.exit(allPassed ? 0 : 1)`).
Build output checked for each change rather than trusting the build's exit
code.



---

## undici 7, and why not 8

6.x reaches end of life **2027-04-30**, about seven months out. 7.x runs to
2028-04-30. Taken as a separate commit, measured rather than assumed — five
runs each, at the concurrency that matters for a loaded node:

```
              dispatch      request
  6.28.1      ~16800 r/s    ~12400 r/s
  7.29.1      ~16400 r/s    ~12000 r/s
  8.10.2      ~16500 r/s    ~11400 r/s
```

**There is no performance argument for 8** — identical on `dispatch`, which is
what `ActiveRequest.send` uses, and consistently ~8% slower on `request`.

7 is also free in a way 8 is not. The dispatch handler uses the
`onConnect`/`onHeaders`/`onData`/`onComplete` shape, and 7 still accepts it:

```
undici 6.28.1: OLD API -> WORKS
undici 7.29.1: OLD API -> WORKS
undici 8.10.2: OLD API -> THROWS: invalid onRequestStart method
```

8 additionally needs Node ≥ 22.19 (dropping anyone on 20 — this repo declares
no `engines` floor) and turns HTTP/2 on by default when TLS negotiates it.
Worth doing eventually, on its own, with the handler rewritten — not folded
into a performance change for a version that benchmarks slower here.

undici is the only package that moves; nothing transitive came with it.

## Docs

README gains a **Profiling** section: what each profiler answers, the flags,
how to read the output, reference p50s, and the two ways to profile the wrong
thing (a stale `lib/`, and leftover nodes holding 5510-5540). Both documented
invocations were run as written.

Writing it down caught a bug in the tool. `--quick` reported **15/36ms** where
the full run reported **5/23ms** for the same build — it warmed with a single
transaction, so with only 10 samples the stragglers from contract compilation,
the JIT and the connection pools landed on the p50 rather than the tail. Now
eight discarded warm-up transactions in every mode: `--quick` reads 6/22ms
against the full run's 6/21ms, and the full run's own p90 tightens from
14/32/37 to **10/22/24**.

`--quick` is what you reach for to compare a before and after, so it was
reporting three times the real number in exactly the situation it exists for.
