### PR TITLE
fix: a partial history walk left nothing behind but a log line

### DIFF
--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -2123,7 +2123,20 @@ export class Endpoints {
     host: Host,
     streamId: string,
     fromUmid: string
-  ): Promise<{ recovered: string[]; stoppedAt: string }> {
+  ): Promise<{
+    recovered: string[];
+    stoppedAt: string;
+    /**
+     * True when the walk ran out of history to recover rather than out of
+     * road - it reached a umid already held, or the creation of the stream.
+     * Anything else left history behind, and the caller has to decide what
+     * to do about that. Returned as a flag rather than left for the caller
+     * to match on stoppedAt's prose, which is written for humans.
+     */
+    complete: boolean;
+    /** The umid it could not get past, when it did not finish. */
+    frontier?: string;
+  }> {
     const recovered: string[] = [];
     const seen = new Set<string>();
     let cursor: string | undefined = fromUmid;
@@ -2132,7 +2145,7 @@ export class Endpoints {
       if (seen.has(cursor)) {
         // A chain should never loop. If one does, stop rather than spin -
         // and say so, because it means something upstream is wrong.
-        return { recovered, stoppedAt: "loop detected" };
+        return { recovered, stoppedAt: "loop detected", complete: false, frontier: cursor };
       }
       seen.add(cursor);
 
@@ -2140,7 +2153,7 @@ export class Endpoints {
         ActiveLogger.warn(
           `SPI WALK ${streamId} - stopped at ${Endpoints.UMID_WALK_LIMIT}, a full restore is the right tool from here`
         );
-        return { recovered, stoppedAt: "limit reached" };
+        return { recovered, stoppedAt: "limit reached", complete: false, frontier: cursor };
       }
 
       // Do we already have it? Everything before it is here too, because a
@@ -2165,10 +2178,10 @@ export class Endpoints {
       // one extra pass at the terminus costs nothing but closes that hole.
       const ok = await Endpoints.backfillUmid(host, cursor);
       if (!ok) {
-        return { recovered, stoppedAt: `could not recover ${cursor}` };
+        return { recovered, stoppedAt: `could not recover ${cursor}`, complete: false, frontier: cursor };
       }
       if (held) {
-        return { recovered, stoppedAt: "reached a umid already held" };
+        return { recovered, stoppedAt: "reached a umid already held", complete: true };
       }
       recovered.push(cursor);
 
@@ -2177,7 +2190,7 @@ export class Endpoints {
       try {
         doc = await host.dbConnection.get(`${cursor}:umid`);
       } catch {
-        return { recovered, stoppedAt: "adopted umid could not be read back" };
+        return { recovered, stoppedAt: "adopted umid could not be read back", complete: false, frontier: cursor };
       }
 
       cursor = Endpoints.previousUmidFor(doc, streamId);
@@ -2192,7 +2205,7 @@ export class Endpoints {
       }
     }
 
-    return { recovered, stoppedAt: "start of stream" };
+    return { recovered, stoppedAt: "start of stream", complete: true };
   }
 
   /** Walks running right now, so the same one never runs twice at once. */
@@ -2363,6 +2376,13 @@ export class Endpoints {
               `SPI WALK (post-commit) ${streamId} recovered ${walk.recovered.length} umid(s), stopped: ${walk.stoppedAt}`
             );
           }
+          await Endpoints.recordIncompleteWalk(
+            host,
+            streamId,
+            walk,
+            prev,
+            "(post-commit)"
+          );
         }
       } catch (error) {
         // Detached from the transaction path - must never surface into it
@@ -2373,6 +2393,55 @@ export class Endpoints {
         Endpoints.pruneHistoryRepairMemory();
       }
     })();
+  }
+
+  /**
+   * Leaves a durable record when a walk stopped before it ran out of history.
+   *
+   * Without this a partial walk existed only as a log line: the node kept
+   * whatever it recovered, still had a hole behind it, and nothing outside
+   * the log said so. The post-commit path did not even do that - it logged
+   * what it recovered and dropped the rest silently.
+   *
+   * The umid recorded is the one the walk could not get past, never the one
+   * it started from. The starting umid is present by definition, so a
+   * recovery attempt against it finds nothing to do and the hole stays.
+   *
+   * Note this is a record, not a retry loop: activerestore's interagent
+   * makes ONE attempt to fetch the umid from peers and purges the document
+   * either way, so a umid no peer can serve right now leaves nothing behind
+   * at all. Making that durable is a separate change on the restore side.
+   *
+   * @private
+   * @static
+   */
+  private static async recordIncompleteWalk(
+    host: Host,
+    streamId: string,
+    walk: { complete: boolean; frontier?: string; stoppedAt: string },
+    fallbackUmid: string,
+    label: string
+  ): Promise<void> {
+    if (walk.complete) {
+      return;
+    }
+    const stuckOn = walk.frontier || fallbackUmid;
+    ActiveLogger.warn(
+      `SPI WALK ${label} ${streamId} left history behind - stopped: ${walk.stoppedAt}`
+    );
+    ActiveLogger.warn(stuckOn, `SPI Adding 950 Checker ${label}`);
+    await host.dbErrorConnection.post({
+      _id: `${stuckOn}:${Date.now()}`,
+      code: 950,
+      processed: false,
+      umid: stuckOn,
+      transaction: {
+        $broadcast: true,
+        $tx: {},
+        $revs: {},
+      },
+      reason: `Vote Failure - "SPI${label} UMID not found`,
+    });
   }
 
   /**
@@ -2430,33 +2499,30 @@ export class Endpoints {
         }
 
         const walk = await Endpoints.walkUmidHistory(host, streamId, adopted);
+
         if (walk.recovered.length) {
           ActiveLogger.warn(
             `SPI WALK ${label} ${streamId} recovered ${walk.recovered.length} umid(s), stopped: ${walk.stoppedAt}`
           );
-          return;
         }
 
-        // Nothing recovered and nothing was missing is the common case -
-        // the walk stopped immediately on a umid already held. Only a walk
-        // that could not do its job earns a durable retry.
-        if (walk.stoppedAt.indexOf("already held") !== -1) {
-          return;
-        }
-
-        ActiveLogger.warn(adopted, `SPI Adding 950 Checker ${label}`);
-        await host.dbErrorConnection.post({
-          _id: `${adopted}:${Date.now()}`,
-          code: 950,
-          processed: false,
-          umid: adopted,
-          transaction: {
-            $broadcast: true,
-            $tx: {},
-            $revs: {},
-          },
-          reason: `Vote Failure - "SPI${label} UMID not found`,
-        });
+        // Whether anything was recovered says nothing about whether the job
+        // is done, and this used to return early whenever it was non-zero.
+        // A walk that recovered fifty umids and then hit a chain it could
+        // not follow logged that fact and left it there: no record outside
+        // the log, no retry, and nothing to tell an operator the stream
+        // still had a hole. Only a walk that recovered *nothing* ever
+        // earned one, which is the least likely case.
+        //
+        // The walk itself now says whether it ran out of history or out of
+        // road, so that is what decides.
+        await Endpoints.recordIncompleteWalk(
+          host,
+          streamId,
+          walk,
+          adopted,
+          label
+        );
       } catch (error) {
         // Must never surface into the transaction path it was detached from
         ActiveLogger.error(error, `SPI WALK ${label} ${streamId} failed`);

--- a/packages/network/src/network/endpoints.ts
+++ b/packages/network/src/network/endpoints.ts
@@ -2425,6 +2425,17 @@ export class Endpoints {
     if (walk.complete) {
       return;
     }
+
+    // The hop limit is the one incomplete ending a 950 cannot help with.
+    // The record asks the interagent to fetch ONE umid from peers; here the
+    // hole is every hop beyond the limit, so fetching the frontier closes a
+    // hundredth of it, does not resume the walk, and the document is purged
+    // after the attempt either way. walkUmidHistory already logs that a full
+    // restore is the right tool from here, which is the actual answer.
+    if (walk.stoppedAt === "limit reached") {
+      return;
+    }
+
     const stuckOn = walk.frontier || fallbackUmid;
     ActiveLogger.warn(
       `SPI WALK ${label} ${streamId} left history behind - stopped: ${walk.stoppedAt}`

--- a/tests/spi-umid-walk.test.ts
+++ b/tests/spi-umid-walk.test.ts
@@ -880,9 +880,11 @@ describe("SPI history repair - a partial walk leaves a durable record", () => {
    * A committed umid whose history breaks partway back. repairHistoryAfterCommit
    * walks from the commit's `prev`, so the chain below that is what matters.
    */
-  function partialHost(unreachable: string[]) {
+  function partialHost(unreachable: string[], depth = 0) {
     const STREAM_P = `p${n}pp`.padEnd(64, "a") + `${n++}`;
-    const chain = ["p3", "p2", "p1", "p0"];
+    const chain = depth
+      ? Array.from({ length: depth }, (_, i) => `d${depth - 1 - i}`)
+      : ["p3", "p2", "p1", "p0"];
     const errors: any[] = [];
     const store = new Map<string, any>();
     const id = `commit-${Date.now()}-${n}`;
@@ -904,7 +906,7 @@ describe("SPI history repair - a partial walk leaves a durable record", () => {
     const committed = {
       _id: `${id}:umid`,
       umid: { $umid: id },
-      streams: { new: [], updated: [{ id: STREAM_P, prev: "p3" }] },
+      streams: { new: [], updated: [{ id: STREAM_P, prev: chain[0] }] },
     };
     store.set(`${id}:umid`, committed);
 
@@ -953,6 +955,15 @@ describe("SPI history repair - a partial walk leaves a durable record", () => {
     // by definition, so a recovery attempt against it finds nothing to do
     // and the hole behind it stays.
     expect(errors[0].umid).to.equal("p1");
+  });
+
+  it("records nothing for the hop limit, which a single umid cannot fix", async () => {
+    // 130 hops behind: the walk stops at 100 and the answer is a full
+    // restore, not a peer fetch for one umid at the frontier.
+    const { host, errors, id } = partialHost([], 130);
+    await Endpoints.repairHistoryAfterCommit(host, id);
+    await new Promise((r) => setTimeout(r, 800));
+    expect(errors).to.deep.equal([]);
   });
 
   it("records nothing when the walk finished the job", async () => {

--- a/tests/spi-umid-walk.test.ts
+++ b/tests/spi-umid-walk.test.ts
@@ -37,6 +37,7 @@ function fakeHost(chain: string[], held: string[] = [], opts: any = {}) {
   const local = new Set(held.map((u) => `${u}:umid`));
   const adopted: string[] = [];
   const replayed: string[] = [];
+  const errors: any[] = [];
 
   const docFor = (umid: string) => {
     const index = chain.indexOf(umid);
@@ -59,6 +60,7 @@ function fakeHost(chain: string[], held: string[] = [], opts: any = {}) {
   return {
     adopted,
     replayed,
+    errors,
     host: {
       dbConnection: {
         get: async (id: string) => {
@@ -77,6 +79,12 @@ function fakeHost(chain: string[], held: string[] = [], opts: any = {}) {
       dbEventConnection: {
         post: async (doc: any) => {
           replayed.push(doc._id);
+          return { ok: true };
+        },
+      },
+      dbErrorConnection: {
+        post: async (doc: any) => {
+          errors.push(doc);
           return { ok: true };
         },
       },
@@ -373,6 +381,7 @@ describe("Endpoints.repairHistoryAfterCommit - guards", () => {
   let counter = 0;
   function guardHost(opts: any = {}) {
     const calls = { knockAll: 0 };
+    const errors: any[] = [];
     const store = new Map<string, any>();
     const id = `committed-${Date.now()}-${counter++}`;
     const missing = `${id}-missing`;
@@ -388,6 +397,7 @@ describe("Endpoints.repairHistoryAfterCommit - guards", () => {
       id,
       missing,
       calls,
+      errors,
       store,
       host: {
         dbConnection: {
@@ -401,6 +411,12 @@ describe("Endpoints.repairHistoryAfterCommit - guards", () => {
           },
         },
         dbEventConnection: { post: async () => ({ ok: true }) },
+        dbErrorConnection: {
+          post: async (doc: any) => {
+            errors.push(doc);
+            return { ok: true };
+          },
+        },
         neighbourhood: {
           knockAll: async (endpoint: string) => {
             calls.knockAll++;
@@ -797,5 +813,152 @@ describe("Endpoints.repairHistoryAfterCommit - the cooldown must be per stream",
     await Endpoints.repairHistoryAfterCommit(host, "w-2");
 
     expect(calls.knockAll).to.be.greaterThan(afterFirst);
+  });
+});
+
+/**
+ * A walk that recovers something and then cannot continue used to return
+ * early and leave nothing behind but a log line. Whether anything was
+ * recovered says nothing about whether the job is finished, and these pin
+ * that distinction so it cannot quietly regress to counting again.
+ */
+describe("Endpoints.walkUmidHistory - saying whether it finished", () => {
+  const CHAIN = ["w5", "w4", "w3", "w2", "w1", "w0"];
+  const realDelay = Endpoints.UMID_WALK_HOP_DELAY_MS;
+  before(() => { Endpoints.UMID_WALK_HOP_DELAY_MS = 0; });
+  after(() => { Endpoints.UMID_WALK_HOP_DELAY_MS = realDelay; });
+
+  it("is complete when it reaches a umid already held", async () => {
+    const { host } = fakeHost(CHAIN, ["w2", "w1", "w0"]);
+    const result = await Endpoints.walkUmidHistory(host, STREAM, "w5");
+    expect(result.stoppedAt).to.contain("already held");
+    expect(result.complete).to.equal(true);
+    expect(result.frontier).to.equal(undefined);
+  });
+
+  it("is complete when it reaches the start of the stream", async () => {
+    const { host } = fakeHost(CHAIN, []);
+    const result = await Endpoints.walkUmidHistory(host, STREAM, "w5");
+    expect(result.stoppedAt).to.equal("start of stream");
+    expect(result.complete).to.equal(true);
+    expect(result.frontier).to.equal(undefined);
+  });
+
+  it("is NOT complete when a hop cannot be recovered, and names it", async () => {
+    const { host } = fakeHost(CHAIN, [], { unreachable: ["w2"] });
+    const result = await Endpoints.walkUmidHistory(host, STREAM, "w5");
+    expect(result.complete).to.equal(false);
+    expect(result.frontier).to.equal("w2");
+    // It keeps what it managed to get - the point is that the remainder is
+    // reported, not that the walk is thrown away.
+    expect(result.recovered).to.deep.equal(["w5", "w4", "w3"]);
+  });
+
+  it("is NOT complete when it hits the hop limit", async () => {
+    const long = Array.from({ length: 130 }, (_, i) => `L${129 - i}`);
+    const { host } = fakeHost(long, []);
+    const result = await Endpoints.walkUmidHistory(host, STREAM, long[0]);
+    expect(result.stoppedAt).to.equal("limit reached");
+    expect(result.complete).to.equal(false);
+    expect(result.frontier).to.be.a("string");
+  });
+});
+
+describe("SPI history repair - a partial walk leaves a durable record", () => {
+  const realDelay = Endpoints.UMID_WALK_HOP_DELAY_MS;
+  before(() => { Endpoints.UMID_WALK_HOP_DELAY_MS = 0; });
+  after(() => { Endpoints.UMID_WALK_HOP_DELAY_MS = realDelay; });
+
+  beforeEach(() => {
+    (Endpoints as any).historyRepairLastRun.clear();
+    (Endpoints as any).historyRepairInFlight.clear();
+  });
+
+  let n = 0;
+
+  /**
+   * A committed umid whose history breaks partway back. repairHistoryAfterCommit
+   * walks from the commit's `prev`, so the chain below that is what matters.
+   */
+  function partialHost(unreachable: string[]) {
+    const STREAM_P = `p${n}pp`.padEnd(64, "a") + `${n++}`;
+    const chain = ["p3", "p2", "p1", "p0"];
+    const errors: any[] = [];
+    const store = new Map<string, any>();
+    const id = `commit-${Date.now()}-${n}`;
+
+    const docFor = (umid: string) => {
+      const i = chain.indexOf(umid);
+      if (i === -1) return undefined;
+      const prev = chain[i + 1];
+      return {
+        _id: `${umid}:umid`,
+        umid: { $umid: umid },
+        streams: prev
+          ? { new: [], updated: [{ id: STREAM_P, prev }] }
+          : { new: [{ id: STREAM_P, name: "created" }], updated: [] },
+      };
+    };
+
+    // The commit itself: held, and pointing at p3 which is not.
+    const committed = {
+      _id: `${id}:umid`,
+      umid: { $umid: id },
+      streams: { new: [], updated: [{ id: STREAM_P, prev: "p3" }] },
+    };
+    store.set(`${id}:umid`, committed);
+
+    return {
+      id,
+      errors,
+      store,
+      host: {
+        dbConnection: {
+          get: async (key: string) => {
+            if (!store.has(key)) throw new Error("not found");
+            return store.get(key);
+          },
+          bulkDocs: async (docs: any[]) => {
+            for (const d of docs) store.set(d._id, d);
+            return { ok: true };
+          },
+        },
+        dbEventConnection: { post: async () => ({ ok: true }) },
+        dbErrorConnection: {
+          post: async (doc: any) => { errors.push(doc); return { ok: true }; },
+        },
+        neighbourhood: {
+          knockAll: async (endpoint: string) => {
+            const umid = endpoint.replace("umid/", "");
+            if (unreachable.indexOf(umid) !== -1) return [];
+            if (umid === id) return [committed, committed];
+            const doc = docFor(umid);
+            return doc ? [doc, doc] : [];
+          },
+        },
+      } as any,
+    };
+  }
+
+  it("records the umid it got stuck on, not the one it started from", async () => {
+    // p3 and p2 recover; p1 is unreachable.
+    const { host, errors, id } = partialHost(["p1"]);
+    await Endpoints.repairHistoryAfterCommit(host, id);
+    await new Promise((r) => setTimeout(r, 500));
+
+    expect(errors.length).to.equal(1);
+    expect(errors[0].code).to.equal(950);
+    expect(errors[0].processed).to.equal(false);
+    // Recording p3 (where the walk began) would be useless: it is present
+    // by definition, so a recovery attempt against it finds nothing to do
+    // and the hole behind it stays.
+    expect(errors[0].umid).to.equal("p1");
+  });
+
+  it("records nothing when the walk finished the job", async () => {
+    const { host, errors, id } = partialHost([]);
+    await Endpoints.repairHistoryAfterCommit(host, id);
+    await new Promise((r) => setTimeout(r, 500));
+    expect(errors).to.deep.equal([]);
   });
 });


### PR DESCRIPTION
A node that recovered part of its missing history and then couldn't continue
kept the hole, and nothing outside the log said so.

## Two callers, both deciding from the wrong thing

`walkUmidHistory` can stop for six reasons. Two mean it **finished** — it
reached a umid already held, or the creation of the stream. Four mean it
**stopped short** — the hop limit, a umid no peer would serve, a looping
chain, or a umid that couldn't be read back after adopting it.

Both callers decided what to do next from `walk.recovered.length`, which says
nothing about either.

**SPI path** returned early whenever the count was non-zero:

```js
const walk = await Endpoints.walkUmidHistory(host, streamId, adopted);
if (walk.recovered.length) {
  ActiveLogger.warn(`... recovered ${n} umid(s), stopped: ${walk.stoppedAt}`);
  return;                       // whatever stoppedAt said
}
```

So a walk that recovered fifty umids and then hit a chain it could not follow
logged it and returned. Only a walk that recovered **nothing** ever earned the
durable 950 — the least likely of the four failures.

**Post-commit path was worse**, and it is the primary one — the trigger the
4.5.16 walk was built around, running from `host.ts`'s commit handler. It
logged what it recovered and wrote **no record at all**, whatever happened.

## The fix

The walk now reports whether it ran out of history or out of road:

```ts
complete: boolean;     // reached a held umid, or the start of the stream
frontier?: string;     // the umid it could not get past, when it did not finish
```

A flag rather than leaving callers to pattern-match on `stoppedAt`, whose text
is written for humans. Both paths record through one helper when
`complete === false` — **except the hop limit**, which is the one incomplete
ending a 950 cannot help with: the record asks the interagent to fetch *one*
umid, and at the limit the hole is every hop beyond it, so fetching the
frontier closes a hundredth of it and does not resume the walk. The walk
already logs that a full restore is the right tool there. The other three
endings are exactly the case where one umid is what is missing, and those
record.

**It records the frontier, not the starting umid.** The starting umid is
present by definition, so a 950 against it finds nothing to do and the hole
stays — which was already true of the SPI path's existing record.

## What this deliberately does not fix

Restore's interagent makes **one** attempt to fetch the umid from peers, and
purges the document either way:

```js
ActiveLogger.error(`UMID ${changeDoc.umid} not found #2`);
return await this.setProcessed(changeDoc, false);
```

That second argument is `storeArchive`, not the processed flag — both branches
call `archive()`, which runs `errorDatabase.purge(document)` unconditionally.
So a umid no peer can serve at that moment leaves **no trace at all**, and with
`false` not even an archive copy. A peer offline for thirty seconds is enough
to lose the record permanently.

So this PR makes the record *exist*; it does not make it *survive*. That is a
change on the restore side, it is the prerequisite for any crash-resume work
(a resume marker built on this would delete itself on first failure), and it
wants its own investigation first — the purge-without-archive looks
unintended, but that is restore's core loop and worth understanding before
touching. `recordIncompleteWalk`'s comment says all of this in place.

## Verified

- **342 passing** (seven new), network suite exit 0
- Four tests pin the `complete` / `frontier` contract per terminus; two cover
  the partial-walk record, including that it names the frontier rather than
  the starting umid
- Mutation-checked: suppressing the record turns one red, so the coverage can
  actually fail

