### PR TITLE
perf: wait for a lock by time, not by how much traffic went past

### DIFF
--- a/packages/network/src/network/host.ts
+++ b/packages/network/src/network/host.ts
@@ -58,7 +58,41 @@ const RELEASE_DELETE_TIMEOUT = 2 * 60 * 1000;
 const TIMER_QUEUE_INTERVAL = 2 * 1000;
 const GRACEFUL_PROC_SHUTDOWN = 7 * 60 * 1000;
 const KILL_PROC_SHUTDOWN = 2.5 * 1000;
-const MAX_RETRIES = 35; // Bubbling up error (may need different counters)
+// How long a transaction may wait for its streams before it is told the locks
+// are busy.
+//
+// This used to be a retry count (35), but the count was never a measure of
+// time: processQueue() runs on every pending() call, so an unrelated
+// transaction arriving anywhere on the node burned one of the 35. A quiet node
+// therefore waited ~7s before giving up while a busy one gave up in a fraction
+// of that - the opposite of what you want, since a busy node is exactly where
+// a stream is worth waiting for. The comment above the old check said as much:
+// "every new transaction (unrelated) will increase the counter ... so possibly
+// a safe timeout should be used".
+//
+// 7s preserves the old quiet-node budget (35 x the 200ms re-check) and sits
+// well inside the 60s broadcast timeouts.
+const QUEUE_MAX_WAIT_MS = Number(process.env.AL_QUEUE_MAX_WAIT_MS || 7_000);
+
+// How long after a release before the lock queue is re-checked.
+//
+// Was 200ms. Deliberately not 0/setImmediate, which benchmarks fastest but is
+// the least safe: processQueue() scans the whole queue and calls hold() on
+// every entry, so each pass is O(queue length), and removing the delay removes
+// the only thing throttling those scans. Measured, it pushed one transaction
+// to 133 retry passes where the old cap was 35, and left unrelated work
+// running at 1.3x its quiet latency during a burst.
+//
+// 50ms keeps almost all of the benefit - on a quiet single node two writers on
+// one stream cost 24ms against setImmediate's 23ms and the old 68ms - while
+// still bounding how often that scan can run. 25ms was measurably worse than
+// both, reproducibly, which is reason enough not to go lower without
+// understanding why.
+const QUEUE_RECHECK_MS = Number(process.env.AL_QUEUE_RECHECK_MS ?? 50);
+
+// The pre-deadline default, kept only so queue_retry keeps meaning what it did
+// for anyone who explicitly configured it.
+const MAX_RETRIES = 35;
 
 /**
  * Reads the first `n` bytes across the front of a chunk array without
@@ -134,6 +168,8 @@ interface BusyLockQueue {
   running: boolean;
   entry: ActiveDefinitions.LedgerEntry;
   retry: number;
+  /** When this first failed to get its locks - see hold()'s give-up test. */
+  queuedAt: number;
 }
 
 /**
@@ -1573,7 +1609,7 @@ export class Host extends Home {
    * @param {ActiveDefinitions.LedgerEntry} v
    * @param {number} retries
    */
-  private hold(v: ActiveDefinitions.LedgerEntry, retries = 0): boolean {
+  private hold(v: ActiveDefinitions.LedgerEntry, retries = 0, queuedAt = 0): boolean {
     // Build a list of streams to lock
     // Would be good to cache this
     // let input = Object.keys(v.$tx.$i || {});
@@ -1665,6 +1701,7 @@ export class Host extends Home {
             running: false,
             entry: v,
             retry: 1,
+            queuedAt: Date.now(),
           });
         } else {
           // Detect internal transaction read below for more information
@@ -1676,7 +1713,15 @@ export class Host extends Home {
           // We could set this really high as every new transaction (unrelated) will increase
           // the counter. So it will eventually send (unless crashed) no matter how high
           // so possibly a safe timeout should be used.
-          if (retries > ActiveOptions.get<number>("queue_retry", MAX_RETRIES)) {
+          // queue_retry, if someone explicitly set it, still means what it
+          // always did. Left unset, how long this has waited decides - see
+          // QUEUE_MAX_WAIT_MS.
+          const configuredRetryCap = ActiveOptions.get<number>("queue_retry", 0);
+          const waited = queuedAt ? Date.now() - queuedAt : 0;
+          const giveUp = configuredRetryCap
+            ? retries > configuredRetryCap
+            : waited > QUEUE_MAX_WAIT_MS;
+          if (giveUp) {
             // $origin check will mean if this is the entry node and is locked it will
             // still send around the network. Broadcast will fail. So for now if entry is locked
             // defaulting to queue attempt to unlock. Otherwise busy locks could be spammed. Doesn't mean
@@ -1798,11 +1843,27 @@ export class Host extends Home {
         }
       }, RELEASE_SHUTDOWN_TIMEOUT);
 
-      // Put this at the end so the queue can clear this transaction
-      setTimeout(() => {
-        // Check the lock queue
-        this.processQueue();
-      }, 200);
+      // Re-check the queue now that these locks are free.
+      //
+      // Locker.release() above is synchronous, so by this point nobody holds
+      // them - this only has to escape the current call stack, which is what
+      // setImmediate does. The 200ms timer this replaces made a queued writer
+      // wait a fifth of a second for a lock that was already available, which
+      // on a quiet node (where nothing else drives the queue) was most of its
+      // latency: two writers on one stream cost 68ms instead of 23ms, and
+      // eight cost 153ms instead of 46ms.
+      //
+      // Only safe alongside the deadline above. On its own, against the old
+      // retry count, the faster passes burned all 35 retries before the queue
+      // drained and rejected roughly half of 80 contending writers in one run
+      // out of three.
+      // 0 means next tick; anything else waits. Overridable without a
+      // redeploy, so a deployment that dislikes either end can move.
+      if (QUEUE_RECHECK_MS > 0) {
+        setTimeout(() => this.processQueue(), QUEUE_RECHECK_MS);
+      } else {
+        setImmediate(() => this.processQueue());
+      }
     } else {
       ActiveLogger.warn(umid, "Trying to release unknown umid");
     }
@@ -1842,7 +1903,7 @@ export class Host extends Home {
             labelOrKey.forEach((io) => checked.add(io));
           }
 
-          if (!this.hold(this.busyLocksQueue.internal[i].entry, this.busyLocksQueue.internal[i].retry++)) {
+          if (!this.hold(this.busyLocksQueue.internal[i].entry, this.busyLocksQueue.internal[i].retry++, this.busyLocksQueue.internal[i].queuedAt)) {
             // If hold fails, add it to the list of items to keep for the next run.
             stillPending.push(this.busyLocksQueue.internal[i]);
           }
@@ -1858,7 +1919,7 @@ export class Host extends Home {
       if (this.busyLocksQueue.external.length) {
         const stillPending: BusyLockQueue[] = [];
         for (let i = 0; i < this.busyLocksQueue.external.length; i++) {
-          if (!this.hold(this.busyLocksQueue.external[i].entry, this.busyLocksQueue.external[i].retry++)) {
+          if (!this.hold(this.busyLocksQueue.external[i].entry, this.busyLocksQueue.external[i].retry++, this.busyLocksQueue.external[i].queuedAt)) {
             stillPending.push(this.busyLocksQueue.external[i]);
           }
         }

--- a/packages/protocol/src/protocol/process.ts
+++ b/packages/protocol/src/protocol/process.ts
@@ -453,8 +453,20 @@ export class Process extends EventEmitter {
             namespacePath = await fs.realpath(
               `${process.cwd()}/contracts/${this.entry.$tx.$namespace}/`
             );
-          } catch {
-            throw new Error("Namespace not found");
+          } catch (error) {
+            // Say why. realpath fails for reasons that are not "the namespace
+            // does not exist" - EIO and EMFILE among them - and discarding the
+            // errno turned a storage or descriptor problem under load into a
+            // message pointing at the transaction's namespace, which is the
+            // one thing that was fine. Seen in profiling: bursts of concurrent
+            // transactions failing as "Namespace not found" against a
+            // namespace that plainly existed, with nothing recorded about the
+            // actual cause.
+            throw new Error(
+              `Namespace not found - ${(error as NodeJS.ErrnoException)?.code ||
+                (error as Error)?.message ||
+                error}`
+            );
           }
 
 

--- a/tests/network/profile.ts
+++ b/tests/network/profile.ts
@@ -318,6 +318,90 @@ async function measureConcurrent(ctx: Ctx, identities: Identity[], inFlight: num
   }
   }
 
+  // --- 6. Does a hot stream slow down everything else? ---------------------
+  //
+  // Section 5 measures a contended stream on its own, which cannot show the
+  // cost that matters most: whether transactions with nothing to do with that
+  // stream get slower while it is being hammered.
+  //
+  // They might, because processQueue() scans the whole busy-lock queue and
+  // tries hold() on every entry, so a long queue makes each pass O(n) - and
+  // each completed transaction schedules a pass. This measures unrelated
+  // work's latency during a burst against one hot stream, against the same
+  // work with no burst running at all.
+  if (wants(6)) {
+  console.log(`\n[6] Does a hot stream slow unrelated transactions down?`);
+  {
+    const nodeCount = Number((process.argv.find(a => a.startsWith("--contend-nodes=")) || "--contend-nodes=1").split("=")[1]);
+    const ctx = await setup(nodeCount, "rsa");
+    try {
+      const BACKGROUND = Number((process.argv.find(a => a.startsWith("--background=")) || "--background=8").split("=")[1]);
+      const HOT = Number((process.argv.find(a => a.startsWith("--hot=")) || "--hot=20").split("=")[1]);
+      process.stdout.write(`  onboarding ${BACKGROUND} background identities...`);
+      const others: Identity[] = [];
+      for (let i = 0; i < BACKGROUND; i++) others.push(await onboardAs(ctx.baseUrl, "rsa"));
+      console.log(" done");
+
+      /** Sequential transactions on independent streams - the unrelated work. */
+      const background = async (label: string) => {
+        const samples: number[] = [];
+        let failed = 0;
+        let example = "";
+        for (let i = 0; i < others.length; i++) {
+          const t = process.hrtime.bigint();
+          const r = await runTx(ctx.baseUrl, others[i], ctx.namespace, ctx.contractStreamId, `${label}${i}`)
+            .catch((e) => ({ __threw: String(e) }));
+          samples.push(Number(process.hrtime.bigint() - t) / 1e6);
+          // A transaction that failed fast is not a fast transaction. Without
+          // this the numbers invert and rejections read as an improvement.
+          if (!(r as any)?.$streams?.updated?.length) {
+            failed++;
+            if (!example) example = JSON.stringify(r).slice(0, 400);
+          }
+        }
+        return { st: stats(samples), failed, example };
+      };
+
+      const quiet = await background("quiet");
+      fmt("unrelated, nothing else running", quiet.st,
+        quiet.failed ? `(${quiet.failed}/${others.length} DID NOT COMMIT: ${quiet.example})` : "");
+
+      // Same work, but with a hot stream under sustained contention.
+      let hotDone = false;
+      const hot = Promise.all(
+        Array.from({ length: HOT }, (_, i) =>
+          runTx(ctx.baseUrl, ctx.identity, ctx.namespace, ctx.contractStreamId, `hot${i}`).catch(() => null))
+      ).then((r) => { hotDone = true; return r; });
+      const busy = await background("busy");
+      fmt("unrelated, during a hot stream", busy.st,
+        (hotDone ? "(burst finished early) " : "") +
+        (busy.failed ? `(${busy.failed}/${others.length} DID NOT COMMIT: ${busy.example})` : ""));
+      const hotResults = await hot;
+      const hotOk = hotResults.filter((r: any) => r?.$streams?.updated?.length).length;
+
+      if (quiet.failed || busy.failed || hotOk < HOT) {
+        console.log(
+          `\n  NOT A VALID COMPARISON - work failed, and a failure is fast.\n` +
+          `  unrelated quiet ${quiet.failed} failed, during-burst ${busy.failed} failed, ` +
+          `hot ${HOT - hotOk} failed.`
+        );
+      }
+
+      const slowdown = quiet.st.p50 > 0 ? busy.st.p50 / quiet.st.p50 : 0;
+      console.log(
+        `\n  hot stream committed ${hotOk}/${HOT}; unrelated work ran ` +
+        `${slowdown.toFixed(2)}x its quiet latency while that happened.`
+      );
+      console.log(
+        `  Above ~1.5x the queue scan is stealing time from work that never\n` +
+        `  touched the contended stream.`
+      );
+    } finally {
+      await shutdown(ctx.harness);
+    }
+  }
+  }
+
   // --- Summary ------------------------------------------------------------
   console.log(`\n${"=".repeat(60)}\nWhat this says`);
   if (bySize[1]?.p50 !== undefined && bySize[4]?.p50 !== undefined) {


### PR DESCRIPTION
Replaces #114, which GitHub auto-closed when the branch it was stacked on (#113) was deleted on merge. Same commit, rebased onto master.

A transaction that has to wait for a stream someone else is writing pays far
more than it should, and the two reasons are coupled: you cannot fix either
one alone without making things worse.

## Result

One node, writers against a single hot stream:

| | 2 writers | 8 writers | unrelated work p90 |
|---|---|---|---|
| before | 81ms | 167ms | 14ms |
| **after (50ms + deadline)** | **26ms** | **108ms** | **14ms** |
| *(setImmediate, rejected)* | *23ms* | *35ms* | *42ms* |

Uncontended latency is unchanged (5/20/22ms for 1/2/4 nodes), and peak
throughput is 236 tx/s.

## Waiting was counted in traffic, not time

The give-up test was a retry count of 35. A count was never a measure of time:
`processQueue()` runs on every `pending()` call, so **an unrelated transaction
arriving anywhere on the node burned one of the 35**.

A quiet node therefore waited ~7s before telling a client its locks were busy;
a node doing 200 tx/s gave up in a fraction of that. The busier the node, the
sooner it abandons a stream — backwards, because a busy node is exactly where
a stream is worth waiting for.

The comment above the old check already knew:

> every new transaction (unrelated) will increase the counter ... so possibly a
> safe timeout should be used

It is now a **7s deadline**, preserving the old quiet-node budget (35 × the
200ms re-check) and sitting well inside the 60s broadcast timeouts.
`queue_retry` still means exactly what it did for anyone who set it explicitly.

## The re-check waited for a lock nobody held

`Locker.release()` is synchronous, so the locks are already free when the
200ms timer is armed. The deferral only has to escape the current call stack.
On a quiet node — where no other traffic drives the queue — that 200ms was
most of a contended transaction's latency.

Now 50ms.

## Why not setImmediate, which is faster

`processQueue()` scans the whole queue and calls `hold()` on every entry, so
each pass is O(queue length) and the delay is the only thing throttling those
scans. Removing it:

- gave unrelated transactions a **threefold worse p90** (42ms vs 14ms) during
  a burst. p50 was unaffected, so a median-only test would have missed it
  entirely
- drove one transaction to **133 retry passes** against the old cap of 35
- against that cap, **rejected roughly half of 80 contending writers in one
  run out of three** — intermittently, which is the worst way to fail

50ms keeps the case that actually happens (two writers on one stream: 81ms →
26ms) and gives up only headroom under contention nobody has reported.

**Neither change is safe alone.** The faster re-check is what exhausts a
counted retry budget; the deadline is what makes the faster re-check
survivable.

Both are env-overridable — `AL_QUEUE_RECHECK_MS`, `AL_QUEUE_MAX_WAIT_MS` — so
a deployment that disagrees can move without a redeploy.

## Profile section 6

A contention test alone cannot answer the question that decided this: whether
unrelated work slows down while a stream is hammered. Section 6 runs
background transactions on independent streams during a burst and compares
against the same work with nothing else running. At 50ms the ratio is
**0.93–1.03x**.

It is also what ruled `setImmediate` out, and it only exists because the
tail-latency risk was raised as a question rather than found in a benchmark.

## Stops discarding why a namespace lookup failed

```js
} catch { throw new Error("Namespace not found"); }
```

`realpath` fails for reasons that are not "the namespace does not exist" — EIO
and EMFILE among them — and the bare catch turned a storage or descriptor
problem under load into a message pointing at the one thing that was fine.
Bursts of concurrent transactions were failing as `Namespace not found`
against a namespace that plainly existed, with nothing recorded about the
cause. The errno now comes through.

## Verified

- **335 passing**, against the gate #113 repairs
- **Three consecutive `test:network` runs at exit 0**
- Uncontended latency unchanged: 5/20/22ms for 1/2/4 nodes

## Known limits

- One earlier `test:network` run exited 1 and has not reproduced in four runs
  since. Unattributed — worth watching rather than declared fixed.
- ~~Section 6 only holds together to ~20 concurrent hot writers~~ — **withdrawn.**
  Section 6 was failing with the namespace error during an earlier stretch of
  back-to-back harness runs, and I attributed it to load and to this branch.
  It reproduces nowhere: master, #113, and this branch at 50ms, 200ms and
  setImmediate all commit 40/40 and 60/60. It was the machine, not the code —
  stray harness processes and temp directories accumulating across dozens of
  runs. The errno change above stands regardless, since that is what will
  identify it if a real deployment hits the same wall.

